### PR TITLE
Refine group card handling to avoid leftover messages

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -70,7 +70,6 @@ class Player:
         self.cards = []
         self.round_rate = 0
         self.ready_message_id = ready_message_id
-        self.group_hand_message_id: Optional[MessageId] = None
         # --- ویژگی‌های اضافه شده ---
         self.total_bet = 0  # کل مبلغ شرط‌بندی شده در یک دست
         self.has_acted = False # آیا در راند فعلی نوبت خود را بازی کرده؟

--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -244,23 +244,15 @@ class PokerBotModel:
             return
 
         stage = self._view._derive_stage_from_table(game.cards_table)
-        previous_message_id = current_player.group_hand_message_id
-        new_message_id = await self._view.send_cards(
+        await self._view.send_cards(
             chat_id=chat_id,
             cards=current_player.cards,
             mention_markdown=current_player.mention_markdown,
             table_cards=game.cards_table,
             hide_hand_text=True,
             stage=stage,
-            message_id=previous_message_id,
             reply_to_ready_message=False,
         )
-        if previous_message_id and previous_message_id in game.message_ids_to_delete:
-            game.message_ids_to_delete.remove(previous_message_id)
-        if new_message_id:
-            current_player.group_hand_message_id = new_message_id
-            if new_message_id not in game.message_ids_to_delete:
-                game.message_ids_to_delete.append(new_message_id)
 
     async def _safe_edit_message_text(
         self,
@@ -538,24 +530,16 @@ class PokerBotModel:
             cards = [game.remain_cards.pop(), game.remain_cards.pop()]
             player.cards = cards
 
-            previous_group_id = player.group_hand_message_id
             stage = self._view._derive_stage_from_table(game.cards_table)
-            group_message_id = await self._view.send_cards(
+            await self._view.send_cards(
                 chat_id=chat_id,
                 cards=cards,
                 mention_markdown=player.mention_markdown,
                 table_cards=game.cards_table,
                 hide_hand_text=True,
                 stage=stage,
-                message_id=previous_group_id,
                 reply_to_ready_message=False,
             )
-            if previous_group_id and previous_group_id in game.message_ids_to_delete:
-                game.message_ids_to_delete.remove(previous_group_id)
-            if group_message_id:
-                player.group_hand_message_id = group_message_id
-                if group_message_id not in game.message_ids_to_delete:
-                    game.message_ids_to_delete.append(group_message_id)
 
     def _is_betting_round_over(self, game: Game) -> bool:
         """
@@ -1089,25 +1073,17 @@ class PokerBotModel:
 
         # به‌روزرسانی کیبورد پیام کارت‌های بازیکنان با کارت‌های میز
         for player in game.seated_players():
-            if player.group_hand_message_id:
-                previous_group_id = player.group_hand_message_id
-                new_group_msg_id = await self._view.send_cards(
-                    chat_id=chat_id,
-                    cards=player.cards,
-                    mention_markdown=player.mention_markdown,
-                    table_cards=game.cards_table,
-                    hide_hand_text=True,
-                    stage=stage,
-                    message_id=previous_group_id,
-                    reply_to_ready_message=False,
-                )
-                if new_group_msg_id:
-                    if previous_group_id in game.message_ids_to_delete:
-                        game.message_ids_to_delete.remove(previous_group_id)
-                    player.group_hand_message_id = new_group_msg_id
-                    if new_group_msg_id not in game.message_ids_to_delete:
-                        game.message_ids_to_delete.append(new_group_msg_id)
-
+            if not player.cards:
+                continue
+            await self._view.send_cards(
+                chat_id=chat_id,
+                cards=player.cards,
+                mention_markdown=player.mention_markdown,
+                table_cards=game.cards_table,
+                hide_hand_text=True,
+                stage=stage,
+                reply_to_ready_message=False,
+            )
             await asyncio.sleep(0.1)
 
         # پس از ارسال/ویرایش تصویر میز، پیام نوبت باید آخرین پیام باشد
@@ -1153,9 +1129,6 @@ class PokerBotModel:
                 )
 
         game.message_ids_to_delete.clear()
-
-        for player in game.players:
-            player.group_hand_message_id = None
 
     async def _showdown(
         self, game: Game, chat_id: ChatId, context: CallbackContext

--- a/tests/test_pokerbotmodel.py
+++ b/tests/test_pokerbotmodel.py
@@ -173,7 +173,7 @@ if __name__ == '__main__':
 
 def _build_model_with_game():
     view = MagicMock()
-    view.send_cards = AsyncMock(return_value="msg42")
+    view.send_cards = AsyncMock(return_value=None)
     view.send_message = AsyncMock()
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
@@ -205,8 +205,8 @@ def test_send_cards_to_user_uses_group_chat():
     asyncio.run(model.send_cards_to_user(update, context))
 
     assert view.send_cards.await_args.kwargs["chat_id"] == chat_id
-    assert player.group_hand_message_id == "msg42"
-    assert "msg42" in game.message_ids_to_delete
+    assert view.send_cards.await_args.kwargs["hide_hand_text"] is True
+    assert game.message_ids_to_delete == []
     view.send_message.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary
- update `PokerBotViewer.send_cards` so the hidden-hand branch only refreshes the reply keyboard via a temporary invisible message that is deleted immediately
- simplify player state by removing stored group hand message IDs and reworking card distribution/table update flows to keep the turn prompt as the last visible message
- refresh viewer/model unit tests to match the new behaviour and verify the hidden-hand workflow leaves no 🔒 text behind while still cleaning up temporary messages

## Testing
- PYTHONPATH=. pytest tests/test_pokerbotviewer.py tests/test_pokerbotmodel.py

------
https://chatgpt.com/codex/tasks/task_e_68cb232900a883289bf4ef59ba9fe802