### PR TITLE
Enforce webhook configuration requirements

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,11 +15,48 @@ def main() -> None:
     load_dotenv()
     cfg: Config = Config()
 
+    missing_settings = []
+
     if cfg.TOKEN == "":
-        logger.error(
-            "Environment variable POKERBOT_TOKEN is not set",
-            extra={"error_type": "MissingToken"},
+        missing_settings.append(
+            (
+                "MissingToken",
+                "Environment variable POKERBOT_TOKEN is not set. "
+                "Add it to your .env file or container environment.",
+            )
         )
+
+    if not cfg.WEBHOOK_PATH:
+        missing_settings.append(
+            (
+                "MissingWebhookPath",
+                "Webhook path is not configured. Set POKERBOT_WEBHOOK_PATH in your "
+                ".env file or container environment.",
+            )
+        )
+
+    if not cfg.WEBHOOK_PUBLIC_URL:
+        missing_settings.append(
+            (
+                "MissingWebhookPublicUrl",
+                "Webhook public URL is not configured. Set POKERBOT_WEBHOOK_DOMAIN (recommended) "
+                "together with POKERBOT_WEBHOOK_PATH, or provide POKERBOT_WEBHOOK_PUBLIC_URL in "
+                "your .env file or container environment.",
+            )
+        )
+
+    if not cfg.WEBHOOK_SECRET:
+        missing_settings.append(
+            (
+                "MissingWebhookSecret",
+                "Webhook secret token is not configured. Set POKERBOT_WEBHOOK_SECRET in your "
+                ".env file or container environment.",
+            )
+        )
+
+    if missing_settings:
+        for error_type, message in missing_settings:
+            logger.error(message, extra={"error_type": error_type})
         exit(1)
 
     bot = PokerBot(token=cfg.TOKEN, cfg=cfg)


### PR DESCRIPTION
## Summary
- add startup validation for token and webhook settings with actionable guidance when required variables are missing
- normalize webhook path/domain and derive the webhook public URL from the configured domain and path to reduce manual errors

## Testing
- PYTHONPATH=. pytest *(fails: async tests require a pytest asyncio plugin in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e12d7ce48328b9c22314f96ebfb5