### PR TITLE
Hide group hand text

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -569,6 +569,7 @@ class PokerBotModel:
                 cards=cards,
                 mention_markdown=player.mention_markdown,
                 table_cards=game.cards_table,
+                hide_hand_text=True,
                 stage=stage,
                 reply_to_ready_message=False,
             )
@@ -1128,6 +1129,7 @@ class PokerBotModel:
                     cards=player.cards,
                     mention_markdown=player.mention_markdown,
                     table_cards=game.cards_table,
+                    hide_hand_text=True,
                     stage=stage,
                     message_id=previous_group_id,
                     reply_to_ready_message=False,

--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -653,6 +653,7 @@ class PokerBotViewer:
             mention_markdown: Mention,
             ready_message_id: str | None = None,
             table_cards: Cards | None = None,
+            hide_hand_text: bool = False,
             stage: str = "",
             message_id: MessageId | None = None,
             reply_to_ready_message: bool = True,
@@ -664,11 +665,14 @@ class PokerBotViewer:
         hand_text = " ".join(str(card) for card in cards)
         table_values = list(table_cards or [])
         table_text = " ".join(str(card) for card in table_values) if table_values else "❔"
-        message_text = (
-            f"{mention_markdown}\n"
-            f"🃏 دست: {hand_text}\n"
-            f"🃎 میز: {table_text}"
-        )
+        if hide_hand_text:
+            message_body = "🔒 کارت‌ها تنها در پیام خصوصی نمایش داده می‌شوند."
+        else:
+            message_body = (
+                f"🃏 دست: {hand_text}\n"
+                f"🃎 میز: {table_text}"
+            )
+        message_text = f"{mention_markdown}\n{message_body}"
         try:
             async def _send() -> Message:
                 reply_kwargs = {}

--- a/tests/test_pokerbotviewer.py
+++ b/tests/test_pokerbotviewer.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from telegram.error import BadRequest, Forbidden
 
+from pokerapp.cards import Card
 from pokerapp.pokerbotview import PokerBotViewer
 
 
@@ -67,3 +68,58 @@ def test_delete_message_logs_error_for_unexpected_exception(caplog):
         record.levelno == logging.ERROR and "Error deleting message" in record.message
         for record in caplog.records
     )
+
+
+async def _passthrough_rate_limit(func, *args, **kwargs):
+    return await func()
+
+
+def test_send_cards_hides_group_hand_text_when_requested():
+    viewer = PokerBotViewer(bot=MagicMock())
+    viewer._rate_limiter.send = _passthrough_rate_limit  # type: ignore[assignment]
+    viewer._bot.send_message = AsyncMock(return_value=MagicMock(message_id=42))
+
+    cards = [Card("A♠"), Card("K♦")]
+    table_cards = [Card("2♣"), Card("3♣"), Card("4♣")]
+
+    run(
+        viewer.send_cards(
+            chat_id=123,
+            cards=cards,
+            mention_markdown="@player",
+            table_cards=table_cards,
+            hide_hand_text=True,
+        )
+    )
+
+    assert viewer._bot.send_message.await_count == 1
+    call = viewer._bot.send_message.await_args
+    text = call.kwargs["text"]
+    assert "@player" in text
+    assert "A♠" not in text and "K♦" not in text
+    assert "2♣" not in text and "3♣" not in text and "4♣" not in text
+    assert "🔒" in text
+
+
+def test_send_cards_includes_hand_details_by_default():
+    viewer = PokerBotViewer(bot=MagicMock())
+    viewer._rate_limiter.send = _passthrough_rate_limit  # type: ignore[assignment]
+    viewer._bot.send_message = AsyncMock(return_value=MagicMock(message_id=24))
+
+    cards = [Card("Q♥"), Card("J♥")]
+    table_cards = [Card("10♥"), Card("9♥"), Card("8♥")]
+
+    run(
+        viewer.send_cards(
+            chat_id=456,
+            cards=cards,
+            mention_markdown="@player",
+            table_cards=table_cards,
+        )
+    )
+
+    assert viewer._bot.send_message.await_count == 1
+    call = viewer._bot.send_message.await_args
+    text = call.kwargs["text"]
+    assert "Q♥" in text and "J♥" in text
+    assert "10♥" in text and "9♥" in text and "8♥" in text


### PR DESCRIPTION
## Summary
- add an option to PokerBotViewer.send_cards that can replace detailed card text with a neutral notice
- use the new option when posting group-facing card messages so shared chats no longer reveal card faces
- extend pokerbotviewer tests to cover the hidden-text behavior while confirming private messages still show full details

## Testing
- PYTHONPATH=. pytest tests/test_pokerbotviewer.py

------
https://chatgpt.com/codex/tasks/task_e_68cab88db5388328ae21fd563e0f4ff3