### PR TITLE
Adjust rate limiter pre-dispatch timing

### DIFF
--- a/pokerapp/pokerbot.py
+++ b/pokerapp/pokerbot.py
@@ -81,6 +81,7 @@ class PokerBot:
             bot=self._application.bot,
             admin_chat_id=cfg.ADMIN_CHAT_ID,
             rate_limit_per_minute=cfg.RATE_LIMIT_PER_MINUTE,
+            rate_limit_per_second=cfg.RATE_LIMIT_PER_SECOND,
         )
         model = PokerBotModel(
             view=view,

--- a/tests/test_rate_limited_sender.py
+++ b/tests/test_rate_limited_sender.py
@@ -38,7 +38,7 @@ def test_rate_limited_sender_uses_explicit_delay():
 async def test_rate_limited_sender_waits_longer_for_low_tokens(monkeypatch):
     sender = RateLimitedSender(delay=0.2, max_per_minute=30)
 
-    permit = RateLimitedSender._TokenPermit(remaining=0.5, delay=1.1)
+    permit = RateLimitedSender._TokenPermit(remaining=0.5, wait_before=1.1)
     sender._wait_for_token = AsyncMock(return_value=permit)
 
     sleep_calls = []
@@ -55,7 +55,7 @@ async def test_rate_limited_sender_waits_longer_for_low_tokens(monkeypatch):
 
     assert result == "ok"
     assert permit.remaining == pytest.approx(0.5)
-    assert sleep_calls[-1] == pytest.approx(1.1)
+    assert sleep_calls == [pytest.approx(1.1)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- move the per-chat cooldown in `RateLimitedSender` ahead of dispatch so `_auto_start_tick` does not sleep after edits
- add coverage ensuring `_auto_start_tick` completes without rate-limiter tail sleeps and update the sender tests for the new permit shape
- allow configuring the per-second limit for `PokerBotViewer` via the config object

## Testing
- `PYTHONPATH=. pytest tests/test_rate_limited_sender.py tests/test_pokerbotmodel.py`


------
https://chatgpt.com/codex/tasks/task_e_68cc7f8f1e948328a4637c0331a6cbcb