### PR TITLE
Refactor messaging flow for anchor messages and request caching

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -85,6 +85,8 @@ class Player:
         self.seat_index = seat_index
         # پیام کیبورد کارت‌ها در گروه برای پاک‌سازی مرحله‌ای
         self.cards_keyboard_message_id: Optional[MessageId] = None
+        self.anchor_message: Optional[Tuple[ChatId, MessageId]] = None
+        self.anchor_role: str = "بازیکن"
         # -------------------------
     def __repr__(self):
         return "{}({!r})".format(self.__class__.__name__, self.__dict__)

--- a/tests/test_private_matchmaking.py
+++ b/tests/test_private_matchmaking.py
@@ -43,7 +43,7 @@ async def _build_model():
     view = MagicMock()
     view.send_message = AsyncMock()
     view.send_message_return_id = AsyncMock(return_value=None)
-    view.send_cards = AsyncMock()
+    view.update_player_anchor = AsyncMock()
     bot = MagicMock()
     cfg = Config()
     table_manager = TableManager(kv)


### PR DESCRIPTION
## Summary
- add anchor-aware message updates in the viewer, including consistent board formatting and new turn-message return type
- refactor the model to manage per-player anchor messages, prevent invisible payloads, and rely on the central messaging service cache
- update tests to reflect the anchor workflow and refreshed helpers while enhancing messaging service caching semantics

## Testing
- PYTHONPATH=. pytest tests/test_pokerbotmodel.py tests/test_pokerbotviewer.py tests/test_private_matchmaking.py

------
https://chatgpt.com/codex/tasks/task_e_68cdc2bf5d0c832899b0f8dae23e787b