### PR TITLE
Handle errors when editing ready message

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -124,9 +124,11 @@ class Game:
         self.ready_users = set()
         self.message_ids = {}
         self.last_actions = []
-    
+
         # 🆕 اضافه شده: پیام لیست آماده‌ها
         self.ready_message_main_id: Optional[MessageId] = None
+        # متن آخرین پیام آماده‌باش برای جلوگیری از ویرایش‌های تکراری
+        self.ready_message_main_text: str = ""
     
         # 🆕 اضافه شده: آرایه پیام‌هایی که باید پاک شوند
         self.message_ids_to_delete: List[MessageId] = []


### PR DESCRIPTION
## Summary
- Avoid editing ready message if content is unchanged
- Log and handle BadRequest errors when editing ready message

## Testing
- `PYTHONPATH=$PWD pytest` *(fails: RoundRateModel lacks finish_rate; async plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b83257c8832895facd366dc1187b