### PR TITLE
Show player hand keyboard in group chat

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -71,6 +71,7 @@ class Player:
         self.round_rate = 0
         self.ready_message_id = ready_message_id
         self.hand_message_id: Optional[MessageId] = None
+        self.group_hand_message_id: Optional[MessageId] = None
         # --- ویژگی‌های اضافه شده ---
         self.total_bet = 0  # کل مبلغ شرط‌بندی شده در یک دست
         self.has_acted = False # آیا در راند فعلی نوبت خود را بازی کرده؟


### PR DESCRIPTION
## Summary
- track a separate group hand message for each player
- send the combined hand/table keyboard to the group chat and refresh it when the board changes
- clear stored group keyboard references when cleaning up game messages

## Testing
- python3 -m unittest discover -s ./tests

------
https://chatgpt.com/codex/tasks/task_e_68cab5750f688328bbdaa978aa99e194