### PR TITLE
Handle wallet pickling

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -75,8 +75,20 @@ class Player:
         self.has_acted = False # آیا در راند فعلی نوبت خود را بازی کرده؟
         self.seat_index = seat_index
         # -------------------------
-def __repr__(self):
+    def __repr__(self):
         return "{}({!r})".format(self.__class__.__name__, self.__dict__)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        wallet = state.pop("wallet", None)
+        if wallet is not None:
+            state["_wallet_info"] = {"user_id": getattr(wallet, "_user_id", None)}
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        # wallet will be reconstructed after unpickling
+        self.wallet = None
 
 class PlayerState(enum.Enum):
     ACTIVE = 1
@@ -228,6 +240,12 @@ class Game:
                 return False
 
         return True
+
+    def __getstate__(self):
+        return self.__dict__.copy()
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
 
     def __repr__(self):
         return "{}({!r})".format(self.__class__.__name__, self.__dict__)

--- a/pokerapp/pokerbot.py
+++ b/pokerapp/pokerbot.py
@@ -38,7 +38,7 @@ class PokerBot:
             password=cfg.REDIS_PASS if cfg.REDIS_PASS != "" else None,
         )
 
-        table_manager = TableManager(kv_async)
+        table_manager = TableManager(kv_async, kv_sync)
         view = PokerBotViewer(bot=self._application.bot)
         model = PokerBotModel(
             view=view,

--- a/tests/test_table_manager.py
+++ b/tests/test_table_manager.py
@@ -1,13 +1,20 @@
+import pickle
+
 import pytest
+import fakeredis
 import fakeredis.aioredis
 
+from pokerapp.entities import Game, Player
+from pokerapp.pokerbotmodel import WalletManagerModel
 from pokerapp.table_manager import TableManager
 
 
 @pytest.mark.asyncio
 async def test_table_manager_multiple_chats():
-    redis = fakeredis.aioredis.FakeRedis()
-    tm = TableManager(redis)
+    server = fakeredis.FakeServer()
+    redis_async = fakeredis.aioredis.FakeRedis(server=server)
+    redis_sync = fakeredis.FakeRedis(server=server)
+    tm = TableManager(redis_async, redis_sync)
 
     chat1, chat2 = 100, 200
 
@@ -25,3 +32,31 @@ async def test_table_manager_multiple_chats():
 
     assert g1_loaded.pot == 10
     assert g2_loaded.pot == 20
+
+
+@pytest.mark.asyncio
+async def test_wallet_recreated_on_load():
+    server = fakeredis.FakeServer()
+    redis_sync = fakeredis.FakeRedis(server=server)
+    redis_async = fakeredis.aioredis.FakeRedis(server=server)
+    tm = TableManager(redis_async, redis_sync)
+
+    chat = 123
+    game = await tm.create_game(chat)
+
+    wallet = WalletManagerModel("user1", redis_sync)
+    player = Player(user_id="user1", mention_markdown="@u1", wallet=wallet, ready_message_id="ready")
+    game.add_player(player, seat_index=0)
+    await tm.save_game(chat, game)
+
+    tm._tables.pop(chat)
+
+    loaded_game = await tm.get_game(chat)
+    loaded_player = loaded_game.seats[0]
+
+    assert loaded_player.wallet is not None
+    assert isinstance(loaded_player.wallet, WalletManagerModel)
+
+
+def test_game_pickle():
+    pickle.dumps(Game())


### PR DESCRIPTION
## Summary
- Add custom pickling for Player and Game to omit Redis clients and store minimal wallet info
- Rehydrate wallets when loading saved games using TableManager
- Pass sync Redis to TableManager and add tests for wallet restoration and Game pickling

## Testing
- `python -m flake8 .` *(fails: AttributeError: 'EntryPoints' object has no attribute 'get')*
- `python -m unittest discover -s ./tests` *(fails: RoundRateModel has no attribute finish_rate; best hand assertion mismatch)*


------
https://chatgpt.com/codex/tasks/task_e_68c577c0bc8483288e0b65dae5584462