### PR TITLE
Compute pot total for private match stats

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -595,8 +595,10 @@ class PokerBotModel:
                 )
             )
 
+        pot_total = sum(result.payout for result in results)
+
         if self._stats_enabled():
-            await self._stats.finish_hand(match_id, chat_id, results)
+            await self._stats.finish_hand(match_id, chat_id, results, pot_total)
 
         game.state = GameState.FINISHED
         await self._table_manager.save_game(chat_id, game)

--- a/tests/test_private_matchmaking.py
+++ b/tests/test_private_matchmaking.py
@@ -150,6 +150,9 @@ async def test_private_matchmaking_reports_results_updates_stats():
     assert stats.finish_hand.await_count == 1
     finish_call = stats.finish_hand.await_args
     assert finish_call.args[0] == match_id
+    results = finish_call.args[2]
+    expected_pot_total = sum(result.payout for result in results)
+    assert finish_call.args[3] == expected_pot_total == 1
     messages = [call.args[1] for call in view.send_message.await_args_list]
     assert any("برنده" in message for message in messages)
 


### PR DESCRIPTION
## Summary
- compute the private match pot total when assembling results
- pass the calculated pot total to the stats service when recording the finished hand
- extend private matchmaking tests to assert the stats call includes the expected pot size

## Testing
- PYTHONPATH=. pytest tests/test_private_matchmaking.py

------
https://chatgpt.com/codex/tasks/task_e_68cd4be771dc83288a181761feb11652