### PR TITLE
Handle missing lupa in wallet dec

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -1129,7 +1129,7 @@ class WalletManagerModel(Wallet):
 
         try:
             result = self._LUA_DECR_IF_GE(keys=[self._val_key], args=[amount, DEFAULT_MONEY])
-        except redis.exceptions.NoScriptError:
+        except (redis.exceptions.NoScriptError, ModuleNotFoundError):
             current = self._kv.get(self._val_key)
             if current is None:
                 self._kv.set(self._val_key, DEFAULT_MONEY)

--- a/tests/test_wallet_manager_model.py
+++ b/tests/test_wallet_manager_model.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import unittest
+import fakeredis
+
+from pokerapp.pokerbotmodel import WalletManagerModel
+
+
+class TestWalletManagerModel(unittest.TestCase):
+    def test_dec_without_lupa(self):
+        kv = fakeredis.FakeRedis()
+        wallet = WalletManagerModel("user", kv)
+        start = wallet.value()
+
+        def raise_module_not_found(*args, **kwargs):
+            raise ModuleNotFoundError("lupa")
+
+        wallet._LUA_DECR_IF_GE = raise_module_not_found
+        result = wallet.dec(100)
+        self.assertEqual(start - 100, result)
+        self.assertEqual(start - 100, wallet.value())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- catch ModuleNotFoundError in wallet decrement to fallback to pure Python operations
- add unit test verifying wallet decrement without Lua support

## Testing
- `python3 -m unittest tests.test_wallet_manager_model`
- `python3 -m unittest discover -s ./tests` *(fails: RoundRateModel has no attribute 'finish_rate')*
- `python3 -m flake8 .` *(fails: many style errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b47a4a1c83288645ea1489edcebe