### PR TITLE
Add group hand messaging support

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -71,6 +71,7 @@ class Player:
         self.round_rate = 0
         self.ready_message_id = ready_message_id
         self.hand_message_id: Optional[MessageId] = None
+        self.group_hand_message_id: Optional[MessageId] = None
         # --- ویژگی‌های اضافه شده ---
         self.total_bet = 0  # کل مبلغ شرط‌بندی شده در یک دست
         self.has_acted = False # آیا در راند فعلی نوبت خود را بازی کرده؟

--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -577,6 +577,7 @@ class PokerBotViewer:
             table_cards: Cards | None = None,
             stage: str = "",
             message_id: MessageId | None = None,
+            reply_to_ready_message: bool = True,
     ) -> Optional[MessageId]:
         markup = self._get_hand_and_board_markup(cards, table_cards or [], stage)
         hand_text = " ".join(str(card) for card in cards)
@@ -612,7 +613,7 @@ class PokerBotViewer:
         try:
             async def _send() -> Message:
                 reply_kwargs = {}
-                if ready_message_id and not message_id:
+                if reply_to_ready_message and ready_message_id and not message_id:
                     reply_kwargs["reply_to_message_id"] = ready_message_id
                 return await self._bot.send_message(
                     chat_id=chat_id,


### PR DESCRIPTION
## Summary
- track a dedicated group hand message id on each player
- send and refresh group card summaries alongside private messages while keeping delete lists updated
- allow viewer card sender to skip replying to ready prompts so group messages behave correctly

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pokerapp')*

------
https://chatgpt.com/codex/tasks/task_e_68ca8cd4623c83289e91dbe532aac227