### PR TITLE
Implement request budgeting and caching for poker bot

### DIFF
--- a/pokerapp/utils/request_tracker.py
+++ b/pokerapp/utils/request_tracker.py
@@ -1,0 +1,178 @@
+import asyncio
+import datetime as _dt
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RequestStats:
+    """Simple counter bucket for tracked Telegram API calls."""
+
+    turn: int = 0
+    stage: int = 0
+    inline: int = 0
+    countdown: int = 0
+
+    def total(self) -> int:
+        return self.turn + self.stage + self.inline + self.countdown
+
+    def increment(self, category: str) -> None:
+        if category == "turn":
+            self.turn += 1
+        elif category == "stage":
+            self.stage += 1
+        elif category == "inline":
+            self.inline += 1
+        elif category == "countdown":
+            self.countdown += 1
+        else:
+            raise ValueError(f"Unknown request category: {category}")
+
+    def decrement(self, category: str) -> None:
+        if category == "turn":
+            self.turn = max(self.turn - 1, 0)
+        elif category == "stage":
+            self.stage = max(self.stage - 1, 0)
+        elif category == "inline":
+            self.inline = max(self.inline - 1, 0)
+        elif category == "countdown":
+            self.countdown = max(self.countdown - 1, 0)
+        else:
+            raise ValueError(f"Unknown request category: {category}")
+
+    def as_dict(self) -> Dict[str, int]:
+        return {
+            "turn": self.turn,
+            "stage": self.stage,
+            "inline": self.inline,
+            "countdown": self.countdown,
+            "total": self.total(),
+        }
+
+
+class RequestTracker:
+    """Concurrency-safe accounting for message-related Telegram requests.
+
+    A shared ``RequestTracker`` instance is responsible for ensuring that the
+    sequence of calls tied to a single poker hand stays within a predefined
+    budget.  Each tracked call category (turn prompts, street transitions,
+    inline keyboard refreshes, and countdown updates) increments a counter. If
+    the cumulative total for a ``(chat_id, round_id)`` pair would exceed the
+    configured limit, ``try_consume`` refuses the reservation and callers must
+    skip the Telegram request.
+    """
+
+    def __init__(self, *, limit: int = 10) -> None:
+        self._limit = limit
+        self._lock = asyncio.Lock()
+        self._stats: Dict[Tuple[int, str], RequestStats] = {}
+        self._history: Dict[Tuple[int, str], list] = {}
+
+    @staticmethod
+    def _key(chat_id: int, round_id: str) -> Tuple[int, str]:
+        return int(chat_id), round_id
+
+    async def try_consume(self, chat_id: int, round_id: Optional[str], category: str) -> bool:
+        """Attempt to reserve room in the per-round budget.
+
+        Returns ``True`` when the request is accounted for, ``False`` when the
+        limit would be exceeded.  When ``round_id`` is missing, the operation is
+        treated as untracked and always allowed.
+        """
+
+        if not round_id:
+            return True
+        key = self._key(chat_id, round_id)
+        async with self._lock:
+            stats = self._stats.setdefault(key, RequestStats())
+            if stats.total() >= self._limit:
+                logger.info(
+                    "Request budget exhausted",
+                    extra={
+                        "chat_id": chat_id,
+                        "round_id": round_id,
+                        "category": category,
+                        "limit": self._limit,
+                        "stats": stats.as_dict(),
+                    },
+                )
+                return False
+            stats.increment(category)
+            self._history.setdefault(key, []).append(
+                {
+                    "ts": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+                    "category": category,
+                    "stats": stats.as_dict(),
+                }
+            )
+            logger.debug(
+                "Recorded Telegram request",
+                extra={
+                    "chat_id": chat_id,
+                    "round_id": round_id,
+                    "category": category,
+                    "stats": stats.as_dict(),
+                },
+            )
+            return True
+
+    async def release(self, chat_id: int, round_id: Optional[str], category: str) -> None:
+        """Undo a previously reserved request when no API call was made."""
+
+        if not round_id:
+            return
+        key = self._key(chat_id, round_id)
+        async with self._lock:
+            stats = self._stats.get(key)
+            if not stats:
+                return
+            stats.decrement(category)
+            logger.debug(
+                "Released Telegram request reservation",
+                extra={
+                    "chat_id": chat_id,
+                    "round_id": round_id,
+                    "category": category,
+                    "stats": stats.as_dict(),
+                },
+            )
+
+    async def snapshot(self, chat_id: int, round_id: Optional[str]) -> RequestStats:
+        """Return a copy of the current statistics for inspection."""
+
+        if not round_id:
+            return RequestStats()
+        key = self._key(chat_id, round_id)
+        async with self._lock:
+            stats = self._stats.get(key)
+            if not stats:
+                return RequestStats()
+            return RequestStats(
+                turn=stats.turn,
+                stage=stats.stage,
+                inline=stats.inline,
+                countdown=stats.countdown,
+            )
+
+    async def reset(self, chat_id: int, round_id: Optional[str]) -> None:
+        if not round_id:
+            return
+        key = self._key(chat_id, round_id)
+        async with self._lock:
+            self._stats.pop(key, None)
+            self._history.pop(key, None)
+
+    async def history(self, chat_id: int, round_id: Optional[str]) -> list:
+        if not round_id:
+            return []
+        key = self._key(chat_id, round_id)
+        async with self._lock:
+            return list(self._history.get(key, []))
+
+    @property
+    def limit(self) -> int:
+        return self._limit

