### PR TITLE
Send player card keyboards via private messages

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -502,13 +502,12 @@ class PokerBotModel:
                     parse_mode="Markdown",
                 )
 
-            # ۲. ارسال پیام با کیبورد کارتی در گروه
+            # ۲. ارسال پیام با کیبورد کارتی در چت خصوصی بازیکن
             # این پیام برای دسترسی سریع بازیکن به کارت‌هایش است.
             cards_message_id = await self._view.send_cards(
-                chat_id=chat_id,
+                chat_id=player.user_id,
                 cards=player.cards,
                 mention_markdown=player.mention_markdown,
-                ready_message_id=player.ready_message_id,
                 table_cards=game.cards_table,
                 stage="",
             )
@@ -1065,7 +1064,7 @@ class PokerBotModel:
         for player in game.seated_players():
             if player.hand_message_id:
                 await self._view.send_cards(
-                    chat_id=chat_id,
+                    chat_id=player.user_id,
                     cards=player.cards,
                     mention_markdown=player.mention_markdown,
                     table_cards=game.cards_table,

--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -526,7 +526,11 @@ class PokerBotViewer:
     def _get_hand_and_board_markup(
         hand: Cards, table_cards: Cards, stage: str
     ) -> ReplyKeyboardMarkup:
-        """Combine player's hand, table cards and stage/hide buttons in one keyboard."""
+        """Combine player's hand, table cards and stage/hide buttons in one keyboard.
+
+        این کیبورد در پیام خصوصی بازیکن نیز استفاده می‌شود تا او هم‌زمان دست و
+        کارت‌های میز را مشاهده کند.
+        """
         table_row = table_cards if table_cards else ["❔"]
         stages = ["فلاپ", "ترن", "ریور"]
         stage_map = {"flop": "فلاپ", "turn": "ترن", "river": "ریور"}


### PR DESCRIPTION
## Summary
- deliver card keyboard messages directly to each player's private chat and track their message IDs
- update private card messages when community cards are dealt
- document combined hand and board keyboard usage for private chats

## Testing
- `make lint` (fails: AttributeError: 'EntryPoints' object has no attribute 'get')
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c8280269408328946e0f6d069f011f