### PR TITLE
Add default SQLite stats backend with migrations and tests

### DIFF
--- a/pokerapp/pokerbot.py
+++ b/pokerapp/pokerbot.py
@@ -70,10 +70,15 @@ class PokerBot:
 
         table_manager = TableManager(kv_async)
         if cfg.DATABASE_URL:
-            stats_service = StatsService(
-                cfg.DATABASE_URL,
-                echo=getattr(cfg, "DATABASE_ECHO", False),
-            )
+            try:
+                stats_service = StatsService(
+                    cfg.DATABASE_URL,
+                    echo=getattr(cfg, "DATABASE_ECHO", False),
+                )
+                stats_service.ensure_ready_blocking()
+            except Exception:
+                logger.exception("Failed to initialize statistics service; using null backend.")
+                stats_service = NullStatsService()
         else:
             stats_service = NullStatsService()
         self._stats_service = stats_service

--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -205,7 +205,9 @@ class PokerBotModel:
             return
 
         report = await self._stats.build_player_report(self._safe_int(user.id))
-        if report is None:
+        if report is None or (
+            report.stats.total_games <= 0 and not report.recent_games
+        ):
             await self._view.send_message(
                 chat.id,
                 "ℹ️ هنوز داده‌ای برای نمایش وجود ندارد. پس از شرکت در چند دست بازی دوباره تلاش کنید.",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 python-telegram-bot[job-queue,webhooks]>=20
 SQLAlchemy[asyncio]>=2.0
 asyncpg>=0.27
+aiosqlite>=0.20
 flake8==4.0.1
 pillow==10.4.0
 PySocks==1.7.1

--- a/tests/test_statistics_integration.py
+++ b/tests/test_statistics_integration.py
@@ -1,0 +1,172 @@
+import datetime as dt
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import fakeredis.aioredis
+import pytest
+
+from pokerapp.pokerbotmodel import PokerBotModel
+from pokerapp.stats import PlayerHandResult, PlayerIdentity, StatsService
+
+
+def _build_model(stats_service: StatsService):
+    view = SimpleNamespace(send_message=AsyncMock())
+    bot = SimpleNamespace()
+    cfg = SimpleNamespace(DEBUG=False)
+    kv = fakeredis.aioredis.FakeRedis()
+    table_manager = MagicMock()
+    model = PokerBotModel(
+        view,
+        bot,
+        cfg,
+        kv,
+        table_manager,
+        stats_service=stats_service,
+    )
+    return model, view
+
+
+def _make_update(user_id: int, chat_id: int, username: str = "player") -> SimpleNamespace:
+    chat = SimpleNamespace(id=chat_id, type="private", PRIVATE="private")
+    user = SimpleNamespace(
+        id=user_id,
+        full_name=f"{username} tester",
+        first_name=username,
+        username=username,
+    )
+    return SimpleNamespace(effective_chat=chat, effective_user=user)
+
+
+@pytest.mark.asyncio
+async def test_statistics_command_formats_report(tmp_path):
+    db_path = tmp_path / "stats.sqlite3"
+    service = StatsService(f"sqlite+aiosqlite:///{db_path}")
+    await service.ensure_ready()
+
+    try:
+        model, view = _build_model(service)
+        identity = PlayerIdentity(
+            user_id=42,
+            display_name="علی قهرمان",
+            username="ali",
+        )
+
+        base_time = dt.datetime(2024, 1, 1, 12, 0, tzinfo=dt.timezone.utc)
+
+        await service.start_hand(
+            "hand-1",
+            chat_id=777,
+            players=[identity],
+            start_time=base_time,
+        )
+        await service.finish_hand(
+            "hand-1",
+            chat_id=777,
+            results=[
+                PlayerHandResult(
+                    user_id=identity.user_id,
+                    display_name=identity.display_name,
+                    total_bet=50,
+                    payout=200,
+                    net_profit=150,
+                    hand_type="رویال فلاش",
+                    was_all_in=True,
+                    result="win",
+                )
+            ],
+            pot_total=200,
+            end_time=base_time + dt.timedelta(minutes=2),
+        )
+
+        await service.start_hand(
+            "hand-2",
+            chat_id=777,
+            players=[identity],
+            start_time=base_time + dt.timedelta(minutes=3),
+        )
+        await service.finish_hand(
+            "hand-2",
+            chat_id=777,
+            results=[
+                PlayerHandResult(
+                    user_id=identity.user_id,
+                    display_name=identity.display_name,
+                    total_bet=60,
+                    payout=120,
+                    net_profit=60,
+                    hand_type="فول هاوس",
+                    was_all_in=False,
+                    result="win",
+                )
+            ],
+            pot_total=120,
+            end_time=base_time + dt.timedelta(minutes=5),
+        )
+
+        await service.start_hand(
+            "hand-3",
+            chat_id=777,
+            players=[identity],
+            start_time=base_time + dt.timedelta(minutes=6),
+        )
+        await service.finish_hand(
+            "hand-3",
+            chat_id=777,
+            results=[
+                PlayerHandResult(
+                    user_id=identity.user_id,
+                    display_name=identity.display_name,
+                    total_bet=40,
+                    payout=0,
+                    net_profit=-40,
+                    hand_type="استریت",
+                    was_all_in=False,
+                    result="loss",
+                )
+            ],
+            pot_total=80,
+            end_time=base_time + dt.timedelta(minutes=7),
+        )
+
+        update = _make_update(identity.user_id, 999, username="ali")
+        context = SimpleNamespace()
+
+        await model._send_statistics_report(update, context)
+
+        assert view.send_message.await_count == 1
+        args, kwargs = view.send_message.await_args
+        message = args[1]
+
+        assert "🎮 مجموع دست‌ها: 3" in message
+        assert "🏆 بردها: 2 | ❌ باخت‌ها: 1" in message
+        assert "🔥 طولانی‌ترین برد متوالی: 2 دست" in message
+        assert "💎 بزرگ‌ترین برد: 150$" in message
+        assert "⚔️ دفعات آل-این: 1 (موفقیت 100.0٪)" in message
+        assert "📐 بازده سرمایه (ROI): 700.0%" in message
+        assert "🥇 پراکندگی دست‌های برنده:" in message
+        assert "رویال فلاش" in message
+        assert "📝 پنج دست اخیر:" in message
+        assert kwargs.get("reply_markup") is not None
+    finally:
+        await service.close()
+
+
+@pytest.mark.asyncio
+async def test_statistics_command_without_history(tmp_path):
+    db_path = tmp_path / "empty.sqlite3"
+    service = StatsService(f"sqlite+aiosqlite:///{db_path}")
+    await service.ensure_ready()
+
+    try:
+        model, view = _build_model(service)
+        update = _make_update(99, 555, username="new")
+        context = SimpleNamespace()
+
+        await model._send_statistics_report(update, context)
+
+        assert view.send_message.await_count == 1
+        args, _kwargs = view.send_message.await_args
+        message = args[1]
+        assert "ℹ️ هنوز داده‌ای برای نمایش وجود ندارد" in message
+    finally:
+        await service.close()


### PR DESCRIPTION
## Summary
- default the bot configuration to a bundled SQLite database when no external DSN is provided
- initialize the statistics service at startup, running migrations and producing the rich report text
- add integration tests for the statistics command and include aiosqlite in dependencies

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd3e156c1c8328bc713563616af250