### PR TITLE
Await view messaging in error paths

### DIFF
--- a/pokerapp/pokerbotcontrol.py
+++ b/pokerapp/pokerbotcontrol.py
@@ -147,11 +147,11 @@ class PokerBotCotroller:
 
         except UserException as ex:
             print(f"INFO: Handled UserException: {ex}")
-            self._view.send_message(chat_id=chat_id, text=str(ex))
+            await self._view.send_message(chat_id=chat_id, text=str(ex))
         except Exception:
             # گرفتن تمام خطاهای دیگر برای دیباگ
             print(f"FATAL ERROR: Unexpected exception in player_action.")
             traceback.print_exc() # چاپ کامل خطا
-            self._view.send_message(chat_id, "یک خطای بحرانی در پردازش حرکت رخ داد. بازی ریست می‌شود.")
+            await self._view.send_message(chat_id, "یک خطای بحرانی در پردازش حرکت رخ داد. بازی ریست می‌شود.")
 
         # ==================== پایان بلوک اصلی دیباگ و اصلاح ====================


### PR DESCRIPTION
## Summary
- ensure error handlers in `_handle_button_clicked` await `_view.send_message`

## Testing
- `PYTHONPATH=. pytest`
- custom script simulating UserException and general Exception paths

------
https://chatgpt.com/codex/tasks/task_e_68c7dca2d8f0832886450a62229c8ce6