### PR TITLE
Cache game in context for button callbacks

### DIFF
--- a/pokerapp/pokerbotcontrol.py
+++ b/pokerapp/pokerbotcontrol.py
@@ -11,8 +11,8 @@ from telegram.ext import (
 )
 import traceback  # <--- برای لاگ دقیق خطا اضافه شد
 
-from pokerapp.entities import PlayerAction, UserException, Game
-from pokerapp.pokerbotmodel import PokerBotModel, KEY_CHAT_DATA_GAME
+from pokerapp.entities import PlayerAction, UserException
+from pokerapp.pokerbotmodel import PokerBotModel
 
 class PokerBotCotroller:
     def __init__(self, model: PokerBotModel, application: Application):
@@ -44,9 +44,8 @@ class PokerBotCotroller:
         این میدل‌ور قبل از اجرای هر دستور دکمه اینلاین، نوبت بازیکن را چک می‌کند
         و لاگ‌های دقیقی برای دیباگ ثبت می‌کند.
         """
-        chat_id = update.effective_chat.id
         user_id = update.effective_user.id
-        game: Game = context.chat_data.get(KEY_CHAT_DATA_GAME)
+        game, chat_id = await self._model._get_game(update, context)
 
         print(f"\nDEBUG: Callback received from user {user_id} in chat {chat_id}.")
 

--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -73,9 +73,17 @@ class PokerBotModel:
         return 1 if self._cfg.DEBUG else MIN_PLAYERS
 
     async def _get_game(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> Tuple[Game, ChatId]:
-        """Fetch or create the Game instance for the current chat."""
+        """Fetch the Game instance for the current chat, caching it in ``chat_data``.
+
+        If the game has already been stored in ``context.chat_data`` it will be
+        reused. Otherwise it is loaded from ``TableManager`` and cached for
+        subsequent calls.
+        """
         chat_id = update.effective_chat.id
-        game = await self._table_manager.get_game(chat_id)
+        game = context.chat_data.get(KEY_CHAT_DATA_GAME)
+        if not game:
+            game = await self._table_manager.get_game(chat_id)
+            context.chat_data[KEY_CHAT_DATA_GAME] = game
         return game, chat_id
 
     async def _get_game_by_user(self, user_id: int) -> Tuple[Game, ChatId]:


### PR DESCRIPTION
## Summary
- Cache loaded poker games in `context.chat_data` for reuse
- Use model's `_get_game` in button middleware to ensure game loads and caches

## Testing
- `PYTHONPATH=$PWD pytest -q` *(fails: RoundRateModel has no attribute `finish_rate`)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b714b720832887ae9039e70b2cca