### PR TITLE
Refresh player keyboards on street transitions

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -2400,12 +2400,15 @@ class PokerBotModel:
             if game.state == GameState.ROUND_PRE_FLOP:
                 game.state = GameState.ROUND_FLOP
                 await self.add_cards_to_table(3, game, chat_id, "🃏 فلاپ")
+                await self._view.update_player_anchors_and_keyboards(game)
             elif game.state == GameState.ROUND_FLOP:
                 game.state = GameState.ROUND_TURN
                 await self.add_cards_to_table(1, game, chat_id, "🃏 ترن")
+                await self._view.update_player_anchors_and_keyboards(game)
             elif game.state == GameState.ROUND_TURN:
                 game.state = GameState.ROUND_RIVER
                 await self.add_cards_to_table(1, game, chat_id, "🃏 ریور")
+                await self._view.update_player_anchors_and_keyboards(game)
             elif game.state == GameState.ROUND_RIVER:
                 # بعد از ریور، دور شرط‌بندی تمام شده و باید showdown انجام شود
                 await self._showdown(game, chat_id, context)


### PR DESCRIPTION
## Summary
- call the viewer to refresh player anchors and keyboards whenever the game advances to flop, turn, or river

## Testing
- pytest tests/test_pokerbotmodel.py

------
https://chatgpt.com/codex/tasks/task_e_68d021afa1548328ae4220f8e0dc2e75