### PR TITLE
Add TableManager.find_game_by_user API and update callers

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -80,11 +80,10 @@ class PokerBotModel:
 
     async def _get_game_by_user(self, user_id: int) -> Tuple[Game, ChatId]:
         """Find the game and chat id for a given user."""
-        for chat_id in self._table_manager._tables.keys():
-            game = await self._table_manager.get_game(chat_id)
-            if any(p.user_id == user_id for p in game.players):
-                return game, chat_id
-        raise UserException("بازی‌ای برای توقف یافت نشد.")
+        result = await self._table_manager.find_game_by_user(user_id)
+        if result is None:
+            raise UserException("بازی‌ای برای توقف یافت نشد.")
+        return result
 
     @staticmethod
     def _current_turn_player(game: Game) -> Optional[Player]:

--- a/pokerapp/table_manager.py
+++ b/pokerapp/table_manager.py
@@ -1,5 +1,5 @@
 import pickle
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import redis
 import redis.asyncio as aioredis
@@ -54,6 +54,15 @@ class TableManager:
     async def save_game(self, chat_id: ChatId, game: Game) -> None:
         self._tables[chat_id] = game
         await self._save(chat_id, game)
+
+    async def find_game_by_user(self, user_id: int) -> Optional[Tuple[Game, ChatId]]:
+        """Return the game and chat id for the given user if present."""
+        # Iterate over cached games and make sure they are loaded
+        for chat_id in list(self._tables.keys()):
+            game = await self.get_game(chat_id)
+            if any(p.user_id == user_id for p in game.players):
+                return game, chat_id
+        return None
 
     # Internal -----------------------------------------------------------
     async def _save(self, chat_id: ChatId, game: Game) -> None:


### PR DESCRIPTION
## Summary
- add TableManager.find_game_by_user to look up a game by user and return its chat id
- switch PokerBotModel._get_game_by_user to use the new TableManager API
- rework table manager tests and add coverage for find_game_by_user

## Testing
- `PYTHONPATH=. pytest tests/test_table_manager.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'lupa'; AssertionError in test_determine_best_hand)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c8c39fcc832891416ce624e426cb