### PR TITLE
Mask player cards in inline keyboard

### DIFF
--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -966,12 +966,13 @@ class PokerBotViewer:
         rows: List[List[InlineKeyboardButton]] = []
         if has_hand:
             rows.append([cls._build_label_button("🎴 کارت‌های شما")])
+            total_cards = len(player_cards)
             card_row = [
                 InlineKeyboardButton(
-                    text=cls._format_card_button(card),
+                    text=f"🂠 کارت مخفی {index + 1}/{total_cards}",
                     callback_data=cls._build_hand_card_callback(player, index),
                 )
-                for index, card in enumerate(player_cards)
+                for index, _ in enumerate(player_cards)
             ]
             rows.append(card_row)
 

--- a/tests/test_pokerbotviewer.py
+++ b/tests/test_pokerbotviewer.py
@@ -164,7 +164,10 @@ def test_update_player_anchor_creates_anchor_message():
     assert isinstance(markup, InlineKeyboardMarkup)
     rows = markup.inline_keyboard
     assert [button.text for button in rows[0]] == ['🎴 کارت‌های شما']
-    assert [button.text for button in rows[1]] == ['A♣️', 'K♥️']
+    assert [button.text for button in rows[1]] == [
+        '🂠 کارت مخفی 1/2',
+        '🂠 کارت مخفی 2/2',
+    ]
     assert [button.text for button in rows[2]] == ['🃏 کارت‌های روی میز']
     assert [button.text for button in rows[3]] == ['A♠️', 'K♦️', '5♣️']
 
@@ -226,7 +229,10 @@ def test_update_player_anchor_inactive_player_keeps_card_keyboard():
     assert isinstance(markup, InlineKeyboardMarkup)
     rows = markup.inline_keyboard
     assert [button.text for button in rows[0]] == ['🎴 کارت‌های شما']
-    assert [button.text for button in rows[1]] == ['Q♣️', 'J♥️']
+    assert [button.text for button in rows[1]] == [
+        '🂠 کارت مخفی 1/2',
+        '🂠 کارت مخفی 2/2',
+    ]
     assert [button.text for button in rows[2]] == ['🃏 کارت‌های روی میز']
     assert [button.text for button in rows[3]] == ['Q♠️', 'J♦️', '9♣️']
     assert [button.text for button in rows[4]] == ['2♥️']


### PR DESCRIPTION
## Summary
- replace the inline keyboard labels for player cards with neutral hidden-card placeholders while keeping callback data intact
- adjust PokerBotViewer tests to expect the masked card labels while preserving the board assertions

## Testing
- pytest tests/test_pokerbotviewer.py

------
https://chatgpt.com/codex/tasks/task_e_68cf1f572bf88328b8e5ba8a10368190