### PR TITLE
Extract foundational game engine utilities

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -1,0 +1,36 @@
+"""Core game engine utilities for PokerBot."""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import Any
+
+from pokerapp.entities import GameState
+
+logger = logging.getLogger(__name__)
+
+
+class GameEngine:
+    """Coordinates game-level constants and helpers."""
+
+    ACTIVE_GAME_STATES = {
+        GameState.ROUND_PRE_FLOP,
+        GameState.ROUND_FLOP,
+        GameState.ROUND_TURN,
+        GameState.ROUND_RIVER,
+    }
+
+    MAX_TIME_FOR_TURN = datetime.timedelta(minutes=2)
+
+    @staticmethod
+    def state_token(state: Any) -> str:
+        """Return a token representing the provided state."""
+
+        name = getattr(state, "name", None)
+        if isinstance(name, str):
+            return name
+        value = getattr(state, "value", None)
+        if isinstance(value, str):
+            return value
+        return str(state)


### PR DESCRIPTION
## Summary
- add a GameEngine module that centralizes active game state tracking, turn timeout, and state token helper
- update PokerBotModel to instantiate the GameEngine and delegate state-token lookups and active state checks
- export timing constants via the new engine while preserving compatibility with existing interfaces

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2d81041d08328a99310f7b5cdc2d4