--- a/tests/test_end_hand_persistence.py
+++ b/tests/test_end_hand_persistence.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 from pokerapp.config import Config
 from pokerapp.table_manager import TableManager
 from pokerapp.pokerbotmodel import PokerBotModel, KEY_CHAT_DATA_GAME
+from pokerapp.utils.request_tracker import RequestTracker
 
 
 @pytest.mark.asyncio
@@ -20,6 +21,9 @@ async def test_end_hand_persists_game_and_reuses_instance():
     view = SimpleNamespace(
         send_message=AsyncMock(),
         send_message_return_id=AsyncMock(return_value=1),
+        request_tracker=RequestTracker(),
+        reset_round_context=AsyncMock(),
+        set_round_context=MagicMock(),
     )
     model = PokerBotModel(view, bot, Config(), redis_sync, table_manager)
 

--- a/tests/test_statistics_integration.py
+++ b/tests/test_statistics_integration.py
@@ -1,6 +1,7 @@
 import datetime as dt
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
+from types import SimpleNamespace
 
 import fakeredis.aioredis
 import pytest
@@ -8,6 +9,7 @@ from telegram.error import BadRequest
 
 from pokerapp.pokerbotmodel import PokerBotModel
 from pokerapp.stats import PlayerHandResult, PlayerIdentity, StatsService
+from pokerapp.utils.request_tracker import RequestTracker
 
 
 def _build_model(stats_service: StatsService):
@@ -19,7 +21,12 @@ def _build_model(stats_service: StatsService):
         return None
 
     send_message.side_effect = safe_send_message
-    view = SimpleNamespace(send_message=send_message)
+    view = SimpleNamespace(
+        send_message=send_message,
+        request_tracker=RequestTracker(),
+        reset_round_context=AsyncMock(),
+        set_round_context=MagicMock(),
+    )
     bot = SimpleNamespace()
     cfg = SimpleNamespace(DEBUG=False)
     kv = fakeredis.aioredis.FakeRedis()


### PR DESCRIPTION
## Summary
- add a concurrency-safe request tracker that enforces the 10-call round budget and exposes diagnostics
- refactor viewer/model flows to use cachetools caches with locks for turn prompts, countdowns, and inline keyboards
- expand the test suite and performance report to validate budgeting behaviour and document the optimizations

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd7538039083288d7b6c5a1c8afd18