### PR TITLE
Refactor anchor updates for shared table keyboards

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -83,8 +83,6 @@ class Player:
         self.total_bet = 0  # کل مبلغ شرط‌بندی شده در یک دست
         self.has_acted = False # آیا در راند فعلی نوبت خود را بازی کرده؟
         self.seat_index = seat_index
-        # پیام کیبورد کارت‌ها در گروه برای پاک‌سازی مرحله‌ای
-        self.cards_keyboard_message_id: Optional[MessageId] = None
         self.anchor_message: Optional[Tuple[ChatId, MessageId]] = None
         self.anchor_role: str = "بازیکن"
         # -------------------------


### PR DESCRIPTION
## Summary
- implement `update_player_anchors_and_keyboards` to refresh all anchor messages with per-player reply keyboards in the shared table chat
- remove the private keyboard distribution flow, store the table chat id on the game, and invoke the new viewer hook at street transitions and during turn prompts
- update tests to exercise the new anchor update logic and expectations for reply keyboards

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d027c1e708832892e0dc9889ba6740