### PR TITLE
Update anchor keyboards to show cards and inactive menu

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -355,6 +355,27 @@ class PokerBotModel:
             reply_markup=self._build_private_menu(),
         )
 
+    async def _send_wallet_balance(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        chat = update.effective_chat
+        user = update.effective_user
+
+        if chat.type == chat.PRIVATE:
+            await self._register_player_identity(user, private_chat_id=chat.id)
+        else:
+            await self._register_player_identity(user)
+
+        wallet = WalletManagerModel(user.id, self._kv)
+        balance = await wallet.value()
+
+        reply_markup = self._build_private_menu() if chat.type == chat.PRIVATE else None
+        await self._view.send_message(
+            chat.id,
+            f"💰 موجودی فعلی شما: {balance}$",
+            reply_markup=reply_markup,
+        )
+
     async def _get_private_match_state(self, user_id: UserId) -> Dict[str, str]:
         key = self._private_user_key(user_id)
         data = await self._kv.hgetall(key)
@@ -1179,6 +1200,8 @@ class PokerBotModel:
                 board_cards=board_cards,
                 active=player.user_id == active_player.user_id,
                 message_id=existing_id,
+                player_cards=list(player.cards),
+                game_state=game.state,
             )
 
             if collect_active and request.active:
@@ -1192,6 +1215,8 @@ class PokerBotModel:
                     seat_number=request.seat_number,
                     role_label=request.role_label,
                     board_cards=request.board_cards,
+                    player_cards=request.player_cards,
+                    game_state=request.game_state,
                     active=request.active,
                     message_id=request.message_id,
                 )
@@ -2111,6 +2136,8 @@ class PokerBotModel:
                             seat_number=anchor_plan.seat_number,
                             role_label=anchor_plan.role_label,
                             board_cards=anchor_plan.board_cards,
+                            player_cards=anchor_plan.player_cards,
+                            game_state=anchor_plan.game_state,
                             active=True,
                             message_id=anchor_plan.message_id,
                         )
@@ -2579,13 +2606,43 @@ class PokerBotModel:
                 ids_to_delete.add(game.turn_message_id)
                 game.turn_message_id = None
 
-            for player in game.seated_players():
-                keyboard_message_id = getattr(player, "cards_keyboard_message_id", None)
-                if keyboard_message_id:
-                    ids_to_delete.add(keyboard_message_id)
-                    player.cards_keyboard_message_id = None
+        for player in game.seated_players():
+            keyboard_message_id: Optional[MessageId] = None
+            if player.anchor_message and player.anchor_message[0] == chat_id:
+                keyboard_message_id = player.anchor_message[1]
+            elif getattr(player, "cards_keyboard_message_id", None):
+                keyboard_message_id = player.cards_keyboard_message_id
+
+            if keyboard_message_id:
+                ids_to_delete.discard(keyboard_message_id)
+                try:
+                    await self._view.update_player_anchor(
+                        chat_id=chat_id,
+                        player=player,
+                        seat_number=(player.seat_index or 0) + 1,
+                        role_label=getattr(player, "anchor_role", "بازیکن"),
+                        board_cards=list(game.cards_table),
+                        player_cards=list(player.cards),
+                        game_state=GameState.FINISHED,
+                        active=False,
+                        message_id=keyboard_message_id,
+                    )
+                except Exception as exc:
+                    logger.debug(
+                        "Failed to update inactive anchor",
+                        extra={
+                            "chat_id": chat_id,
+                            "message_id": keyboard_message_id,
+                            "error_type": type(exc).__name__,
+                        },
+                    )
+            if keyboard_message_id:
+                player.anchor_message = (chat_id, keyboard_message_id)
+                player.cards_keyboard_message_id = keyboard_message_id
+            else:
                 player.anchor_message = None
-                player.anchor_role = "بازیکن"
+                player.cards_keyboard_message_id = None
+            player.anchor_role = "بازیکن"
 
             for message_id in ids_to_delete:
                 try:

--- a/tests/test_pokerbotviewer.py
+++ b/tests/test_pokerbotviewer.py
@@ -138,6 +138,7 @@ def test_update_player_anchor_creates_anchor_message():
     viewer._messenger.send_message = AsyncMock(return_value=MagicMock(message_id=42))
 
     player = MagicMock(mention_markdown=MENTION_MARKDOWN, user_id=111)
+    player.cards = [Card('A♣'), Card('K♥')]
     board_cards = [Card('A♠'), Card('K♦'), Card('5♣')]
 
     result = run(
@@ -147,6 +148,8 @@ def test_update_player_anchor_creates_anchor_message():
             seat_number=3,
             role_label='دیلر',
             board_cards=board_cards,
+            player_cards=player.cards,
+            game_state=GameState.ROUND_PRE_FLOP,
             active=True,
         )
     )
