### PR TITLE
Strengthen anchor deletion safeguards

### DIFF
--- a/tests/test_pokerbotviewer.py
+++ b/tests/test_pokerbotviewer.py
@@ -309,7 +309,11 @@ def test_clear_all_player_anchors_deletes_messages():
     run(viewer.clear_all_player_anchors(game))
 
     viewer.delete_message.assert_awaited_once_with(
-        chat_id=game.chat_id, message_id=404, allow_anchor_deletion=True
+        chat_id=game.chat_id,
+        message_id=404,
+        allow_anchor_deletion=True,
+        game=game,
+        reason="hand_end",
     )
     assert player.anchor_message is None
     assert player.anchor_role == 'بازیکن'
@@ -439,6 +443,7 @@ def test_delete_message_allows_anchor_cleanup_after_hand():
             chat_id=chat_id,
             message_id=message_id,
             allow_anchor_deletion=True,
+            reason="hand_end",
         )
     )
 


### PR DESCRIPTION
## Summary
- tighten role anchor deletion guards to require explicit reasons, skip protected stages, and log allowed removals
- refresh existing anchors instead of deleting them mid-hand and abort fallback recreation when deletion is blocked
- update viewer unit tests to exercise the stricter cleanup policy

## Testing
- pytest tests/test_pokerbotviewer.py tests/test_pokerbotmodel.py

------
https://chatgpt.com/codex/tasks/task_e_68d275ec00b483289b72fdbb3b128876