### PR TITLE
Enable in-place turn message edits

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -1827,9 +1827,16 @@ class PokerBotModel:
 
             previous_message_id = game.turn_message_id
 
-            new_message_id = await self._view.send_turn_actions(
-                chat_id, game, player, money, recent_actions=recent_actions
+            turn_result = await self._view.send_turn_actions(
+                chat_id,
+                game,
+                player,
+                money,
+                message_id=previous_message_id,
+                recent_actions=recent_actions,
             )
+
+            new_message_id = turn_result.message_id if turn_result else None
 
             if new_message_id:
                 if (
@@ -1847,6 +1854,14 @@ class PokerBotModel:
                                 "error_type": type(e).__name__,
                             },
                         )
+                elif previous_message_id and turn_result:
+                    await self._view.remember_text_payload(
+                        chat_id=chat_id,
+                        message_id=new_message_id,
+                        text=turn_result.text,
+                        reply_markup=turn_result.reply_markup,
+                        parse_mode=turn_result.parse_mode,
+                    )
                 game.turn_message_id = new_message_id
 
             game.last_turn_time = datetime.datetime.now()
@@ -2021,6 +2036,9 @@ class PokerBotModel:
         4. پخش کردن کارت‌های جدید روی میز (فلاپ، ترن، ریور).
         5. پیدا کردن اولین بازیکن فعال برای شروع دور شرط‌بندی جدید.
         6. اگر فقط یک بازیکن باقی مانده باشد، او را برنده اعلام می‌کند.
