### PR TITLE
Persist game state after showdown reset

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -974,6 +974,7 @@ class PokerBotModel:
         context.chat_data[KEY_OLD_PLAYERS] = [p.user_id for p in remaining_players]
 
         game.reset()
+        await self._table_manager.save_game(chat_id, game)
 
         await asyncio.sleep(1)
         await _send_with_retry(self._view.send_new_hand_ready_message, chat_id)


### PR DESCRIPTION
## Summary
- Save game state via `TableManager` after resetting in `_showdown`
- Ensure new hand ready message sent after persisting game

## Testing
- `python3 -m flake8 .` *(fails: AttributeError: 'EntryPoints' object has no attribute 'get')*
- `python3 -m unittest discover -s ./tests` *(fails: AttributeError: 'RoundRateModel' object has no attribute 'finish_rate')*

------
https://chatgpt.com/codex/tasks/task_e_68c6bf3599f083289a01e220f356b692