### PR TITLE
Handle webhook DNS failures by falling back to polling

### DIFF
--- a/tests/test_pokerbot.py
+++ b/tests/test_pokerbot.py
@@ -35,3 +35,16 @@ def test_run_reraises_when_fallback_disabled():
         bot.run()
 
     bot.run_polling.assert_not_called()
+
+
+def test_run_dns_failure_triggers_automatic_polling(caplog):
+    bot = _create_bot(False)
+    error_message = "Bad webhook: failed to resolve host: temporary failure in name resolution"
+    bot.run_webhook = Mock(side_effect=TelegramError(error_message))
+    bot.run_polling = Mock()
+
+    with caplog.at_level(logging.ERROR):
+        bot.run()
+
+    bot.run_polling.assert_called_once()
+    assert "automatically falling back to polling mode" in caplog.text.lower()


### PR DESCRIPTION
## Summary
- add automatic long polling fallback when webhook start fails due to DNS resolution errors
- detect webhook DNS errors by inspecting the exception chain for common resolution failure messages
- extend pokerbot tests to cover the automatic polling fallback behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cef820f8088328b5a884e66942bec9