### PR TITLE
Escape markdown in private matches and stats

### DIFF
--- a/pokerapp/stats/service.py
+++ b/pokerapp/stats/service.py
@@ -29,6 +29,8 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy.pool import StaticPool
 
+from pokerapp.utils.markdown import escape_markdown_v1
+
 
 logger = logging.getLogger(__name__)
 
@@ -844,7 +846,8 @@ class StatsService(BaseStatsService):
         lines: List[str] = []
         lines.append("📊 گزارش پیشرفته عملکرد شما")
         if stats.display_name:
-            lines.append(f"👤 نام: {stats.display_name}")
+            safe_display_name = escape_markdown_v1(stats.display_name)
+            lines.append(f"👤 نام: {safe_display_name}")
         if stats.username:
             lines.append(f"🔖 نام کاربری: @{stats.username}")
         lines.append(f"🎮 مجموع دست‌ها: {self._format_number(total_games)}")

--- a/pokerapp/utils/__init__.py
+++ b/pokerapp/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for the poker application."""
+
+from .markdown import escape_markdown_v1
+
+__all__ = ["escape_markdown_v1"]

--- a/pokerapp/utils/markdown.py
+++ b/pokerapp/utils/markdown.py
@@ -1,0 +1,17 @@
+"""Helpers for working with Telegram Markdown v1."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from telegram.helpers import escape_markdown as _escape_markdown
+
+
+def escape_markdown_v1(text: Optional[str]) -> str:
+    """Return ``text`` escaped for Telegram Markdown v1 messages."""
+    if text is None:
+        return ""
+    return _escape_markdown(text, version=1)
+
+
+__all__ = ["escape_markdown_v1"]


### PR DESCRIPTION
## Summary
- add a markdown utility helper that wraps Telegram's v1 escaping
- escape player names in private match notifications and statistics reports
- extend private match and stats tests to ensure tricky display names no longer cause BadRequest errors

## Testing
- PYTHONPATH=. pytest tests/test_private_matchmaking.py tests/test_statistics_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68cd54390a0c832896c2a3e18038d9c9