### PR TITLE
Optimize messaging flow with per-stage throttling and caching

### DIFF
--- a/pokerapp/utils/messaging_service.py
+++ b/pokerapp/utils/messaging_service.py
@@ -147,7 +147,7 @@ class MessagingService:
         *,
         chat_id: int,
         photo: Any,
-        request_category: RequestCategory = RequestCategory.PHOTO,
+        request_category: RequestCategory = RequestCategory.MEDIA,
         caption: Optional[str] = None,
         **params: Any,
     ) -> Any:
@@ -208,6 +208,10 @@ class MessagingService:
                 chat_id,
                 message_id,
             )
+            await self._metrics.record_skip(
+                chat_id=chat_id,
+                category=request_category,
+            )
             return message_id
 
         if not await self._consume_budget(
@@ -225,6 +229,10 @@ class MessagingService:
                     "SKIP EDIT: identical content for chat %s, msg %s",
                     chat_id,
                     message_id,
+                )
+                await self._metrics.record_skip(
+                    chat_id=chat_id,
+                    category=request_category,
                 )
                 return message_id
 
@@ -287,6 +295,10 @@ class MessagingService:
                 chat_id,
                 message_id,
             )
+            await self._metrics.record_skip(
+                chat_id=chat_id,
+                category=request_category,
+            )
             return True
 
         if not await self._consume_budget(
@@ -304,6 +316,10 @@ class MessagingService:
                     "SKIP EDIT: identical content for chat %s, msg %s",
                     chat_id,
                     message_id,
+                )
+                await self._metrics.record_skip(
+                    chat_id=chat_id,
+                    category=request_category,
                 )
                 return True
 

--- a/tests/test_pokerbotmodel.py
+++ b/tests/test_pokerbotmodel.py
@@ -436,7 +436,14 @@ def test_send_turn_message_updates_turn_message_only():
 
     assert game.turn_message_id == 321
     view.update_turn_message.assert_awaited_once()
-    view.update_player_anchor.assert_not_awaited()
+    assert view.update_player_anchor.await_count == 2
+    active_calls = [
+        call
+        for call in view.update_player_anchor.await_args_list
+        if call.kwargs.get("active")
+    ]
+    assert len(active_calls) == 1
+    assert active_calls[0].kwargs["player"].user_id == player.user_id
 
 
 def test_add_cards_to_table_does_not_send_stage_message():
@@ -931,10 +938,10 @@ async def test_start_game_assigns_blinds_to_occupied_seats():
     assert send_call.args[1].user_id == player_b.user_id
     assert send_call.args[2] == chat_id
 
-    assert view.update_player_anchor.await_count == 2
-    active_calls = [call for call in view.update_player_anchor.await_args_list if call.kwargs["active"]]
-    assert len(active_calls) == 1
-    assert active_calls[0].kwargs["player"].user_id == player_b.user_id
+    assert view.update_player_anchor.await_count == 1
+    call_kwargs = view.update_player_anchor.await_args.kwargs
+    assert call_kwargs["player"].user_id == player_a.user_id
+    assert call_kwargs["active"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- throttle `PokerBotViewer._update_message` per stage and cache payload hashes so redundant turn, countdown, and anchor edits are skipped across callbacks, jobs, and deletes
- batch anchor + turn updates through `_send_turn_message`, reuse cached signatures, and expose helpers for countdown dedupe so auto-start ticks respect recent callbacks
- enrich `RequestMetrics`/`MessagingService` with skip accounting, new `ANCHOR`/`MEDIA` categories, and include structured per-cycle before/after tables while updating tests for the new flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cf00aa53c08328bd53dfa94d862814