### PR TITLE
feat: show group reply keyboard for anchors

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -1929,9 +1929,6 @@ class PokerBotModel:
             stage_lock = await self._get_stage_lock(chat_id)
             async with stage_lock:
                 await self._view.send_player_role_anchors(game=game, chat_id=chat_id)
-                await self._view.sync_player_private_keyboards(
-                    game, include_inactive=True
-                )
 
             action_str = "بازی شروع شد"
             game.last_actions.append(action_str)
@@ -2153,7 +2150,6 @@ class PokerBotModel:
             async with stage_lock:
                 game.chat_id = chat_id
                 await self._view.update_player_anchors_and_keyboards(game)
-                await self._view.sync_player_private_keyboards(game)
 
                 money = await player.wallet.value()
                 recent_actions = list(game.last_actions)
@@ -2386,7 +2382,6 @@ class PokerBotModel:
                 game.state = next_state
                 await self.add_cards_to_table(card_count, game, chat_id, stage_label)
                 await self._view.update_player_anchors_and_keyboards(game)
-                await self._view.sync_player_private_keyboards(game)
             elif game.state == GameState.ROUND_RIVER:
                 # بعد از ریور، دور شرط‌بندی تمام شده و باید showdown انجام شود
                 await self._showdown(game, chat_id, context)

--- a/tests/test_pokerbotmodel.py
+++ b/tests/test_pokerbotmodel.py
@@ -277,12 +277,7 @@ async def test_register_player_identity_updates_active_game_private_chat():
     assert model._private_chat_ids[player.user_id] == 999
     table_manager.save_game.assert_awaited_once_with(chat_id, game)
 
-    await view.sync_player_private_keyboards(game)
-
-    view._send_player_private_keyboard.assert_awaited_once()
-    send_call = view._send_player_private_keyboard.await_args
-    assert send_call.kwargs["player"] is player
-    assert send_call.kwargs["game"] is game
+    view._send_player_private_keyboard.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -486,7 +481,7 @@ def test_send_turn_message_updates_turn_message_only():
     assert game.turn_message_id == 321
     view.update_turn_message.assert_awaited_once()
     view.update_player_anchors_and_keyboards.assert_awaited_once_with(game)
-    view.sync_player_private_keyboards.assert_awaited_once_with(game)
+    view.sync_player_private_keyboards.assert_not_awaited()
 
 
 def test_add_cards_to_table_does_not_send_stage_message():
@@ -945,9 +940,7 @@ async def test_start_game_assigns_blinds_to_occupied_seats():
     assert blind_players == {1, 2}
 
     view.send_player_role_anchors.assert_awaited_once_with(game=game, chat_id=chat_id)
-    view.sync_player_private_keyboards.assert_awaited_once_with(
-        game, include_inactive=True
-    )
+    view.sync_player_private_keyboards.assert_not_awaited()
 
     model._send_turn_message.assert_awaited_once()
     send_call = model._send_turn_message.await_args
@@ -995,9 +988,7 @@ async def test_start_game_keeps_ready_message_id_when_deletion_fails():
     model._divide_cards.assert_awaited_once_with(game, chat_id)
     model._round_rate.set_blinds.assert_awaited_once_with(game, chat_id)
     view.send_player_role_anchors.assert_awaited_once_with(game=game, chat_id=chat_id)
-    view.sync_player_private_keyboards.assert_awaited_once_with(
-        game, include_inactive=True
-    )
+    view.sync_player_private_keyboards.assert_not_awaited()
 
 
 def test_send_turn_message_updates_existing_message():


### PR DESCRIPTION
## Summary
- attach a shared reply keyboard to anchor updates using new card-formatting helpers and forced message edits so the group always sees refreshed hole and board cards
- drop the private keyboard sync flow in favour of the anchor keyboard and clear it at showdown with a ReplyKeyboardRemove

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1a07fc5b08328982bc3b2c7aed3fb