### PR TITLE
Add reply keyboard to new hand ready message

### DIFF
--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -1179,6 +1179,12 @@ class PokerBotViewer:
             "♻️ دست به پایان رسید. بازیکنان باقی‌مانده برای دست بعد حفظ شدند.\n"
             "برای شروع دست جدید، /start را بزنید یا بازیکنان جدید می‌توانند با دکمهٔ «نشستن سر میز» وارد شوند."
         )
+        reply_keyboard = ReplyKeyboardMarkup(
+            keyboard=[["/start", "نشستن سر میز"], ["/stop"]],
+            resize_keyboard=True,
+            one_time_keyboard=False,
+            selective=False,
+        )
         try:
             await self._rate_limiter.send(
                 lambda: self._bot.send_message(
@@ -1187,6 +1193,7 @@ class PokerBotViewer:
                     parse_mode=ParseMode.MARKDOWN,
                     disable_notification=True,
                     disable_web_page_preview=True,
+                    reply_markup=reply_keyboard,
                 ),
                 chat_id=chat_id,
             )


### PR DESCRIPTION
## Summary
- add a reply keyboard with start/stop/sit actions to the post-hand notification
- cover the new keyboard with a unit test in `tests/test_pokerbotviewer.py`

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cc59f395f08328bb0f81222adc462a