### PR TITLE
Ensure anchor reply keyboards send new messages

### DIFF
--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -1393,16 +1393,22 @@ class PokerBotViewer:
                 getattr(player, "display_name", None) or player.mention_markdown
             )
 
-            lines = [
-                f"🎮 {display_name}",
-                f"🪑 Seat: {seat_number}",
-                f"🎖️ Role: {role_label}",
-            ]
+            visible_label = display_name
+            hidden_mention = self._build_hidden_mention(
+                getattr(player, "mention_markdown", None)
+            )
+            if hidden_mention and hidden_mention not in visible_label:
+                visible_label = f"{visible_label} {hidden_mention}"
+
+            text = self._build_anchor_text(
+                mention_markdown=visible_label,
+                seat_number=seat_number,
+                role_label=role_label,
+            )
+
             is_current_turn = current_player is player
             if is_current_turn:
-                lines.append("")
-                lines.append("🎯 It's this player's turn.")
-            text = "\n".join(lines)
+                text = f"{text}\n\n🎯 نوبت این بازیکن است."
 
             logger.debug(
                 "Anchor update: player=%s | seat=%s | role=%s | hole_cards=%s | "
@@ -1417,14 +1423,28 @@ class PokerBotViewer:
                 anchor_id,
             )
 
+            send_new_anchor = isinstance(keyboard, ReplyKeyboardMarkup)
+
             try:
-                result = await self._update_message(
-                    chat_id=chat_id,
-                    message_id=anchor_id,
-                    text=text,
-                    reply_markup=keyboard,
-                    request_category=RequestCategory.ANCHOR,
-                )
+                if send_new_anchor:
+                    result = await self.schedule_message_update(
+                        chat_id=chat_id,
+                        message_id=None,
+                        text=text,
+                        reply_markup=keyboard,
+                        parse_mode=ParseMode.MARKDOWN,
+                        disable_web_page_preview=True,
+                        disable_notification=True,
+                        request_category=RequestCategory.ANCHOR,
+                    )
+                else:
+                    result = await self._update_message(
+                        chat_id=chat_id,
+                        message_id=anchor_id,
+                        text=text,
+                        reply_markup=keyboard,
+                        request_category=RequestCategory.ANCHOR,
+                    )
             except Exception as exc:
                 logger.error(
                     "Failed to refresh anchor",
@@ -1447,12 +1467,32 @@ class PokerBotViewer:
                 except (TypeError, ValueError):
                     resolved_anchor_id = None
 
+            if (
+                send_new_anchor
+                and resolved_anchor_id is not None
+                and anchor_id is not None
+                and resolved_anchor_id != anchor_id
+            ):
+                try:
+                    await self.delete_message(chat_id=chat_id, message_id=anchor_id)
+                except Exception as delete_exc:
+                    logger.debug(
+                        "Failed to delete superseded anchor",
+                        extra={
+                            "chat_id": chat_id,
+                            "player_id": getattr(player, "user_id", None),
+                            "old_message_id": anchor_id,
+                            "error_type": type(delete_exc).__name__,
+                        },
+                    )
+
             final_anchor_id = resolved_anchor_id or anchor_id
             try:
                 normalized_anchor = int(final_anchor_id)
             except (TypeError, ValueError):
                 continue
             player.anchor_message = (chat_id, normalized_anchor)
+            player.anchor_role = role_label
 
     async def clear_all_player_anchors(self, game: Game) -> None:
         chat_id = getattr(game, "chat_id", None)

--- a/tests/test_pokerbotviewer.py
+++ b/tests/test_pokerbotviewer.py
@@ -135,7 +135,9 @@ def test_notify_admin_failure_logs_error(caplog):
 
 def test_update_player_anchors_and_keyboards_highlights_active_player():
     viewer = PokerBotViewer(bot=MagicMock())
-    viewer._update_message = AsyncMock(side_effect=[101, 202])
+    viewer.schedule_message_update = AsyncMock(side_effect=[303, 404])
+    viewer.delete_message = AsyncMock()
+    viewer._update_message = AsyncMock()
 
     game = Game()
     game.chat_id = -777
@@ -170,27 +172,36 @@ def test_update_player_anchors_and_keyboards_highlights_active_player():
 
     run(viewer.update_player_anchors_and_keyboards(game))
 
-    assert viewer._update_message.await_count == 2
+    assert viewer.schedule_message_update.await_count == 2
+    viewer._update_message.assert_not_awaited()
 
-    first_call = viewer._update_message.await_args_list[0]
-    second_call = viewer._update_message.await_args_list[1]
+    first_call = viewer.schedule_message_update.await_args_list[0]
+    second_call = viewer.schedule_message_update.await_args_list[1]
 
-    assert first_call.kwargs['message_id'] == 101
-    assert "🎯 It's this player's turn." in first_call.kwargs['text']
+    assert first_call.kwargs['message_id'] is None
+    assert "🎯 نوبت این بازیکن است." in first_call.kwargs['text']
     assert 'Player One' in first_call.kwargs['text']
-    assert 'Seat: 1' in first_call.kwargs['text']
-    assert 'Role: دیلر' in first_call.kwargs['text']
+    assert '@one' in first_call.kwargs['text']
+    assert '🪑 صندلی: `1`' in first_call.kwargs['text']
+    assert '🎖️ نقش: دیلر' in first_call.kwargs['text']
     assert isinstance(first_call.kwargs['reply_markup'], ReplyKeyboardMarkup)
     board_row = _row_texts(first_call.kwargs['reply_markup'].keyboard[1])
     assert board_row == ['A♠', 'K♦', '5♣']
 
-    assert second_call.kwargs['message_id'] == 202
-    assert "🎯 It's this player's turn." not in second_call.kwargs['text']
+    assert second_call.kwargs['message_id'] is None
+    assert "🎯 نوبت این بازیکن است." not in second_call.kwargs['text']
     assert 'Player Two' in second_call.kwargs['text']
-    assert 'Role: بلایند بزرگ' in second_call.kwargs['text']
+    assert '@two' in second_call.kwargs['text']
+    assert '🎖️ نقش: بلایند بزرگ' in second_call.kwargs['text']
 
-    assert player_one.anchor_message == (game.chat_id, 101)
-    assert player_two.anchor_message == (game.chat_id, 202)
+    deleted_calls = [call.kwargs for call in viewer.delete_message.await_args_list]
+    assert deleted_calls == [
+        {'chat_id': game.chat_id, 'message_id': 101},
+        {'chat_id': game.chat_id, 'message_id': 202},
+    ]
+
+    assert player_one.anchor_message == (game.chat_id, 303)
+    assert player_two.anchor_message == (game.chat_id, 404)
 
 
 def test_update_player_anchors_and_keyboards_skips_players_without_anchor():


### PR DESCRIPTION
## Summary
- send new anchor messages when reply keyboards are required and clean up superseded anchors
- reuse the localized anchor text while keeping player anchor metadata in sync
- expand viewer coverage to confirm localized text, keyboard content, and anchor replacement

## Testing
- pytest tests/test_pokerbotviewer.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d050c7f6348328813e970ab018dc69