### PR TITLE
Make end-of-hand cleanup async and await message sending

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -919,7 +919,7 @@ class PokerBotModel:
 
         await self._view.send_new_hand_ready_message(chat_id)
         
-    def _end_hand(self, game: Game, chat_id: ChatId, context: CallbackContext) -> None:
+    async def _end_hand(self, game: Game, chat_id: ChatId, context: CallbackContext) -> None:
         """
         یک دست از بازی را تمام کرده، پیام‌ها را پاکسازی کرده و برای دست بعدی آماده می‌شود.
         """
@@ -927,29 +927,29 @@ class PokerBotModel:
         # این کار باعث می‌شود چت گروه شلوغ نشود
         for message_id in set(game.message_ids_to_delete): # از set استفاده می‌کنیم که پیام تکراری حذف نکنیم
             try:
-                context.bot.delete_message(chat_id=chat_id, message_id=message_id)
+                await context.bot.delete_message(chat_id=chat_id, message_id=message_id)
             except Exception as e:
                 # اگر پیام قبلاً حذف شده یا مشکلی پیش بیاید، خطا را فقط چاپ می‌کنیم
                 print(f"INFO: Could not delete message {message_id} in chat {chat_id}. Reason: {e}")
-        
+
         # پاک کردن آخرین پیام نوبت
         if game.turn_message_id:
             try:
-                context.bot.delete_message(chat_id=chat_id, message_id=game.turn_message_id)
+                await context.bot.delete_message(chat_id=chat_id, message_id=game.turn_message_id)
             except Exception as e:
                 print(f"INFO: Could not delete turn message {game.turn_message_id}. Reason: {e}")
-    
+
         # ۲. ذخیره بازیکنان برای دست بعدی
         # این باعث می‌شود در بازی بعدی، لازم نباشد همه دوباره /ready بزنند
         context.chat_data[KEY_OLD_PLAYERS] = [p.user_id for p in game.players if p.wallet.value() > 0]
-    
+
         # ۳. ریست کردن کامل آبجکت بازی برای شروع یک دست جدید و تمیز
         # یک آبجکت جدید Game می‌سازیم تا هیچ داده‌ای از دست قبل باقی نماند
         context.chat_data[KEY_CHAT_DATA_GAME] = Game()
-    
+
         # ۴. اعلام پایان دست و راهنمایی برای شروع دست بعدی
         keyboard = ReplyKeyboardMarkup([["/ready", "/start"]], resize_keyboard=True)
-        context.bot.send_message(
+        await context.bot.send_message(
             chat_id=chat_id,
             text="🎉 دست تمام شد! برای شروع دست بعدی، /ready بزنید یا منتظر بمانید تا کسی /start کند.",
             reply_markup=keyboard


### PR DESCRIPTION
## Summary
- Convert `_end_hand` to an async function
- Await `context.bot.send_message` and message deletions

## Testing
- `PYTHONPATH=. pytest -q` *(fails: 'RoundRateModel' object has no attribute 'finish_rate')*

------
https://chatgpt.com/codex/tasks/task_e_68c581a56cb48328ab8720953f22c91b