### PR TITLE
Ensure legacy Markdown mentions when joining

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -367,7 +367,7 @@ class PokerBotModel:
         if user.id not in game.ready_users:
             player = Player(
                 user_id=user.id,
-                mention_markdown=user.mention_markdown(),
+                mention_markdown=user.mention_markdown(version=1),
                 wallet=wallet,
                 ready_message_id=game.ready_message_main_id,
                 seat_index=None,


### PR DESCRIPTION
## Summary
- ensure join_game stores player mention strings using Telegram's Markdown v1 flavor so later messages stay compatible with ParseMode.MARKDOWN

## Testing
- PYTHONPATH=. pytest *(fails: async def functions are not natively supported; pytest-asyncio plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68cab053c0008328b4ee66c28c5884ed