### PR TITLE
Store recent actions and reuse turn message

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -124,7 +124,8 @@ class Game:
         self.ready_users = set()
         self.message_ids = {}
         # history of most recent player actions; cleared each reset
-        self.last_actions: List[str] = []
+        # Each entry is a tuple of (player name, action type, amount)
+        self.last_actions: List[Tuple[str, str, Money]] = []
 
         # 🆕 اضافه شده: پیام لیست آماده‌ها
         self.ready_message_main_id: Optional[MessageId] = None


### PR DESCRIPTION
## Summary
- Track player actions as tuples and show the last four actions in the turn message
- Preserve editable turn message between turns and streets
- Remove chat action messages for call, raise, all-in and fold

## Testing
- `PYTHONPATH=. pytest -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'send_message_return_id')*

------
https://chatgpt.com/codex/tasks/task_e_68c7cc0d92a08328bbd8ccd6681d6090