### PR TITLE
Refine anchor updates with community cards and cleanup

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -89,6 +89,11 @@ class Player:
     def __repr__(self):
         return "{}({!r})".format(self.__class__.__name__, self.__dict__)
 
+    def is_active(self) -> bool:
+        """Return ``True`` if the player is still participating in the hand."""
+
+        return self.state in (PlayerState.ACTIVE, PlayerState.ALL_IN)
+
     def __getstate__(self):
         state = self.__dict__.copy()
         wallet = state.pop("wallet", None)

--- a/tests/test_private_matchmaking.py
+++ b/tests/test_private_matchmaking.py
@@ -44,6 +44,7 @@ async def _build_model():
     view.send_message = AsyncMock()
     view.send_message_return_id = AsyncMock(return_value=None)
     view.update_player_anchors_and_keyboards = AsyncMock()
+    view.clear_all_player_anchors = AsyncMock(return_value=None)
     bot = MagicMock()
     cfg = Config()
     table_manager = TableManager(kv)


### PR DESCRIPTION
## Summary
- update PokerBotViewer anchor refresh to include community cards, skip inactive players, and add a clear_all_player_anchors cleanup path
- ensure PokerBotModel clears anchor messages across hand transitions and unify street progression logic
- expand unit tests to validate anchor handling changes and accommodate the new cleanup helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d035540fe083288a9235b9657b3e4a