### PR TITLE
Preserve private keyboard messages for hidden hands

### DIFF
--- a/tests/test_pokerbotmodel.py
+++ b/tests/test_pokerbotmodel.py
@@ -173,7 +173,7 @@ if __name__ == '__main__':
 
 def _build_model_with_game():
     view = MagicMock()
-    view.send_cards = AsyncMock(return_value=None)
+    view.send_cards = AsyncMock(return_value=900)
     view.send_message = AsyncMock()
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
@@ -206,7 +206,9 @@ def test_send_cards_to_user_uses_group_chat():
 
     assert view.send_cards.await_args.kwargs["chat_id"] == chat_id
     assert view.send_cards.await_args.kwargs["hide_hand_text"] is True
+    assert view.send_cards.await_args.kwargs["message_id"] is None
     assert game.message_ids_to_delete == []
+    assert game.message_ids[player.user_id] == 900
     view.send_message.assert_not_awaited()
 
 
@@ -226,8 +228,30 @@ def test_send_cards_to_user_reports_missing_player_in_group():
     assert view.send_message.await_args.args[0] == chat_id
 
 
+def test_send_cards_to_user_reuses_previous_keyboard_message():
+    model, game, player, view = _build_model_with_game()
+    chat_id = -300
+    model._get_game = AsyncMock(return_value=(game, chat_id))
+
+    update = MagicMock()
+    update.effective_user.id = player.user_id
+    update.effective_user.full_name = "Test User"
+    context = MagicMock()
+
+    view.send_cards.side_effect = [111, 222]
+
+    asyncio.run(model.send_cards_to_user(update, context))
+    assert game.message_ids[player.user_id] == 111
+
+    asyncio.run(model.send_cards_to_user(update, context))
+
+    assert view.send_cards.await_count == 2
+    assert view.send_cards.await_args_list[1].kwargs["message_id"] == 111
+    assert game.message_ids[player.user_id] == 222
+
+
 def test_add_cards_to_table_sends_plain_message_without_keyboard():
-    model, game, _, view = _build_model_with_game()
+    model, game, player, view = _build_model_with_game()
     chat_id = -300
     view.send_message_return_id = AsyncMock(return_value=101)
     view.delete_message = AsyncMock()
@@ -247,7 +271,9 @@ def test_add_cards_to_table_sends_plain_message_without_keyboard():
     cards_call = view.send_cards.await_args
     assert cards_call.kwargs["hide_hand_text"] is True
     assert cards_call.kwargs["table_cards"] == game.cards_table
+    assert cards_call.kwargs["message_id"] is None
 
     assert game.board_message_id == 101
     assert 101 in game.message_ids_to_delete
+    assert game.message_ids[player.user_id] == 900
     view.delete_message.assert_not_awaited()


### PR DESCRIPTION
## Summary
- keep hidden hand keyboards alive by editing existing messages or leaving zero-width placeholders instead of deleting them
- store per-player keyboard message ids in the model so subsequent updates reuse the same message and cleanup removes them
- update viewer and model tests to cover the new behaviour and message id tracking

## Testing
- PYTHONPATH=. pytest tests/test_pokerbotviewer.py tests/test_pokerbotmodel.py

------
https://chatgpt.com/codex/tasks/task_e_68cb2bed39908328a2e1ec6df065fab0