### PR TITLE
Await callback query answers to suppress warning

### DIFF
--- a/pokerapp/pokerbotcontrol.py
+++ b/pokerapp/pokerbotcontrol.py
@@ -55,7 +55,7 @@ class PokerBotCotroller:
             # می‌توانید یک پیام به کاربر بدهید که بازی فعال نیست
             query = update.callback_query
             if query:
-                query.answer(text="بازی در جریان نیست.", show_alert=False)
+                await query.answer(text="بازی در جریان نیست.", show_alert=False)
             return
 
         current_player = self._model._current_turn_player(game)
@@ -67,7 +67,7 @@ class PokerBotCotroller:
             print(f"DEBUG: Not user's turn. Current turn: {current_player.user_id}, Requester: {user_id}.")
             query = update.callback_query
             if query:
-                query.answer(text="☝️ نوبت شما نیست!", show_alert=True)
+                await query.answer(text="☝️ نوبت شما نیست!", show_alert=True)
             return
 
         # اگر نوبت کاربر بود، به متد اصلی برای پردازش دکمه برو


### PR DESCRIPTION
## Summary
- await CallbackQuery.answer when game inactive or not player's turn to avoid unawaited coroutine warnings

## Testing
- `python3 -m flake8 pokerapp/pokerbotcontrol.py` (fails: line too long etc.)
- `python3 -m unittest discover -s ./tests` (fails: AttributeError: 'RoundRateModel' object has no attribute 'finish_rate')

------
https://chatgpt.com/codex/tasks/task_e_68c5c7a7814483289e723b92e524e543