### PR TITLE
Fix game scoring and fallback wallet without Redis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 python-telegram-bot==13.12
-flake8==4.0.1
+flake8==5.0.4
 pillow==9.3.0
 PySocks==1.7.1
 redis==4.5.4
 python-dotenv==0.20.0
+urllib3==1.26.18


### PR DESCRIPTION
## Summary
- add urllib3 dependency and upgrade flake8
- implement hand scoring helpers and best-hand selector
- support in-memory wallet when Redis isn't available and distribute pot
- simplify Game player storage for tests

## Testing
- `make test`
- `make lint` *(fails: many flake8 style errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c304cca4832881fd8e2c2a18a0f8