### PR TITLE
Refactor anchor handling and countdown flow

### DIFF
--- a/pokerapp/pokerbotcontrol.py
+++ b/pokerapp/pokerbotcontrol.py
@@ -155,8 +155,21 @@ class PokerBotCotroller:
         await self._model.join_game(update, context)
 
     async def _handle_start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-        if update.callback_query:
-            await update.callback_query.answer()
+        query = update.callback_query
+        if query:
+            await query.answer()
+            data = query.data or ""
+            if data.startswith("start_game:"):
+                _, _, game_id = data.partition(":")
+                chat = update.effective_chat
+                if chat:
+                    await self._model.start_hand(
+                        context=context,
+                        chat_id=chat.id,
+                        game_id=game_id,
+                        trigger="button",
+                    )
+                return
         await self._model.start(update, context)
 
     async def _handle_stop(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -264,6 +277,9 @@ class PokerBotCotroller:
         chat = update.effective_chat
 
         if action == "noop":
+            await query.answer()
+            return
+        if action.startswith("card") or action.startswith("board") or action.startswith("stage"):
             await query.answer()
             return
 

--- a/tests/test_pokerbotmodel.py
+++ b/tests/test_pokerbotmodel.py
@@ -21,14 +21,12 @@ from pokerapp.pokerbotmodel import (
     KEY_CHAT_DATA_GAME,
     KEY_START_COUNTDOWN_LAST_TEXT,
     KEY_START_COUNTDOWN_LAST_TIMESTAMP,
-    KEY_PRESTART_COUNTDOWN_ACTIVE,
-    KEY_PRESTART_COUNTDOWN_ANCHOR,
-    KEY_PRESTART_COUNTDOWN_SECONDS,
+    KEY_PRESTART_COUNTDOWN_STATE,
     KEY_STOP_REQUEST,
     STOP_CONFIRM_CALLBACK,
     STOP_RESUME_CALLBACK,
 )
-from pokerapp.pokerbotview import TurnMessageUpdate
+from pokerapp.pokerbotview import PrestartCountdownContext, TurnMessageUpdate
 from telegram.error import BadRequest
 from telegram import InlineKeyboardMarkup
 
@@ -530,17 +528,24 @@ async def test_auto_start_tick_starts_prestart_countdown_and_updates_state():
     view.start_prestart_countdown.assert_awaited_once()
     countdown_call = view.start_prestart_countdown.await_args
     assert countdown_call.kwargs["chat_id"] == chat_id
-    assert countdown_call.kwargs["anchor_message_id"] == 111
+    assert countdown_call.kwargs["game_id"] == game.id
+    assert countdown_call.kwargs["message_id"] == 111
     assert countdown_call.kwargs["seconds"] == 5
     payload_fn = countdown_call.kwargs["payload_fn"]
     initial_text = game.ready_message_main_text
     assert "5 ثانیه" in initial_text
-    preview_text, _ = payload_fn(3)
+    state_before = dict(context.chat_data[KEY_PRESTART_COUNTDOWN_STATE])
+    assert state_before["active"] is True
+    assert state_before["message_id"] == 111
+    assert state_before["seconds"] == 5
+    dummy_context = PrestartCountdownContext(
+        chat_id=chat_id, game_id=game.id, message_id=111
+    )
+    preview_text, _ = payload_fn(3, dummy_context)
     assert "3 ثانیه" in preview_text
     assert context.chat_data["start_countdown"] == 4
-    assert context.chat_data[KEY_PRESTART_COUNTDOWN_ACTIVE] is True
-    assert context.chat_data[KEY_PRESTART_COUNTDOWN_ANCHOR] == 111
-    assert context.chat_data[KEY_PRESTART_COUNTDOWN_SECONDS] == 5
+    state_after = context.chat_data[KEY_PRESTART_COUNTDOWN_STATE]
+    assert state_after["seconds"] == 3
     assert context.chat_data[KEY_START_COUNTDOWN_LAST_TEXT] == preview_text
     assert context.chat_data[KEY_CHAT_DATA_GAME] is game
     assert game.ready_message_main_text == preview_text
@@ -572,7 +577,8 @@ async def test_auto_start_tick_does_not_restart_on_regular_tick():
 
     assert view.start_prestart_countdown.await_count == 1
     assert context.chat_data["start_countdown"] == 2
-    assert context.chat_data[KEY_PRESTART_COUNTDOWN_ACTIVE] is True
+    state = context.chat_data[KEY_PRESTART_COUNTDOWN_STATE]
+    assert state["active"] is True
     table_manager.save_game.assert_not_awaited()
 
 
@@ -621,6 +627,12 @@ async def test_auto_start_tick_triggers_game_start_when_zero():
     model = PokerBotModel(view=view, bot=bot, cfg=cfg, kv=kv, table_manager=table_manager)
     model._start_game = AsyncMock()
 
+    # Ensure enough players are seated so start_hand proceeds.
+    player_a = Player(user_id=1, mention_markdown='@a', wallet=MagicMock(), ready_message_id='ready-a')
+    player_b = Player(user_id=2, mention_markdown='@b', wallet=MagicMock(), ready_message_id='ready-b')
+    game.add_player(player_a, seat_index=0)
+    game.add_player(player_b, seat_index=1)
+
     job = SimpleNamespace(chat_id=chat_id)
     job.schedule_removal = MagicMock()
     context = SimpleNamespace(
@@ -628,9 +640,12 @@ async def test_auto_start_tick_triggers_game_start_when_zero():
         chat_data={
             "start_countdown": 0,
             "start_countdown_job": object(),
-            KEY_PRESTART_COUNTDOWN_ACTIVE: True,
-            KEY_PRESTART_COUNTDOWN_ANCHOR: 111,
-            KEY_PRESTART_COUNTDOWN_SECONDS: 0,
+            KEY_PRESTART_COUNTDOWN_STATE: {
+                "game_id": game.id,
+                "message_id": 111,
+                "seconds": 0,
+                "active": True,
+            },
         },
     )
 
@@ -640,7 +655,7 @@ async def test_auto_start_tick_triggers_game_start_when_zero():
     table_manager.save_game.assert_awaited_once_with(chat_id, game)
     job.schedule_removal.assert_called_once()
     assert "start_countdown" not in context.chat_data
-    assert KEY_PRESTART_COUNTDOWN_ACTIVE not in context.chat_data
+    assert KEY_PRESTART_COUNTDOWN_STATE not in context.chat_data
     assert view._cancel_prestart_countdown.await_count == 1
 
 
@@ -672,8 +687,11 @@ async def test_auto_start_tick_creates_message_when_missing():
     assert game.ready_message_main_id == 999
     assert view.start_prestart_countdown.await_count == 1
     call_kwargs = view.start_prestart_countdown.await_args.kwargs
-    assert call_kwargs["anchor_message_id"] == 999
+    assert call_kwargs["message_id"] == 999
+    assert call_kwargs["game_id"] == game.id
     assert context.chat_data["start_countdown"] == 2
+    state = context.chat_data[KEY_PRESTART_COUNTDOWN_STATE]
+    assert state["message_id"] == 999
 
 
 @pytest.mark.asyncio
@@ -700,8 +718,9 @@ async def test_auto_start_tick_does_not_start_when_message_creation_fails():
 
     assert view.start_prestart_countdown.await_count == 0
     assert context.chat_data["start_countdown"] == 3
-    assert context.chat_data[KEY_PRESTART_COUNTDOWN_ACTIVE] is False
-    view._cancel_prestart_countdown.assert_awaited_once_with(chat_id)
+    state = context.chat_data[KEY_PRESTART_COUNTDOWN_STATE]
+    assert state["active"] is False
+    view._cancel_prestart_countdown.assert_awaited_once_with(chat_id, game.id)
     table_manager.save_game.assert_not_awaited()
 
 

--- a/tests/test_pokerbotviewer.py
+++ b/tests/test_pokerbotviewer.py
@@ -181,8 +181,9 @@ def test_update_player_anchors_and_keyboards_highlights_active_player():
     assert 'Player One' in first_text
     assert '🪑 صندلی: 1' in first_text
     assert '🎖️ نقش: دیلر' in first_text
-    assert isinstance(first_call.kwargs['reply_markup'], ReplyKeyboardMarkup)
-    board_row = _row_texts(first_call.kwargs['reply_markup'].keyboard[1])
+    first_markup = first_call.kwargs['reply_markup']
+    assert isinstance(first_markup, InlineKeyboardMarkup)
+    board_row = [button.text for button in first_markup.inline_keyboard[1]]
     assert board_row == ['A♠', 'K♦', '5♣']
 
     assert second_call.kwargs['message_id'] == 202
@@ -252,13 +253,12 @@ def test_build_player_cards_keyboard_layout():
         current_stage='FLOP',
     )
 
