### PR TITLE
Clear seat announcement message when clearing hand state

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -2481,6 +2481,10 @@ class PokerBotModel:
                 ids_to_delete.add(game.turn_message_id)
                 game.turn_message_id = None
 
+            if game.seat_announcement_message_id:
+                ids_to_delete.add(game.seat_announcement_message_id)
+                game.seat_announcement_message_id = None
+
             game.chat_id = chat_id
 
             for player in game.seated_players():


### PR DESCRIPTION
## Summary
- clear seat announcement messages when cleaning up per-hand Telegram messages
- ensure the tracked message id is reset so subsequent hands can post a fresh seat announcement

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0474f8f2883288bd53d7bb301daa8