### PR TITLE
Ensure JsonFormatter keeps request tracker fields

### DIFF
--- a/pokerapp/logging_config.py
+++ b/pokerapp/logging_config.py
@@ -14,6 +14,35 @@ class JsonFormatter(logging.Formatter):
         for key in ("chat_id", "message_id", "request_params", "error_type"):
             if key in record.__dict__:
                 log_record[key] = record.__dict__[key]
+
+        standard_attrs = {
+            "name",
+            "msg",
+            "args",
+            "levelname",
+            "levelno",
+            "pathname",
+            "filename",
+            "module",
+            "exc_info",
+            "exc_text",
+            "stack_info",
+            "lineno",
+            "funcName",
+            "created",
+            "msecs",
+            "relativeCreated",
+            "thread",
+            "threadName",
+            "processName",
+            "process",
+            "message",
+            "stacklevel",
+        }
+        for key, value in record.__dict__.items():
+            if key.startswith("_") or key in log_record or key in standard_attrs:
+                continue
+            log_record[key] = value
         if record.exc_info:
             log_record["exception"] = self.formatException(record.exc_info)
         return json.dumps(log_record, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- extend the JSON log formatter to carry through non-standard LogRecord attributes so request tracker data is preserved
- add a unit test verifying the formatter output includes the tracker fields

## Testing
- pytest tests/test_request_tracker.py

------
https://chatgpt.com/codex/tasks/task_e_68cd90a4aeb4832887f66fbb9e9ef3e5