### PR TITLE
Refactor turn messaging and seat announcements

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -152,6 +152,9 @@ class Game:
         # 🆕 اضافه شده: پیام تصویر میز
         self.board_message_id: Optional[MessageId] = None
 
+        # پیام لیست صندلی‌ها که ابتدای هر دست ارسال می‌شود
+        self.seat_announcement_message_id: Optional[MessageId] = None
+
     # --- Seats / players helpers ----------------------------------------
     @property
     def players(self) -> List[Player]:


### PR DESCRIPTION
## Summary
- add a persistent seat announcement message tracked on the `Game` and sent at the start of each hand
- refactor turn updates to run through a cached `_update_message` helper so the turn text and keyboard stay in sync with consistent board formatting
- format board and hand displays in player card messages and showdown results with the new spaced card layout

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdbc745730832892d48bb68b539f68