### PR TITLE
Handle expected delete_message errors quietly

### DIFF
--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -360,6 +360,34 @@ class PokerBotViewer:
                 ),
                 chat_id=chat_id,
             )
+        except (BadRequest, Forbidden) as e:
+            error_message = getattr(e, "message", None) or str(e) or ""
+            normalized_message = error_message.lower()
+            ignorable_messages = (
+                "message to delete not found",
+                "message can't be deleted",
+                "message cant be deleted",
+            )
+            if any(msg in normalized_message for msg in ignorable_messages):
+                logger.debug(
+                    "Ignoring delete_message error",
+                    extra={
+                        "chat_id": chat_id,
+                        "message_id": message_id,
+                        "error_type": type(e).__name__,
+                        "error_message": error_message,
+                    },
+                )
+                return
+            logger.warning(
+                "Failed to delete message",
+                extra={
+                    "error_type": type(e).__name__,
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "error_message": error_message,
+                },
+            )
         except Exception as e:
             logger.error(
                 "Error deleting message",

--- a/tests/test_pokerbotviewer.py
+++ b/tests/test_pokerbotviewer.py
@@ -1,0 +1,69 @@
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+from telegram.error import BadRequest, Forbidden
+
+from pokerapp.pokerbotview import PokerBotViewer
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_delete_message_ignores_missing_message(caplog):
+    viewer = PokerBotViewer(bot=MagicMock())
+    viewer._rate_limiter.send = AsyncMock(
+        side_effect=BadRequest("Message to delete not found")
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        run(viewer.delete_message(chat_id=123, message_id=456))
+
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+    assert not any(
+        record.levelno == logging.WARNING and "Failed to delete message" in record.message
+        for record in caplog.records
+    )
+
+
+def test_delete_message_logs_warning_for_unexpected_bad_request(caplog):
+    viewer = PokerBotViewer(bot=MagicMock())
+    viewer._rate_limiter.send = AsyncMock(side_effect=BadRequest("Some other error"))
+
+    with caplog.at_level(logging.WARNING):
+        run(viewer.delete_message(chat_id=123, message_id=456))
+
+    assert any(
+        record.levelno == logging.WARNING and "Failed to delete message" in record.message
+        for record in caplog.records
+    )
+
+
+def test_delete_message_ignores_forbidden_when_message_cannot_be_deleted(caplog):
+    viewer = PokerBotViewer(bot=MagicMock())
+    viewer._rate_limiter.send = AsyncMock(
+        side_effect=Forbidden("message can't be deleted")
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        run(viewer.delete_message(chat_id=123, message_id=456))
+
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+    assert not any(
+        record.levelno == logging.WARNING and "Failed to delete message" in record.message
+        for record in caplog.records
+    )
+
+
+def test_delete_message_logs_error_for_unexpected_exception(caplog):
+    viewer = PokerBotViewer(bot=MagicMock())
+    viewer._rate_limiter.send = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with caplog.at_level(logging.ERROR):
+        run(viewer.delete_message(chat_id=123, message_id=456))
+
+    assert any(
+        record.levelno == logging.ERROR and "Error deleting message" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- treat Telegram `BadRequest`/`Forbidden` delete failures for already removed messages as ignorable while logging other issues as warnings
- add coverage around `PokerBotViewer.delete_message` log levels

## Testing
- PYTHONPATH=. pytest tests/test_pokerbotviewer.py

------
https://chatgpt.com/codex/tasks/task_e_68ca8dc4315083289f31760db767f6cc