### PR TITLE
Fix missing send_message_return_id in persistence test

### DIFF
--- a/tests/test_end_hand_persistence.py
+++ b/tests/test_end_hand_persistence.py
@@ -17,7 +17,10 @@ async def test_end_hand_persists_game_and_reuses_instance():
     table_manager = TableManager(redis_async, redis_sync)
 
     bot = SimpleNamespace(send_message=AsyncMock())
-    view = SimpleNamespace(send_message=AsyncMock())
+    view = SimpleNamespace(
+        send_message=AsyncMock(),
+        send_message_return_id=AsyncMock(return_value=1),
+    )
     model = PokerBotModel(view, bot, Config(), redis_sync, table_manager)
 
     chat_id = 123


### PR DESCRIPTION
## Summary
- add `send_message_return_id` mock to `view` stub in `test_end_hand_persistence`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7d39d142c8328be101ae9e31e4ad9