### PR TITLE
Add JSON logger with admin alerts

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,25 +5,25 @@ from dotenv import load_dotenv
 from pokerapp.config import Config
 from pokerapp.pokerbot import PokerBot
 import logging
-from pokerapp.pokerbot import PokerBot
-from pokerapp.config import Config
+from pokerapp.logging_config import setup_logging
 
-logging.basicConfig(
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    level=logging.DEBUG
-)
+setup_logging(logging.DEBUG)
+logger = logging.getLogger(__name__)
+
 
 def main() -> None:
     load_dotenv()
     cfg: Config = Config()
 
     if cfg.TOKEN == "":
-        print("Environment varaible POKERBOT_TOKEN is not set")
+        logger.error(
+            "Environment variable POKERBOT_TOKEN is not set",
+            extra={"error_type": "MissingToken"},
+        )
         exit(1)
 
     bot = PokerBot(token=cfg.TOKEN, cfg=cfg)
     bot.run()
-
 
 
 if __name__ == "__main__":

--- a/pokerapp/config.py
+++ b/pokerapp/config.py
@@ -23,7 +23,8 @@ class Config:
             "POKERBOT_TOKEN",
             default="",
         )
-        self.DEBUG: bool = bool(os.getenv(
-            "POKERBOT_DEBUG",
-            default="0"
-        ) == "1")
+        self.DEBUG: bool = bool(
+            os.getenv("POKERBOT_DEBUG", default="0") == "1"
+        )
+        admin_chat_id = os.getenv("POKERBOT_ADMIN_CHAT_ID", "")
+        self.ADMIN_CHAT_ID = int(admin_chat_id) if admin_chat_id else None

--- a/pokerapp/logging_config.py
+++ b/pokerapp/logging_config.py
@@ -1,0 +1,27 @@
+import logging
+import json
+import datetime
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        log_record = {
+            "timestamp": datetime.datetime.utcnow().isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        for key in ("chat_id", "message_id", "request_params", "error_type"):
+            if key in record.__dict__:
+                log_record[key] = record.__dict__[key]
+        if record.exc_info:
+            log_record["exception"] = self.formatException(record.exc_info)
+        return json.dumps(log_record, ensure_ascii=False)
+
+
+def setup_logging(level: int = logging.INFO) -> None:
+    if logging.getLogger().handlers:
+        return
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    logging.basicConfig(level=level, handlers=[handler])

--- a/pokerapp/pokerbot.py
+++ b/pokerapp/pokerbot.py
@@ -10,11 +10,9 @@ from pokerapp.pokerbotcontrol import PokerBotCotroller
 from pokerapp.pokerbotmodel import PokerBotModel
 from pokerapp.pokerbotview import PokerBotViewer
 from pokerapp.table_manager import TableManager
+from pokerapp.logging_config import setup_logging
 
-logging.basicConfig(
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    level=logging.INFO,
-)
+setup_logging(logging.INFO)
 
 
 class PokerBot:
@@ -39,7 +37,7 @@ class PokerBot:
         )
 
         table_manager = TableManager(kv_async, kv_sync)
-        view = PokerBotViewer(bot=self._application.bot)
+        view = PokerBotViewer(bot=self._application.bot, admin_chat_id=cfg.ADMIN_CHAT_ID)
         model = PokerBotModel(
             view=view,
             bot=self._application.bot,


### PR DESCRIPTION
## Summary
- replace prints with JSON-structured logging and optional admin notifications
- configure global JSON logging
- add admin chat ID support for critical log forwarding

## Testing
- `make lint` *(fails: E501 line too long, F401 unused imports, etc.)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c723b837e0832890beb3c090f29e08