### PR TITLE
Add Redis player index and restart lookup support

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -114,6 +114,11 @@ class PokerBotModel:
         try:
             return await self._table_manager.find_game_by_user(user_id)
         except LookupError as exc:
+            await self._view.send_message(
+                user_id,
+                "❌ هیچ بازی فعالی برای شما پیدا نشد. اگر بازی تازه راه‌اندازی شده،"
+                " دوباره تلاش کنید.",
+            )
             raise UserException("بازی‌ای برای توقف یافت نشد.") from exc
 
     @staticmethod

--- a/tests/test_table_manager.py
+++ b/tests/test_table_manager.py
@@ -77,5 +77,38 @@ async def test_find_game_by_user():
         await tm.find_game_by_user("user2")
 
 
+@pytest.mark.asyncio
+async def test_find_game_by_user_after_restart_loads_from_disk():
+    server = fakeredis.FakeServer()
+    redis_async = fakeredis.aioredis.FakeRedis(server=server)
+    redis_sync = fakeredis.FakeRedis(server=server)
+    tm = TableManager(redis_async, redis_sync)
+
+    chat = -100123
+    game = await tm.create_game(chat)
+    wallet = WalletManagerModel("user42", redis_sync)
+    player = Player(
+        user_id="user42",
+        mention_markdown="@u42",
+        wallet=wallet,
+        ready_message_id="ready",
+    )
+    game.add_player(player, seat_index=0)
+    game.pot = 77
+    await tm.save_game(chat, game)
+
+    # simulate application restart by creating a new TableManager instance
+    redis_async_new = fakeredis.aioredis.FakeRedis(server=server)
+    redis_sync_new = fakeredis.FakeRedis(server=server)
+    tm_restarted = TableManager(redis_async_new, redis_sync_new)
+
+    loaded_game, loaded_chat = await tm_restarted.find_game_by_user("user42")
+
+    assert loaded_chat == chat
+    assert loaded_game.pot == 77
+    assert loaded_game.seats[0].user_id == "user42"
+    assert tm_restarted._tables[loaded_chat] is loaded_game
+
+
 def test_game_pickle():
     pickle.dumps(Game())


### PR DESCRIPTION
## Summary
- maintain a Redis-backed player-to-chat index whenever games are saved to keep mappings stable across restarts
- load games from Redis on demand in `find_game_by_user` when the in-memory cache is empty
- notify users when no active game is associated with them and add restart coverage to the table manager tests

## Testing
- PYTHONPATH=. pytest tests/test_table_manager.py *(fails: async tests require pytest-asyncio plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4df77af0832897442f4cca4c3b94