### PR TITLE
Restore inline card keyboard for player anchors

### DIFF
--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -1029,15 +1029,13 @@ class PokerBotViewer:
         mention_markdown: Mention,
         seat_number: int,
         role_label: str,
-        board_cards: Sequence[Card],
     ) -> str:
         lines = [
             f"🎮 {mention_markdown}",
             f"🪑 صندلی: `{seat_number}`",
             f"🎖️ نقش: {role_label}",
         ]
-        board_line = cls._format_card_line("🃏 Board", board_cards)
-        lines.extend(["", board_line])
+        # کارت‌های بازیکن و میز در کیبورد اینلاین نمایش داده می‌شوند تا متن ثابت بماند.
         return "\n".join(lines)
 
     async def update_player_anchor(
@@ -1057,7 +1055,6 @@ class PokerBotViewer:
             mention_markdown=player.mention_markdown,
             seat_number=seat_number,
             role_label=role_label,
-            board_cards=board_cards,
         )
         reply_markup: Optional[InlineKeyboardMarkup] = None
         if not self._is_private_chat(chat_id):


### PR DESCRIPTION
## Summary
- ensure anchor texts remain static while cards are rendered in the inline keyboard markup
- update anchor update tests to cover markup-only refreshes when community cards are revealed

## Testing
- pytest tests/test_pokerbotviewer.py
- pytest tests/test_aiogram_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68cf1ae4c73483289054e4ce10ec158c