### PR TITLE
Expose cached lookup for user games

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -80,10 +80,10 @@ class PokerBotModel:
 
     async def _get_game_by_user(self, user_id: int) -> Tuple[Game, ChatId]:
         """Find the game and chat id for a given user."""
-        result = await self._table_manager.find_game_by_user(user_id)
-        if result is None:
-            raise UserException("بازی‌ای برای توقف یافت نشد.")
-        return result
+        try:
+            return await self._table_manager.find_game_by_user(user_id)
+        except LookupError as exc:
+            raise UserException("بازی‌ای برای توقف یافت نشد.") from exc
 
     @staticmethod
     def _current_turn_player(game: Game) -> Optional[Player]:

--- a/tests/test_table_manager.py
+++ b/tests/test_table_manager.py
@@ -73,7 +73,8 @@ async def test_find_game_by_user():
     await tm.save_game(chat, game)
 
     assert await tm.find_game_by_user("user1") == (game, chat)
-    assert await tm.find_game_by_user("user2") is None
+    with pytest.raises(LookupError):
+        await tm.find_game_by_user("user2")
 
 
 def test_game_pickle():


### PR DESCRIPTION
## Summary
- add TableManager.find_game_by_user to search cached games and raise LookupError when absent
- streamline PokerBotModel._get_game_by_user to use new lookup
- update table manager tests for LookupError

## Testing
- `PYTHONPATH=. pytest -q` *(fails: RoundRateModel.finish_rate missing, WinnerDetermination order mismatch; 6 failed, 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b05ac9588328b582671adebdf4a0