### PR TITLE
Persist and edit table message with card keyboard

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -1045,20 +1045,12 @@ class PokerBotModel:
                 if msg_id not in game.message_ids_to_delete:
                     game.message_ids_to_delete.append(msg_id)
         else:
-            edited_id = await self._view.edit_message_text(
+            await self._view.edit_message_text(
                 chat_id=chat_id,
                 message_id=game.board_message_id,
                 text=street_name,
                 reply_markup=markup,
             )
-            if not edited_id:
-                msg_id = await self._view.send_message_return_id(
-                    chat_id, street_name, reply_markup=markup
-                )
-                if msg_id:
-                    game.board_message_id = msg_id
-                    if msg_id not in game.message_ids_to_delete:
-                        game.message_ids_to_delete.append(msg_id)
 
         # به‌روزرسانی کیبورد پیام کارت‌های بازیکنان با کارت‌های میز
         for player in game.seated_players():

--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -508,7 +508,7 @@ class PokerBotViewer:
     @staticmethod
     def _get_table_markup(table_cards: Cards, stage: str) -> ReplyKeyboardMarkup:
         """Creates a keyboard displaying table cards and stage buttons."""
-        cards_row = table_cards if table_cards else ["❔"]
+        cards_row = [str(card) for card in table_cards] if table_cards else ["❔"]
         stages = ["فلاپ", "ترن", "ریور", "👁️ نمایش میز"]
         stage_map = {"flop": "فلاپ", "turn": "ترن", "river": "ریور"}
         if stage in stage_map:


### PR DESCRIPTION
## Summary
- Send table message once and edit it for flop/turn/river updates
- Display dealt cards in the first row of the table keyboard

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c829147820832888dabc5da900c181