-    assert isinstance(markup, ReplyKeyboardMarkup)
-    assert markup.resize_keyboard is True
-    assert markup.one_time_keyboard is False
-    assert markup.selective is True
-    assert _row_texts(markup.keyboard[0]) == ['A♠', 'K♥']
-    assert _row_texts(markup.keyboard[1]) == ['❔', '5♦', '❔', '❔', '❔']
-    stage_row = _row_texts(markup.keyboard[2])
+    assert isinstance(markup, InlineKeyboardMarkup)
+    first_row = [button.text for button in markup.inline_keyboard[0]]
+    assert first_row == ['A♠', 'K♥']
+    community_row = [button.text for button in markup.inline_keyboard[1]]
+    assert community_row == ['❔', '5♦', '❔', '❔', '❔']
+    stage_row = [button.text for button in markup.inline_keyboard[2]]
     assert stage_row[0] == 'پری فلاپ'
     assert stage_row[1].startswith('✅')
     assert stage_row[2] == 'ترن'


### PR DESCRIPTION
## Summary
- convert player role anchors to inline keyboards per player and ensure anchor deletions cancel pending edits
- rework prestart countdowns to track by (chat, game) context and invoke the new start_hand entry point from countdowns and buttons
- adjust readiness messaging layout and update the test suite for the inline keyboard and countdown changes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1726515e08328b8b4b50af87336d9