### PR TITLE
Format and display recent turn actions

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -124,8 +124,8 @@ class Game:
         self.ready_users = set()
         self.message_ids = {}
         # history of most recent player actions; cleared each reset
-        # Each entry is a tuple of (player name, action type, amount)
-        self.last_actions: List[Tuple[str, str, Money]] = []
+        # Each entry is a formatted string like "player: action amount$"
+        self.last_actions: List[str] = []
 
         # 🆕 اضافه شده: پیام لیست آماده‌ها
         self.ready_message_main_id: Optional[MessageId] = None

--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -11,7 +11,7 @@ from telegram import (
 from telegram.constants import ParseMode
 from telegram.error import BadRequest, Forbidden, RetryAfter, TelegramError
 from io import BytesIO
-from typing import Optional, Callable, Awaitable, Dict, Any
+from typing import Optional, Callable, Awaitable, Dict, Any, List
 import asyncio
 import logging
 import json
@@ -450,7 +450,7 @@ class PokerBotViewer:
         player: Player,
         money: Money,
         message_id: Optional[MessageId] = None,
-        recent_actions: str = "",
+        recent_actions: Optional[List[str]] = None,
     ) -> Optional[MessageId]:
         """ارسال یا ویرایش پیام نوبت بازیکن با نمایش اکشن‌های اخیر."""
 
@@ -479,7 +479,7 @@ class PokerBotViewer:
             f"⬇️ حرکت خود را انتخاب کنید:"
         )
         if recent_actions:
-            text += f"\n\n🎬 **اکشن‌های اخیر:**\n{recent_actions}"
+            text += "\n\n🎬 **اکشن‌های اخیر:**\n" + "\n".join(recent_actions)
 
         # کیبورد اینلاین
         markup = self._get_turns_markup(call_check_text, call_check_action)


### PR DESCRIPTION
## Summary
- Record player actions as standardized strings
- Show recent actions list in turn prompts

## Testing
- `PYTHONPATH=. pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cdc6338c8328b2baff82035be386