### PR TITLE
Fix mention markdown creation for seated players

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -15,6 +15,7 @@ from telegram import (
 from telegram.constants import ParseMode
 from telegram.error import BadRequest, RetryAfter
 from telegram.ext import CallbackContext, ContextTypes
+from telegram.helpers import mention_markdown as format_mention_markdown
 
 import logging
 
@@ -367,7 +368,9 @@ class PokerBotModel:
         if user.id not in game.ready_users:
             player = Player(
                 user_id=user.id,
-                mention_markdown=user.mention_markdown(version=1),
+                mention_markdown=format_mention_markdown(
+                    user.id, user.full_name, version=1
+                ),
                 wallet=wallet,
                 ready_message_id=game.ready_message_main_id,
                 seat_index=None,


### PR DESCRIPTION
## Summary
- format stored player mentions with `telegram.helpers.mention_markdown(..., version=1)` so that Markdown V1 private messages no longer crash when users join the table

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pokerapp')*


------
https://chatgpt.com/codex/tasks/task_e_68ca852d23cc8328be7285aa2a06c67c