### PR TITLE
Handle missing JobQueue gracefully

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -166,6 +166,11 @@ class PokerBotModel:
     async def _schedule_auto_start(self, context: CallbackContext, game: Game, chat_id: ChatId) -> None:
         if context.chat_data.get("start_countdown_job"):
             return
+
+        if context.job_queue is None:
+            logger.warning("JobQueue not available; auto start disabled")
+            return
+
         context.chat_data["start_countdown"] = 60
         job = context.job_queue.run_repeating(
             self._auto_start_tick, interval=1, chat_id=chat_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-telegram-bot>=20
+python-telegram-bot[job-queue]>=20
 flake8==4.0.1
 pillow==10.4.0
 PySocks==1.7.1


### PR DESCRIPTION
## Summary
- avoid AttributeError when JobQueue is absent by checking `context.job_queue` before scheduling auto-start
- ensure job-queue dependency is installed by using `python-telegram-bot[job-queue]`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c837d4c29c8328ad1b27c019bf75b6