### PR TITLE
Revamp countdown flow and readiness messaging

### DIFF
--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -179,7 +179,10 @@ class PokerBotViewer:
         self._admin_chat_id = admin_chat_id
         # 0.1s base delay to allow faster message delivery while avoiding limits
         self._rate_limiter = RateLimitedSender(
-            delay=0.1, error_delay=0.1, notify_admin=self.notify_admin
+            delay=0.1,
+            error_delay=0.1,
+            notify_admin=self.notify_admin,
+            max_per_minute=60,
         )
 
     async def notify_admin(self, log_data: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- consolidate ready-message rendering through a single helper that keeps the countdown text and inline keyboard in sync
- update the auto-start ticker to edit the existing countdown message once per second and clear countdown state when the hand starts
- ensure the ready prompt is deleted on game start, adjust post-hand messaging order, and raise the per-chat send budget to support the faster cadence
- refresh countdown-focused unit tests and add coverage for the new showdown message ordering

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc2fefa54c8328a815f7989609ee17