### PR TITLE
Normalize anchor ID comparison during cleanup

### DIFF
--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -3172,13 +3172,14 @@ class PokerBotViewer:
         active_players: List[Player] = [
             player for player in getattr(game, "players", []) if player is not None
         ]
-        active_ids: Set[Any] = {
-            getattr(player, "user_id", None) for player in active_players if player is not None
-        }
+        active_ids: Set[int] = set()
+        for player in active_players:
+            normalized_id = self._safe_int(getattr(player, "user_id", None))
+            active_ids.add(normalized_id)
 
         # Remove anchors for players who are no longer seated.
         for player_id, record in list(state.role_anchors.items()):
-            if player_id in active_ids:
+            if self._safe_int(player_id) in active_ids:
                 continue
             message_id = getattr(record, "message_id", None)
             if message_id:

--- a/tests/test_pokerbotviewer.py
+++ b/tests/test_pokerbotviewer.py
@@ -135,6 +135,40 @@ def test_notify_admin_failure_logs_error(caplog):
 
 
 
+def test_clear_all_player_anchors_preserves_anchor_for_string_registry_id():
+    viewer = PokerBotViewer(bot=MagicMock())
+    viewer.delete_message = AsyncMock()
+    viewer.update_player_anchors_and_keyboards = AsyncMock()
+
+    game = Game()
+    game.chat_id = -1234
+    game.state = GameState.INITIAL
+
+    player = Player(
+        user_id=123,
+        mention_markdown="@player",
+        wallet=MagicMock(),
+        ready_message_id="ready-msg",
+    )
+    game.add_player(player, seat_index=0)
+
+    viewer._anchor_registry.register_role(
+        game.chat_id,
+        player_id="123",
+        seat_index=0,
+        message_id=999,
+        base_text="anchor",
+        payload_signature="payload",
+        markup_signature="markup",
+    )
+
+    run(viewer.clear_all_player_anchors(game))
+
+    viewer.delete_message.assert_not_awaited()
+    state = viewer._anchor_registry.get_chat_state(game.chat_id)
+    assert "123" in state.role_anchors
+
+
 def test_update_player_anchors_and_keyboards_highlights_active_player():
     viewer = PokerBotViewer(bot=MagicMock())
     viewer._update_message = AsyncMock(return_value=101)


### PR DESCRIPTION
## Summary
- normalize player anchor cleanup to compare normalized player identifiers
- add a regression test covering string registry ids vs integer player ids

## Testing
- pytest tests/test_pokerbotviewer.py -k string_registry -q


------
https://chatgpt.com/codex/tasks/task_e_68d27fe894608328b0d1dbf74639e2dd