### PR TITLE
Simplify game table management

### DIFF
--- a/pokerapp/pokerbotcontrol.py
+++ b/pokerapp/pokerbotcontrol.py
@@ -11,8 +11,8 @@ from telegram.ext import (
 )
 import traceback  # <--- برای لاگ دقیق خطا اضافه شد
 
-from pokerapp.entities import PlayerAction, UserException
-from pokerapp.pokerbotmodel import PokerBotModel
+from pokerapp.entities import PlayerAction, UserException, Game
+from pokerapp.pokerbotmodel import PokerBotModel, KEY_CHAT_DATA_GAME
 
 class PokerBotCotroller:
     def __init__(self, model: PokerBotModel, application: Application):
@@ -26,10 +26,8 @@ class PokerBotCotroller:
         application.add_handler(CommandHandler('ban', self._handle_ban))
         application.add_handler(CommandHandler('cards', self._handle_cards))
 
-        # new table management commands
-        application.add_handler(CommandHandler('newtable', self._handle_new_table))
-        application.add_handler(CommandHandler('join', self._handle_join))
-        application.add_handler(CommandHandler('listtables', self._handle_list_tables))
+        # game management command
+        application.add_handler(CommandHandler('newgame', self._handle_create_game))
 
         application.add_handler(
             MessageHandler(
@@ -106,14 +104,8 @@ class PokerBotCotroller:
     async def _handle_money(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await self._model.bonus(update, context)
 
-    async def _handle_new_table(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-        await self._model.new_table(update, context)
-
-    async def _handle_join(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-        await self._model.join_table(update, context)
-
-    async def _handle_list_tables(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-        await self._model.list_tables(update, context)
+    async def _handle_create_game(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        await self._model.create_game(update, context)
 
     async def _handle_button_clicked(
         self,

--- a/pokerapp/table_manager.py
+++ b/pokerapp/table_manager.py
@@ -1,6 +1,5 @@
 import pickle
-from collections import defaultdict
-from typing import Dict, List
+from typing import Dict
 
 import redis.asyncio as aioredis
 
@@ -8,54 +7,45 @@ from pokerapp.entities import Game, ChatId
 
 
 class TableManager:
-    """Manage multiple game tables per chat and persist them in Redis."""
+    """Manage a single poker game per chat and persist it in Redis."""
 
     def __init__(self, redis: aioredis.Redis):
         self._redis = redis
-        self._tables: Dict[ChatId, Dict[int, Game]] = defaultdict(dict)
+        # Keep games cached in memory keyed only by chat_id
+        self._tables: Dict[ChatId, Game] = {}
 
     # Keys ---------------------------------------------------------------
     @staticmethod
-    def _tables_key(chat_id: ChatId) -> str:
-        return f"chat:{chat_id}:tables"
-
-    @staticmethod
-    def _table_key(chat_id: ChatId, table_id: int) -> str:
-        return f"chat:{chat_id}:table:{table_id}"
+    def _game_key(chat_id: ChatId) -> str:
+        return f"chat:{chat_id}:game"
 
     # Public API ---------------------------------------------------------
-    async def new_table(self, chat_id: ChatId) -> int:
-        """Create a new table for chat and persist it."""
-        existing = await self.list_tables(chat_id)
-        new_id = max(existing, default=0) + 1
+    async def create_game(self, chat_id: ChatId) -> Game:
+        """Create a new game for the chat and persist it."""
         game = Game()
-        self._tables[chat_id][new_id] = game
-        await self._save(chat_id, new_id, game)
-        return new_id
+        self._tables[chat_id] = game
+        await self._save(chat_id, game)
+        return game
 
-    async def get_game(self, chat_id: ChatId, table_id: int) -> Game:
-        """Load a game for chat/table, creating if missing."""
-        tables = self._tables[chat_id]
-        if table_id in tables:
-            return tables[table_id]
-        data = await self._redis.get(self._table_key(chat_id, table_id))
+    async def get_game(self, chat_id: ChatId) -> Game:
+        """Load the chat's game, creating one if necessary."""
+        if chat_id in self._tables:
+            return self._tables[chat_id]
+
+        data = await self._redis.get(self._game_key(chat_id))
         if data:
             game = pickle.loads(data)
         else:
             game = Game()
-            await self._save(chat_id, table_id, game)
-        tables[table_id] = game
+            await self._save(chat_id, game)
+
+        self._tables[chat_id] = game
         return game
 
-    async def list_tables(self, chat_id: ChatId) -> List[int]:
-        ids = await self._redis.smembers(self._tables_key(chat_id))
-        return sorted(int(x) for x in ids) if ids else []
-
-    async def save_game(self, chat_id: ChatId, table_id: int, game: Game) -> None:
-        self._tables[chat_id][table_id] = game
-        await self._save(chat_id, table_id, game)
+    async def save_game(self, chat_id: ChatId, game: Game) -> None:
+        self._tables[chat_id] = game
+        await self._save(chat_id, game)
 
     # Internal -----------------------------------------------------------
-    async def _save(self, chat_id: ChatId, table_id: int, game: Game) -> None:
-        await self._redis.sadd(self._tables_key(chat_id), table_id)
-        await self._redis.set(self._table_key(chat_id, table_id), pickle.dumps(game))
+    async def _save(self, chat_id: ChatId, game: Game) -> None:
+        await self._redis.set(self._game_key(chat_id), pickle.dumps(game))

--- a/tests/test_table_manager.py
+++ b/tests/test_table_manager.py
@@ -4,35 +4,24 @@ import fakeredis.aioredis
 from pokerapp.table_manager import TableManager
 
 
-@pytest.mark.anyio("asyncio")
-async def test_table_manager_multiple_groups():
+@pytest.mark.asyncio
+async def test_table_manager_multiple_chats():
     redis = fakeredis.aioredis.FakeRedis()
     tm = TableManager(redis)
 
     chat1, chat2 = 100, 200
-    t1 = await tm.new_table(chat1)
-    t2 = await tm.new_table(chat1)
-    t3 = await tm.new_table(chat2)
 
-    game1 = await tm.get_game(chat1, t1)
-    game2 = await tm.get_game(chat1, t2)
-    game3 = await tm.get_game(chat2, t3)
+    game1 = await tm.create_game(chat1)
+    game2 = await tm.create_game(chat2)
 
     game1.pot = 10
     game2.pot = 20
-    game3.pot = 30
 
-    await tm.save_game(chat1, t1, game1)
-    await tm.save_game(chat1, t2, game2)
-    await tm.save_game(chat2, t3, game3)
+    await tm.save_game(chat1, game1)
+    await tm.save_game(chat2, game2)
 
-    assert set(await tm.list_tables(chat1)) == {t1, t2}
-    assert set(await tm.list_tables(chat2)) == {t3}
-
-    g1_loaded = await tm.get_game(chat1, t1)
-    g2_loaded = await tm.get_game(chat1, t2)
-    g3_loaded = await tm.get_game(chat2, t3)
+    g1_loaded = await tm.get_game(chat1)
+    g2_loaded = await tm.get_game(chat2)
 
     assert g1_loaded.pot == 10
     assert g2_loaded.pot == 20
-    assert g3_loaded.pot == 30


### PR DESCRIPTION
## Summary
- manage a single `Game` per chat and persist it under `chat:{chat_id}:game`
- update model and controller for new `create_game/get_game/save_game` API
- adjust tests to match simplified table management

## Testing
- `PYTHONPATH=. pytest tests/test_table_manager.py -q`
- `PYTHONPATH=. pytest tests/test_winnerdetermination.py -q` *(fails: best hand assertion)*
- `PYTHONPATH=. pytest tests/test_pokerbotmodel.py -q` *(fails: ModuleNotFoundError: No module named 'PIL')*


------
https://chatgpt.com/codex/tasks/task_e_68c4fcfa24908328be1919eea80a770b