### PR TITLE
Convert wallet handling to async redis

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 import enum
 import datetime
 from typing import Tuple, List, Optional
@@ -18,40 +18,49 @@ Mention = str
 Score = int
 Money = int
 
-@abstractmethod
-class Wallet:
+class Wallet(ABC):
     @staticmethod
     def _prefix(id: int, suffix: str = ""):
         pass
 
-    def add_daily(self, amount: Money) -> Money:
+    @abstractmethod
+    async def add_daily(self, amount: Money) -> Money:
         pass
 
-    def has_daily_bonus(self) -> bool:
+    @abstractmethod
+    async def has_daily_bonus(self) -> bool:
         pass
 
-    def inc(self, amount: Money = 0) -> None:
+    @abstractmethod
+    async def inc(self, amount: Money = 0) -> Money:
         pass
 
-    def inc_authorized_money(self, game_id: str, amount: Money) -> None:
+    @abstractmethod
+    async def inc_authorized_money(self, game_id: str, amount: Money) -> None:
         pass
 
-    def authorized_money(self, game_id: str) -> Money:
+    @abstractmethod
+    async def authorized_money(self, game_id: str) -> Money:
         pass
 
-    def authorize(self, game_id: str, amount: Money) -> None:
+    @abstractmethod
+    async def authorize(self, game_id: str, amount: Money) -> None:
         pass
 
-    def authorize_all(self, game_id: str) -> Money:
+    @abstractmethod
+    async def authorize_all(self, game_id: str) -> Money:
         pass
 
-    def value(self) -> Money:
+    @abstractmethod
+    async def value(self) -> Money:
         pass
 
-    def approve(self, game_id: str) -> None:
+    @abstractmethod
+    async def approve(self, game_id: str) -> None:
         pass
 
-    def cancel(self, game_id: str) -> None:
+    @abstractmethod
+    async def cancel(self, game_id: str) -> None:
         pass
 
 class Player:

--- a/pokerapp/table_manager.py
+++ b/pokerapp/table_manager.py
@@ -1,7 +1,6 @@
 import pickle
 from typing import Dict, Optional
 
-import redis
 import redis.asyncio as aioredis
 
 from pokerapp.entities import Game, ChatId
@@ -10,9 +9,9 @@ from pokerapp.entities import Game, ChatId
 class TableManager:
     """Manage a single poker game per chat and persist it in Redis."""
 
-    def __init__(self, redis: aioredis.Redis, wallet_redis: Optional[redis.Redis] = None):
+    def __init__(self, redis: aioredis.Redis, wallet_redis: Optional[aioredis.Redis] = None):
         self._redis = redis
-        self._wallet_redis = wallet_redis
+        self._wallet_redis = wallet_redis or redis
         # Keep games cached in memory keyed only by chat_id
         self._tables: Dict[ChatId, Game] = {}
 
@@ -47,6 +46,7 @@ class TableManager:
             game = pickle.loads(data)
             if self._wallet_redis is not None:
                 from pokerapp.pokerbotmodel import WalletManagerModel
+
                 for player in game.players:
                     info = getattr(player, "_wallet_info", {"user_id": player.user_id})
                     player.wallet = WalletManagerModel(info["user_id"], self._wallet_redis)

--- a/tests/test_wallet_manager_model.py
+++ b/tests/test_wallet_manager_model.py
@@ -1,25 +1,25 @@
 #!/usr/bin/env python3
 
-import unittest
-import fakeredis
+import pytest
+import fakeredis.aioredis
 
 from pokerapp.pokerbotmodel import WalletManagerModel
 
 
-class TestWalletManagerModel(unittest.TestCase):
-    def test_dec_without_lupa(self):
-        kv = fakeredis.FakeRedis()
-        wallet = WalletManagerModel("user", kv)
-        start = wallet.value()
+@pytest.mark.asyncio
+async def test_dec_without_lupa():
+    kv = fakeredis.aioredis.FakeRedis()
+    wallet = WalletManagerModel("user", kv)
+    start = await wallet.value()
 
-        def raise_module_not_found(*args, **kwargs):
-            raise ModuleNotFoundError("lupa")
+    async def raise_module_not_found(*args, **kwargs):
+        raise ModuleNotFoundError("lupa")
 
-        wallet._LUA_DECR_IF_GE = raise_module_not_found
-        result = wallet.dec(100)
-        self.assertEqual(start - 100, result)
-        self.assertEqual(start - 100, wallet.value())
+    wallet._LUA_DECR_IF_GE = raise_module_not_found
+    result = await wallet.dec(100)
+    assert start - 100 == result
+    assert start - 100 == await wallet.value()
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest.main()


### PR DESCRIPTION
## Summary
- convert the wallet abstraction and manager to async redis-based operations
- update the table manager and bot to wire async redis clients into player wallets
- adjust wallet call sites and tests to await async wallets using fakeredis async fixtures

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc6db72b848328a0701480215cd07c