### PR TITLE
Remove group hand message tracking from dealing flow

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -71,7 +71,6 @@ class Player:
         self.round_rate = 0
         self.ready_message_id = ready_message_id
         self.hand_message_id: Optional[MessageId] = None
-        self.group_hand_message_id: Optional[MessageId] = None
         # --- ویژگی‌های اضافه شده ---
         self.total_bet = 0  # کل مبلغ شرط‌بندی شده در یک دست
         self.has_acted = False # آیا در راند فعلی نوبت خود را بازی کرده؟

--- a/tests/test_pokerbotmodel.py
+++ b/tests/test_pokerbotmodel.py
@@ -2,13 +2,20 @@
 
 import unittest
 from typing import Tuple
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import fakeredis
+import pytest
 
 from pokerapp.cards import Cards, Card
 from pokerapp.config import Config
 from pokerapp.entities import Money, Player, Game
-from pokerapp.pokerbotmodel import RoundRateModel, WalletManagerModel
+from pokerapp.pokerbotmodel import (
+    PokerBotModel,
+    RoundRateModel,
+    WalletManagerModel,
+)
 
 
 HANDS_FILE = "./tests/hands.txt"
@@ -163,6 +170,74 @@ class TestRoundRateModel(unittest.TestCase):
         self.assert_authorized_money_zero(
             g.id, first_winner, second_winner, third_loser, fourth_loser
         )
+class _DummyView:
+    def __init__(self):
+        self.private_calls = []
+        self.group_messages = []
+
+    def _get_hand_and_board_markup(self, cards, table_cards):
+        return "markup"
+
+    async def send_desk_cards_img(self, chat_id, cards, caption, reply_markup):
+        self.private_calls.append(
+            {
+                "chat_id": chat_id,
+                "cards": list(cards),
+                "caption": caption,
+                "reply_markup": reply_markup,
+            }
+        )
+        return SimpleNamespace(message_id=100 + len(self.private_calls))
+
+    async def send_message(self, *args, **kwargs):
+        self.group_messages.append((args, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_divide_cards_sends_only_private_messages():
+    view = _DummyView()
+    model = PokerBotModel(
+        view=view,
+        bot=MagicMock(),
+        cfg=Config(),
+        kv=fakeredis.FakeRedis(),
+        table_manager=MagicMock(),
+    )
+
+    game = Game()
+
+    player_one = Player(
+        user_id=1,
+        mention_markdown="@p1",
+        wallet=MagicMock(),
+        ready_message_id="ready-1",
+    )
+    player_two = Player(
+        user_id=2,
+        mention_markdown="@p2",
+        wallet=MagicMock(),
+        ready_message_id="ready-2",
+    )
+
+    game.add_player(player_one)
+    game.add_player(player_two)
+
+    game.remain_cards = [
+        Card("2♣"),
+        Card("3♣"),
+        Card("4♣"),
+        Card("5♣"),
+    ]
+
+    await model._divide_cards(game, chat_id=999)
+
+    assert [call["chat_id"] for call in view.private_calls] == [1, 2]
+    assert view.group_messages == []
+    assert game.message_ids_to_delete == []
+    assert player_one.hand_message_id == 101
+    assert player_two.hand_message_id == 102
+    assert player_one.cards == [Card("5♣"), Card("4♣")]
+    assert player_two.cards == [Card("3♣"), Card("2♣")]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- remove group chat dealing messages and stop tracking extra message IDs when dealing
- update table card refreshes to touch only private player messages
- add a regression test ensuring card dealing only emits private messages

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb18c5cc48832897d9c8836a78c20b