+        7. با اتکا به ویرایش پیام‌های قبلی، بودجهٔ ۱۰ درخواستی تلگرام
+           (P ویرایش بازیکنان + یک ویرایش کارت‌های میز + یک ویرایش نوبت)
+           حفظ می‌شود و نیازی به ارسال/حذف پیام جدید نیست.
         """
         async with self._chat_guard(chat_id):
             # پیام‌های نوبت قبلی را حذف نمی‌کنیم
@@ -2609,15 +2627,15 @@ class RoundRateModel:
                 await self._model._send_turn_message(game, player_turn, chat_id)
             else:
                 player_money = await player_turn.wallet.value()
-                msg_id = await self._view.send_turn_actions(
+                turn_result = await self._view.send_turn_actions(
                     chat_id=chat_id,
                     game=game,
                     player=player_turn,
                     money=player_money,
                     recent_actions=game.last_actions,
                 )
-                if msg_id:
-                    game.turn_message_id = msg_id
+                if turn_result and turn_result.message_id:
+                    game.turn_message_id = turn_result.message_id
 
     async def _set_player_blind(
         self,

--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -323,6 +323,16 @@ class ChatUpdateQueue:
         state.new_item.set()
 
 
+@dataclass(slots=True)
+class TurnActionsResult:
+    """Result payload for a turn action update."""
+
+    message_id: Optional[MessageId]
+    text: Optional[str]
+    reply_markup: Optional[InlineKeyboardMarkup | ReplyKeyboardMarkup]
+    parse_mode: Optional[str]
+
+
 class PokerBotViewer:
     _ZERO_WIDTH_SPACE = "\u2063"
 
@@ -1146,7 +1156,7 @@ class PokerBotViewer:
         money: Money,
         message_id: Optional[MessageId] = None,
         recent_actions: Optional[List[str]] = None,
-    ) -> Optional[MessageId]:
+    ) -> Optional[TurnActionsResult]:
         """ارسال یا ویرایش پیام نوبت بازیکن با نمایش اکشن‌های اخیر."""
 
         # نمایش کارت‌های میز
@@ -1199,7 +1209,19 @@ class PokerBotViewer:
                 chat_id, message_id, normalized_text, markup
             )
             if edited_id:
-                return edited_id
+                await self.remember_text_payload(
+                    chat_id=chat_id,
+                    message_id=edited_id,
+                    text=normalized_text,
+                    reply_markup=markup,
+                    parse_mode=ParseMode.MARKDOWN,
+                )
+                return TurnActionsResult(
+                    message_id=edited_id,
+                    text=normalized_text,
+                    reply_markup=markup,
+                    parse_mode=ParseMode.MARKDOWN,
+                )
             # پیام اصلی دیگر قابل ویرایش نیست، پیام جدید ارسال می‌کنیم
 
         try:
@@ -1230,7 +1252,12 @@ class PokerBotViewer:
                                 "message_id": message_id,
                             },
                         )
-                return new_message_id
+                return TurnActionsResult(
+                    message_id=new_message_id,
+                    text=normalized_text,
+                    reply_markup=markup,
+                    parse_mode=ParseMode.MARKDOWN,
+                )
         except Exception as e:
             logger.error(
                 "Error sending turn actions",

--- a/tests/test_pokerbotmodel.py
+++ b/tests/test_pokerbotmodel.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import datetime
+import sys
+import types
 import unittest
 from types import SimpleNamespace
 from typing import List, Tuple, Optional
@@ -10,6 +12,31 @@ from unittest.mock import AsyncMock, MagicMock
 import fakeredis
 import fakeredis.aioredis
 import pytest
+
+
+def _install_aiogram_stub() -> None:
+    if "aiogram" in sys.modules:
+        return
+    aiogram_module = types.ModuleType("aiogram")
+    dispatcher_module = types.ModuleType("aiogram.dispatcher")
+    middlewares_module = types.ModuleType("aiogram.dispatcher.middlewares")
+    base_module = types.ModuleType("aiogram.dispatcher.middlewares.base")
+
+    class _BaseMiddleware:  # minimal stub for tests
+        pass
+
+    base_module.BaseMiddleware = _BaseMiddleware
+    middlewares_module.base = base_module
+    dispatcher_module.middlewares = middlewares_module
+    aiogram_module.dispatcher = dispatcher_module
+
+    sys.modules["aiogram"] = aiogram_module
+    sys.modules["aiogram.dispatcher"] = dispatcher_module
+    sys.modules["aiogram.dispatcher.middlewares"] = middlewares_module
+    sys.modules["aiogram.dispatcher.middlewares.base"] = base_module
+
+
+_install_aiogram_stub()
 
 from pokerapp.cards import Cards, Card
 from pokerapp.config import Config
@@ -27,6 +54,7 @@ from pokerapp.pokerbotmodel import (
 )
 from telegram.error import BadRequest
 from telegram import InlineKeyboardMarkup
+from telegram.constants import ParseMode
 
 
 HANDS_FILE = "./tests/hands.txt"
@@ -198,6 +226,7 @@ def _build_model_with_game():
     view = MagicMock()
     view.send_cards = AsyncMock(return_value=None)
     view.send_message = AsyncMock()
+    view.remember_text_payload = AsyncMock()
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
     kv = MagicMock()
@@ -910,7 +939,14 @@ def test_send_turn_message_replaces_previous_message():
     game.turn_message_id = 111
     game.last_actions = ["action"]
 
-    view.send_turn_actions = AsyncMock(return_value=222)
+    view.send_turn_actions = AsyncMock(
+        return_value=SimpleNamespace(
+            message_id=222,
+            text="payload",
+            reply_markup=None,
+            parse_mode=ParseMode.MARKDOWN,
+        )
+    )
     view.delete_message = AsyncMock()
 
     asyncio.run(model._send_turn_message(game, player, chat_id))
@@ -919,6 +955,7 @@ def test_send_turn_message_replaces_previous_message():
     call = view.send_turn_actions.await_args
     assert call.args == (chat_id, game, player, 450)
     assert call.kwargs["recent_actions"] == game.last_actions
+    assert call.kwargs["message_id"] == 111
 
     view.delete_message.assert_awaited_once_with(chat_id, 111)
     assert game.turn_message_id == 222
@@ -939,3 +976,39 @@ def test_send_turn_message_keeps_previous_when_new_message_missing():
     view.send_turn_actions.assert_awaited_once()
     view.delete_message.assert_not_awaited()
     assert game.turn_message_id == 333
+
+
+def test_send_turn_message_edits_in_place():
+    model, game, player, view = _build_model_with_game()
+    chat_id = -603
+    player.wallet.value.return_value = 500
+    game.turn_message_id = 444
+    game.last_actions = ["raise"]
+
+    markup = InlineKeyboardMarkup([])
+    view.delete_message = AsyncMock()
+    view.edit_turn_actions = AsyncMock(return_value=444)
+
+    async def fake_send_turn_actions(*args, **kwargs):
+        assert kwargs["message_id"] == 444
+        await view.edit_turn_actions(chat_id, 444, "new text", markup)
+        return SimpleNamespace(
+            message_id=444,
+            text="new text",
+            reply_markup=markup,
+            parse_mode=ParseMode.MARKDOWN,
+        )
+
+    view.send_turn_actions = AsyncMock(side_effect=fake_send_turn_actions)
+
+    asyncio.run(model._send_turn_message(game, player, chat_id))
+
+    view.edit_turn_actions.assert_awaited_once()
+    view.delete_message.assert_not_awaited()
+    view.remember_text_payload.assert_awaited_once_with(
+        chat_id=chat_id,
+        message_id=444,
+        text="new text",
+        reply_markup=markup,
+        parse_mode=ParseMode.MARKDOWN,
+    )


### PR DESCRIPTION
## Summary
- allow `_send_turn_message` to pass the current turn message id so the viewer can edit in place and keep the cached payload when edits succeed
- return structured metadata from `PokerBotViewer.send_turn_actions` and update the method to record payloads after edits while leaving existing chat messages intact
- extend the pokerbot model tests with an aiogram stub and a new scenario that verifies the edit path skips deletions and records the edited payload
- document that street transitions now stay within the 10-request budget by relying on edits instead of re-sends

## Testing
- `PYTHONPATH=. pytest tests/test_pokerbotmodel.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68cd72e6b3bc83289c0626cbc0a9d105