### PR TITLE
Expose bot service port for webhook proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,17 @@ services:
   bot:
     build: .
     restart: always
+    ports:
+      - "127.0.0.1:3000:3000"
+    # پروکسی خارجی TLS را خاتمه می‌دهد و درخواست‌ها را به 127.0.0.1:3000 می‌فرستد.
     environment:
       - POKERBOT_TOKEN=$POKERBOT_TOKEN
       - POKERBOT_REDIS_HOST=redis
+      - POKERBOT_WEBHOOK_LISTEN=$POKERBOT_WEBHOOK_LISTEN
+      - POKERBOT_WEBHOOK_PORT=$POKERBOT_WEBHOOK_PORT
+      - POKERBOT_WEBHOOK_PATH=$POKERBOT_WEBHOOK_PATH
+      - POKERBOT_WEBHOOK_PUBLIC_URL=$POKERBOT_WEBHOOK_PUBLIC_URL
+      - POKERBOT_WEBHOOK_SECRET=$POKERBOT_WEBHOOK_SECRET
 
 volumes:
   redis_data:


### PR DESCRIPTION
## Summary
- expose the bot container on 127.0.0.1:3000 so it can receive traffic via nginx
- document that TLS is terminated by the external proxy and forward requests to the bot
- add webhook-related environment variable bindings for the bot service

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9e28ae2c08328b8e9460840a6abc7