### PR TITLE
Normalize chat id when deleting reply keyboard message

### DIFF
--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -1327,14 +1327,14 @@ class PokerBotViewer:
                             else None
                         )
                         if (
-                            isinstance(chat_id, int)
-                            and resolved_new_id is not None
+                            resolved_new_id is not None
                             and resolved_new_id != normalized_existing_message
+                            and normalized_chat != 0
                         ):
                             async def _delete_replaced_message() -> None:
                                 try:
                                     await self._messenger.delete_message(
-                                        chat_id=int(chat_id),
+                                        chat_id=normalized_chat,
                                         message_id=normalized_existing_message,
                                         request_category=RequestCategory.DELETE,
                                     )

--- a/tests/test_pokerbotviewer.py
+++ b/tests/test_pokerbotviewer.py
@@ -319,7 +319,8 @@ def test_build_player_cards_keyboard_layout():
     assert stage_row[3] == 'ریور'
 
 
-def test_update_message_resends_reply_keyboard_and_deletes_previous():
+@pytest.mark.parametrize("chat_id", (-123, "-123"))
+def test_update_message_resends_reply_keyboard_and_deletes_previous(chat_id):
     viewer = PokerBotViewer(bot=MagicMock())
     messenger = MagicMock()
     messenger.send_message = AsyncMock(
@@ -337,7 +338,7 @@ def test_update_message_resends_reply_keyboard_and_deletes_previous():
 
     result = run(
         viewer._update_message(
-            chat_id=-123,
+            chat_id=chat_id,
             message_id=555,
             text='به‌روزرسانی',
             reply_markup=keyboard,
@@ -351,7 +352,7 @@ def test_update_message_resends_reply_keyboard_and_deletes_previous():
     messenger.edit_message_text.assert_not_awaited()
     messenger.delete_message.assert_awaited_once()
     delete_call = messenger.delete_message.await_args
-    assert delete_call.kwargs['chat_id'] == -123
+    assert delete_call.kwargs['chat_id'] == int(chat_id)
     assert delete_call.kwargs['message_id'] == 555
 
 


### PR DESCRIPTION
## Summary
- ensure reply keyboard cleanup reuses the normalized chat id so replacement messages are deleted for string chat identifiers
- extend the PokerBotViewer test to cover integer and string chat ids when asserting delete_message usage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d22576000483288ddf72e0d39af718