### PR TITLE
Restore inline anchor card keyboard

### DIFF
--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -1029,16 +1029,14 @@ class PokerBotViewer:
         mention_markdown: Mention,
         seat_number: int,
         role_label: str,
-        board_cards: Sequence[Card],
     ) -> str:
-        lines = [
-            f"🎮 {mention_markdown}",
-            f"🪑 صندلی: `{seat_number}`",
-            f"🎖️ نقش: {role_label}",
-        ]
-        board_line = cls._format_card_line("🃏 Board", board_cards)
-        lines.extend(["", board_line])
-        return "\n".join(lines)
+        return "\n".join(
+            [
+                f"🎮 {mention_markdown}",
+                f"🪑 صندلی: `{seat_number}`",
+                f"🎖️ نقش: {role_label}",
+            ]
+        )
 
     async def update_player_anchor(
         self,
@@ -1057,7 +1055,6 @@ class PokerBotViewer:
             mention_markdown=player.mention_markdown,
             seat_number=seat_number,
             role_label=role_label,
-            board_cards=board_cards,
         )
         reply_markup: Optional[InlineKeyboardMarkup] = None
         if not self._is_private_chat(chat_id):

--- a/tests/test_pokerbotviewer.py
+++ b/tests/test_pokerbotviewer.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from typing import List
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -158,7 +159,6 @@ def test_update_player_anchor_creates_anchor_message():
     call = viewer._messenger.send_message.await_args
     assert '🪑 صندلی: `3`' in call.kwargs['text']
     assert '🎖️ نقش: دیلر' in call.kwargs['text']
-    assert '🃏 Board:' in call.kwargs['text']
     assert '🎯 **نوبت بازی این بازیکن است.**' in call.kwargs['text']
     markup = call.kwargs['reply_markup']
     assert isinstance(markup, InlineKeyboardMarkup)
@@ -171,10 +171,34 @@ def test_update_player_anchor_creates_anchor_message():
 
 def test_update_player_anchor_inactive_player_keeps_card_keyboard():
     viewer = PokerBotViewer(bot=MagicMock())
-    viewer._messenger.edit_message_text = AsyncMock(return_value=77)
+    viewer._messenger.send_message = AsyncMock(
+        return_value=MagicMock(message_id=77)
+    )
+    viewer._messenger.edit_message_reply_markup = AsyncMock(return_value=True)
+    viewer._messenger.edit_message_text = AsyncMock()
 
     player = MagicMock(mention_markdown=MENTION_MARKDOWN, user_id=222)
     player.cards = [Card('Q♣'), Card('J♥')]
+    initial_board: List[Card] = []
+
+    # Initial creation of the anchor message caches the message text
+    run(
+        viewer.update_player_anchor(
+            chat_id=888,
+            player=player,
+            seat_number=4,
+            role_label='بازیکن',
+            board_cards=initial_board,
+            player_cards=player.cards,
+            game_state=GameState.ROUND_PRE_FLOP,
+            active=False,
+        )
+    )
+
+    viewer._messenger.send_message.reset_mock()
+    viewer._messenger.edit_message_reply_markup.reset_mock()
+    viewer._messenger.edit_message_text.reset_mock()
+
     board_cards = [Card('Q♠'), Card('J♦'), Card('9♣'), Card('2♥')]
 
     result = run(
@@ -192,9 +216,9 @@ def test_update_player_anchor_inactive_player_keeps_card_keyboard():
     )
 
     assert result == 77
-    call = viewer._messenger.edit_message_text.await_args
-    assert '🃏 Board:' in call.kwargs['text']
-    assert '🎯 **نوبت بازی این بازیکن است.**' not in call.kwargs['text']
+    assert viewer._messenger.edit_message_text.await_count == 0
+    assert viewer._messenger.edit_message_reply_markup.await_count == 1
+    call = viewer._messenger.edit_message_reply_markup.await_args
     markup = call.kwargs['reply_markup']
     assert isinstance(markup, InlineKeyboardMarkup)
     rows = markup.inline_keyboard


### PR DESCRIPTION
## Summary
- keep anchor text limited to role/seat while restoring inline card keyboard display
- ensure inline card rows update via edit_message_reply_markup and adjust viewer tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cf1ae4c73483289054e4ce10ec158c