### PR TITLE
Send per-player role anchor messages

### DIFF
--- a/tests/test_pokerbotmodel.py
+++ b/tests/test_pokerbotmodel.py
@@ -56,6 +56,7 @@ def _prepare_view_mock(view: MagicMock) -> MagicMock:
     view.send_message_return_id = AsyncMock(return_value=None)
     view.send_message = AsyncMock()
     view.announce_player_seats = AsyncMock(return_value=None)
+    view.send_player_role_anchors = AsyncMock(return_value=None)
     view.delete_message = AsyncMock()
     view.start_prestart_countdown = AsyncMock(return_value=None)
     view._cancel_prestart_countdown = AsyncMock(return_value=None)
@@ -858,6 +859,8 @@ async def test_start_game_assigns_blinds_to_occupied_seats():
     }
     assert blind_players == {1, 2}
 
+    view.send_player_role_anchors.assert_awaited_once_with(game=game, chat_id=chat_id)
+
     model._send_turn_message.assert_awaited_once()
     send_call = model._send_turn_message.await_args
     assert send_call.args[1].user_id == player_b.user_id
@@ -903,6 +906,7 @@ async def test_start_game_keeps_ready_message_id_when_deletion_fails():
     assert game.ready_message_main_text == ""
     model._divide_cards.assert_awaited_once_with(game, chat_id)
     model._round_rate.set_blinds.assert_awaited_once_with(game, chat_id)
+    view.send_player_role_anchors.assert_awaited_once_with(game=game, chat_id=chat_id)
 
 
 def test_send_turn_message_updates_existing_message():

--- a/tests/test_pokerbotviewer.py
+++ b/tests/test_pokerbotviewer.py
@@ -176,18 +176,20 @@ def test_update_player_anchors_and_keyboards_highlights_active_player():
     second_call = viewer._update_message.await_args_list[1]
 
     assert first_call.kwargs['message_id'] == 101
-    assert "🎯 It's this player's turn." in first_call.kwargs['text']
-    assert 'Player One' in first_call.kwargs['text']
-    assert 'Seat: 1' in first_call.kwargs['text']
-    assert 'Role: دیلر' in first_call.kwargs['text']
+    first_text = first_call.kwargs['text']
+    assert "🎯 نوبت این بازیکن است." in first_text
+    assert 'Player One' in first_text
+    assert '🪑 صندلی: 1' in first_text
+    assert '🎖️ نقش: دیلر' in first_text
     assert isinstance(first_call.kwargs['reply_markup'], ReplyKeyboardMarkup)
     board_row = _row_texts(first_call.kwargs['reply_markup'].keyboard[1])
     assert board_row == ['A♠', 'K♦', '5♣']
 
     assert second_call.kwargs['message_id'] == 202
-    assert "🎯 It's this player's turn." not in second_call.kwargs['text']
-    assert 'Player Two' in second_call.kwargs['text']
-    assert 'Role: بلایند بزرگ' in second_call.kwargs['text']
+    second_text = second_call.kwargs['text']
+    assert "🎯 نوبت این بازیکن است." not in second_text
+    assert 'Player Two' in second_text
+    assert '🎖️ نقش: بلایند بزرگ' in second_text
 
     assert player_one.anchor_message == (game.chat_id, 101)
     assert player_two.anchor_message == (game.chat_id, 202)


### PR DESCRIPTION
## Summary
- replace the consolidated seat announcement with per-player role anchor messages at the start of each hand
- attach the player card keyboards to the new anchors and refresh anchor text in Persian with turn indicators
- adjust anchor update logic to refresh reply keyboard markup and update tests for the new workflow

## Testing
- pytest tests/test_pokerbotmodel.py tests/test_pokerbotviewer.py tests/test_aiogram_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68d054b339ac832889e18ca4f634ff32