### PR TITLE
Initialize JobQueue instance for PTB v20

### DIFF
--- a/pokerapp/pokerbot.py
+++ b/pokerapp/pokerbot.py
@@ -46,13 +46,13 @@ class PokerBot:
             allowed_updates=cfg.ALLOWED_UPDATES,
             drop_pending_updates=True,
         )
-        job_queue = JobQueue()
+        self._job_queue = JobQueue()
 
         builder = (
             ApplicationBuilder()
             .token(token)
             .post_stop(self._cleanup_webhook)
-            .job_queue(job_queue)
+            .job_queue(self._job_queue)
         )
         self._application = builder.build()
         self._application.add_error_handler(self._handle_error)


### PR DESCRIPTION
## Summary
- ensure the PokerBot application builder receives a concrete JobQueue instance to satisfy PTB v20

## Testing
- PYTHONPATH=. pytest *(fails: async plugin required for async tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ca74b8067083288a969250dbe40302