### PR TITLE
Reduce redundant Telegram requests when updating card messages

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -269,23 +269,15 @@ class PokerBotModel:
         Safely edit a message's text, retrying on rate limits and
         sending a new message if the original cannot be edited.
 
-        The method attempts to ensure the target message exists by
-        calling ``get_chat`` before editing. It handles ``BadRequest``
-        and ``RetryAfter`` errors by retrying or falling back to sending
-        a fresh message. The ID of the edited or newly sent message is
-        returned.
+        The method handles ``BadRequest`` and ``RetryAfter`` errors by
+        retrying or falling back to sending a fresh message. The ID of
+        the edited or newly sent message is returned.
         """
 
         if not message_id:
             return await self._view.send_message_return_id(
                 chat_id, text, reply_markup=reply_markup
             )
-
-        # Confirm chat availability; errors here are non-fatal.
-        try:
-            await self._bot.get_chat(chat_id)
-        except Exception:
-            pass
 
         try:
             result = await self._view.edit_message_text(

--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -713,6 +713,18 @@ class PokerBotViewer:
             f"🃎 میز: {table_text}"
         )
         message_text = f"{mention_markdown}\n{message_body}"
+
+        if message_id:
+            updated_id = await self.edit_message_text(
+                chat_id=chat_id,
+                message_id=message_id,
+                text=message_text,
+                reply_markup=markup,
+                parse_mode=ParseMode.MARKDOWN,
+            )
+            if updated_id:
+                return updated_id
+
         try:
             async def _send() -> Message:
                 reply_kwargs = {}
@@ -730,7 +742,7 @@ class PokerBotViewer:
             message = await self._rate_limiter.send(_send, chat_id=chat_id)
             new_message_id: Optional[MessageId] = getattr(message, "message_id", None)
 
-            if message_id:
+            if message_id and new_message_id and new_message_id != message_id:
                 try:
                     await self._rate_limiter.send(
                         lambda: self._bot.delete_message(


### PR DESCRIPTION
## Summary
- remove the pre-emptive get_chat lookup from safe edit operations to avoid an unnecessary Telegram request
- reuse in-place message editing when updating player card summaries so we no longer send a replacement message and delete the old one when edits succeed

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pokerapp')*

------
https://chatgpt.com/codex/tasks/task_e_68cb3ec428448328bdb980a67d056030