### PR TITLE
Persist new game after hand

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -989,7 +989,9 @@ class PokerBotModel:
 
         # ۳. ریست کردن کامل آبجکت بازی برای شروع یک دست جدید و تمیز
         # یک آبجکت جدید Game می‌سازیم تا هیچ داده‌ای از دست قبل باقی نماند
-        context.chat_data[KEY_CHAT_DATA_GAME] = Game()
+        new_game = Game()
+        context.chat_data[KEY_CHAT_DATA_GAME] = new_game
+        await self._table_manager.save_game(chat_id, new_game)
 
         # ۴. اعلام پایان دست و راهنمایی برای شروع دست بعدی
         keyboard = ReplyKeyboardMarkup([["/ready", "/start"]], resize_keyboard=True)

--- a/tests/test_end_hand_persistence.py
+++ b/tests/test_end_hand_persistence.py
@@ -1,0 +1,34 @@
+import pytest
+import fakeredis
+import fakeredis.aioredis
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from pokerapp.config import Config
+from pokerapp.table_manager import TableManager
+from pokerapp.pokerbotmodel import PokerBotModel, KEY_CHAT_DATA_GAME
+
+
+@pytest.mark.asyncio
+async def test_end_hand_persists_game_and_reuses_instance():
+    server = fakeredis.FakeServer()
+    redis_async = fakeredis.aioredis.FakeRedis(server=server)
+    redis_sync = fakeredis.FakeRedis(server=server)
+    table_manager = TableManager(redis_async, redis_sync)
+
+    bot = SimpleNamespace(delete_message=AsyncMock(), send_message=AsyncMock())
+    model = PokerBotModel(MagicMock(), bot, Config(), redis_sync, table_manager)
+
+    chat_id = 123
+    game = await table_manager.create_game(chat_id)
+    context = SimpleNamespace(bot=bot, chat_data={})
+
+    await model._end_hand(game, chat_id, context)
+
+    new_game = context.chat_data[KEY_CHAT_DATA_GAME]
+    assert await table_manager.get_game(chat_id) is new_game
+
+    new_context = SimpleNamespace(bot=bot, chat_data={})
+    update = SimpleNamespace(effective_chat=SimpleNamespace(id=chat_id))
+    loaded_game, _ = await model._get_game(update, new_context)
+    assert loaded_game is new_game


### PR DESCRIPTION
## Summary
- Save the freshly created Game after each hand using TableManager so later commands reuse the same instance
- Add an async unit test ensuring `_end_hand` persists and reloads the new Game

## Testing
- `python3 -m flake8 .` *(fails: many style issues across repository)*
- `PYTHONPATH=. pytest` *(fails: missing RoundRateModel.finish_rate in several tests; new test passes)*
- `python3 -m unittest discover -s ./tests` *(fails: RoundRateModel tests missing finish_rate)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b9d114a88328b2d47630f901e568