### PR TITLE
Fix inline markup cache size calculation

### DIFF
--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -404,7 +404,7 @@ class PokerBotViewer:
         )
         self._turn_cache_lock = asyncio.Lock()
         self._inline_markup_cache: FIFOCache[Tuple[str, str], _InlineMarkupEntry] = FIFOCache(
-            maxsize=64, getsizeof=lambda entry: len(entry.markup_hash)
+            maxsize=64, getsizeof=lambda entry: 1
         )
         self._inline_markup_lock = asyncio.Lock()
         self._request_tracker = RequestTracker()


### PR DESCRIPTION
## Summary
- adjust the inline markup cache weight to treat each cached markup as a single entry so large serialized markups no longer trigger ValueError

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pokerapp')*

------
https://chatgpt.com/codex/tasks/task_e_68cd7c38090083288e11788f14f05b7d