### PR TITLE
Remove deprecated job_queue argument

### DIFF
--- a/pokerapp/pokerbot.py
+++ b/pokerapp/pokerbot.py
@@ -51,7 +51,6 @@ class PokerBot:
         builder = (
             ApplicationBuilder()
             .token(token)
-            .job_queue(True)
             .post_init(self._apply_webhook_settings)
             .post_stop(self._cleanup_webhook)
         )


### PR DESCRIPTION
## Summary
- stop passing a boolean to ApplicationBuilder.job_queue so the default queue is used

## Testing
- PYTHONPATH=. pytest *(fails: async def functions are not natively supported; pytest-asyncio missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6fe03cfc8328bb4906e37164adf9