### PR TITLE
Improve role anchor edit resilience

### DIFF
--- a/tests/test_pokerbotviewer.py
+++ b/tests/test_pokerbotviewer.py
@@ -191,6 +191,8 @@ def test_update_player_anchors_and_keyboards_highlights_active_player():
         reply_markup=keyboard_one,
         stage_name=stage_name,
         community_cards=community_cards,
+        hole_cards=viewer._extract_player_hole_cards(player_one),
+        turn_indicator="",
     )
     viewer._anchor_registry.register_role(
         game.chat_id,
@@ -219,6 +221,8 @@ def test_update_player_anchors_and_keyboards_highlights_active_player():
         reply_markup=keyboard_two,
         stage_name=stage_name,
         community_cards=community_cards,
+        hole_cards=viewer._extract_player_hole_cards(player_two),
+        turn_indicator="",
     )
     viewer._anchor_registry.register_role(
         game.chat_id,


### PR DESCRIPTION
## Summary
- track the last Telegram edit error in `MessagingService` and mark anchors deleted when Telegram reports missing or uneditable messages
- reuse existing role anchor messages wherever possible and update them with an edit-first strategy that retries on rate limits, forces text refreshes when needed, and validates before falling back to a resend
- expand anchor payload hashing to cover hole cards and turn indicators, add diagnostics around fallbacks, and update viewer tests for the new signatures

## Testing
- pytest
- pytest tests/test_pokerbotviewer.py

------
https://chatgpt.com/codex/tasks/task_e_68d253ec8c2c8328b420aa21ab2c931d