### PR TITLE
Refactor anchor updates to group refresh flow

### DIFF
--- a/tests/test_private_matchmaking.py
+++ b/tests/test_private_matchmaking.py
@@ -43,7 +43,7 @@ async def _build_model():
     view = MagicMock()
     view.send_message = AsyncMock()
     view.send_message_return_id = AsyncMock(return_value=None)
-    view.update_player_anchor = AsyncMock()
+    view.update_player_anchors_and_keyboards = AsyncMock()
     bot = MagicMock()
     cfg = Config()
     table_manager = TableManager(kv)


### PR DESCRIPTION
## Summary
- replace per-player anchor updates with a unified `update_player_anchors_and_keyboards` flow that refreshes group anchors, keyboards, and turn highlights using `_update_message`
- ensure `_clear_game_messages` reuses the new anchor updater while keeping player anchors intact and skipping private chats during gameplay
- update viewer, model, and matchmaking tests to cover the new anchor refresh behaviour and keyboard contents

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d0302e00988328b0628cdf13b09e49