@@ -157,14 +160,21 @@ def test_update_player_anchor_creates_anchor_message():
     assert '🎖️ نقش: دیلر' in call.kwargs['text']
     assert '🃏 Board:' in call.kwargs['text']
     assert '🎯 **نوبت بازی این بازیکن است.**' in call.kwargs['text']
-    assert call.kwargs['reply_markup'] is None
+    markup = call.kwargs['reply_markup']
+    assert isinstance(markup, InlineKeyboardMarkup)
+    rows = markup.inline_keyboard
+    assert [button.text for button in rows[0]] == ['🎴 کارت‌های شما']
+    assert [button.text for button in rows[1]] == ['A♣️', 'K♥️']
+    assert [button.text for button in rows[2]] == ['🃏 کارت‌های روی میز']
+    assert [button.text for button in rows[3]] == ['A♠️', 'K♦️', '5♣️']
 
 
-def test_update_player_anchor_inactive_removes_keyboard():
+def test_update_player_anchor_inactive_player_keeps_card_keyboard():
     viewer = PokerBotViewer(bot=MagicMock())
     viewer._messenger.edit_message_text = AsyncMock(return_value=77)
 
     player = MagicMock(mention_markdown=MENTION_MARKDOWN, user_id=222)
+    player.cards = [Card('Q♣'), Card('J♥')]
     board_cards = [Card('Q♠'), Card('J♦'), Card('9♣'), Card('2♥')]
 
     result = run(
@@ -174,6 +184,8 @@ def test_update_player_anchor_inactive_removes_keyboard():
             seat_number=4,
             role_label='بازیکن',
             board_cards=board_cards,
+            player_cards=player.cards,
+            game_state=GameState.ROUND_TURN,
             active=False,
             message_id=77,
         )
@@ -181,9 +193,49 @@ def test_update_player_anchor_inactive_removes_keyboard():
 
     assert result == 77
     call = viewer._messenger.edit_message_text.await_args
-    assert call.kwargs['reply_markup'] is None
     assert '🃏 Board:' in call.kwargs['text']
     assert '🎯 **نوبت بازی این بازیکن است.**' not in call.kwargs['text']
+    markup = call.kwargs['reply_markup']
+    assert isinstance(markup, InlineKeyboardMarkup)
+    rows = markup.inline_keyboard
+    assert [button.text for button in rows[0]] == ['🎴 کارت‌های شما']
+    assert [button.text for button in rows[1]] == ['Q♣️', 'J♥️']
+    assert [button.text for button in rows[2]] == ['🃏 کارت‌های روی میز']
+    assert [button.text for button in rows[3]] == ['Q♠️', 'J♦️', '9♣️']
+    assert [button.text for button in rows[4]] == ['2♥️']
+
+
+def test_update_player_anchor_when_game_inactive_shows_menu():
+    viewer = PokerBotViewer(bot=MagicMock())
+    viewer._messenger.edit_message_text = AsyncMock(return_value=99)
+
+    player = MagicMock(mention_markdown=MENTION_MARKDOWN, user_id=333)
+    player.cards = [Card('2♣'), Card('3♦')]
+
+    result = run(
+        viewer.update_player_anchor(
+            chat_id=-777,
+            player=player,
+            seat_number=2,
+            role_label='بازیکن',
+            board_cards=[],
+            player_cards=player.cards,
+            game_state=GameState.INITIAL,
+            active=False,
+            message_id=99,
+        )
+    )
+
+    assert result == 99
+    call = viewer._messenger.edit_message_text.await_args
+    markup = call.kwargs['reply_markup']
+    assert isinstance(markup, InlineKeyboardMarkup)
+    rows = [[button.text for button in row] for row in markup.inline_keyboard]
+    assert rows == [
+        ['🎮 شروع بازی جدید', '📊 آمار شما'],
+        ['🛠 راهنما / قوانین', '💰 موجودی کیف پول'],
+        ['💬 گفتگوی دوستانه'],
+    ]
 
 
 def test_update_turn_message_includes_stage_and_keyboard():


### PR DESCRIPTION
## Summary
- add rich card keyboard markup to anchor messages across game stages and keep inactive anchors alive with a menu
- extend model/controller to populate card data, reuse finished anchors, and expose Persian menu callbacks (stats, help, wallet, chat)
- cover anchor transitions with updated viewer/model tests

## Testing
- pytest tests/test_pokerbotviewer.py tests/test_pokerbotmodel.py

------
https://chatgpt.com/codex/tasks/task_e_68cf1274292c8328a4a9d0f26014ed38