### PR TITLE
Document TLS termination for bot service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,8 @@ services:
     restart: always
     ports:
       - "127.0.0.1:3000:3000"
-    # پروکسی خارجی TLS را خاتمه می‌دهد و درخواست‌ها را به 127.0.0.1:3000 می‌فرستد.
+    # TLS در Nginx خاتمه می‌یابد و درخواست‌ها به 127.0.0.1:3000 هدایت می‌شود،
+    # بنابراین کانتینر فقط روی لوپ‌بک گوش می‌دهد.
     environment:
       - POKERBOT_TOKEN=$POKERBOT_TOKEN
       - POKERBOT_REDIS_HOST=redis


### PR DESCRIPTION
## Summary
- document that TLS termination happens in Nginx while the bot listens on 127.0.0.1:3000
- keep the webhook-related environment variables configured for the bot service

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c9ea17380c8328b93abedc3a987a57