### PR TITLE
chore: rate limit bot interactions

### DIFF
--- a/tests/test_end_hand_persistence.py
+++ b/tests/test_end_hand_persistence.py
@@ -17,7 +17,8 @@ async def test_end_hand_persists_game_and_reuses_instance():
     table_manager = TableManager(redis_async, redis_sync)
 
     bot = SimpleNamespace(delete_message=AsyncMock(), send_message=AsyncMock())
-    model = PokerBotModel(MagicMock(), bot, Config(), redis_sync, table_manager)
+    view = SimpleNamespace(send_message=AsyncMock())
+    model = PokerBotModel(view, bot, Config(), redis_sync, table_manager)
 
     chat_id = 123
     game = await table_manager.create_game(chat_id)


### PR DESCRIPTION
## Summary
- centralize send/edit/delete calls through a new RateLimitedSender
- delegate model message handling to viewer so rate limits apply everywhere
- adapt tests for async viewer

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c71aa7a3d88328bff104ce7b98d9a0