### PR TITLE
Remove private messaging from dealing flow

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -70,7 +70,6 @@ class Player:
         self.cards = []
         self.round_rate = 0
         self.ready_message_id = ready_message_id
-        self.hand_message_id: Optional[MessageId] = None
         self.group_hand_message_id: Optional[MessageId] = None
         # --- ویژگی‌های اضافه شده ---
         self.total_bet = 0  # کل مبلغ شرط‌بندی شده در یک دست

--- a/pokerapp/pokerbotcontrol.py
+++ b/pokerapp/pokerbotcontrol.py
@@ -134,7 +134,8 @@ class PokerBotCotroller:
         game, _ = await self._model._get_game(update, context)
         if 0 <= index < len(game.cards_table):
             card = game.cards_table[index]
-            await self._view.send_single_card(chat_id=query.from_user.id, card=card)
+            await query.answer(text=str(card), show_alert=True)
+            return
         await query.answer()
 
     async def _handle_button_clicked(

--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -630,22 +630,6 @@ class PokerBotViewer:
             one_time_keyboard=False,
         )
 
-    async def show_reopen_keyboard(self, chat_id: ChatId) -> None:
-        """Hides cards and sends a private keyboard to reopen them."""
-        show_cards_button_text = "🃏 نمایش کارت‌ها"
-        show_table_button_text = "👁️ نمایش میز"
-        reopen_keyboard = ReplyKeyboardMarkup(
-            keyboard=[[show_cards_button_text, show_table_button_text]],
-            selective=False,
-            resize_keyboard=True,
-            one_time_keyboard=False
-        )
-        await self.send_message(
-            chat_id=chat_id,
-            text="کارت‌ها پنهان شد. برای مشاهده دوباره از دکمه‌ها استفاده کن.",
-            reply_markup=reopen_keyboard,
-        )
-
     async def send_cards(
             self,
             chat_id: ChatId,


### PR DESCRIPTION
## Summary
- stop tracking per-player private card messages and only refresh the public, selective keyboards when cards are dealt
- ensure /cards and board-card callbacks answer inside the group (using message edits or alerts) and drop the reopen keyboard helper
- extend unit coverage to confirm /cards stays in-group while keeping existing viewer tests working with asyncio helpers

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cb20d3ea608328812e7c582515a3b4