### PR TITLE
Refactor stop logic into game engine

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -5,15 +5,26 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, Dict, Optional, Set
 
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
+from telegram.helpers import mention_markdown as format_mention_markdown
 
-from pokerapp.entities import ChatId, Game, GameState, Player
+from pokerapp.entities import (
+    ChatId,
+    Game,
+    GameState,
+    MessageId,
+    Player,
+    PlayerState,
+    UserException,
+    UserId,
+)
 from pokerapp.pokerbotview import PokerBotViewer
 from pokerapp.stats import BaseStatsService, NullStatsService, PlayerIdentity
 from pokerapp.table_manager import TableManager
-from pokerapp.utils.request_metrics import RequestMetrics
+from pokerapp.utils.request_metrics import RequestCategory, RequestMetrics
 from pokerapp.winnerdetermination import WinnerDetermination
 
 
@@ -35,6 +46,9 @@ class GameEngine:
     KEY_START_COUNTDOWN_LAST_TEXT = "start_countdown_last_text"
     KEY_START_COUNTDOWN_LAST_TIMESTAMP = "start_countdown_last_timestamp"
     KEY_START_COUNTDOWN_CONTEXT = "start_countdown_context"
+    KEY_STOP_REQUEST = "stop_request"
+    STOP_CONFIRM_CALLBACK = "stop:confirm"
+    STOP_RESUME_CALLBACK = "stop:resume"
 
     def __init__(
         self,
@@ -52,6 +66,7 @@ class GameEngine:
         build_identity_from_player: Callable[[Player], PlayerIdentity],
         safe_int: Callable[[ChatId], int],
         old_players_key: str,
+        safe_edit_message_text: Callable[..., Awaitable[Optional[MessageId]]],
         logger: logging.Logger,
     ) -> None:
         self._table_manager = table_manager
@@ -67,6 +82,7 @@ class GameEngine:
         self._build_identity_from_player = build_identity_from_player
         self._safe_int = safe_int
         self._old_players_key = old_players_key
+        self._safe_edit_message_text = safe_edit_message_text
         self._logger = logger
 
     @staticmethod
@@ -211,3 +227,242 @@ class GameEngine:
 
             cards = [game.remain_cards.pop(), game.remain_cards.pop()]
             player.cards = cards
+
+    async def stop_game(
+        self,
+        context: ContextTypes.DEFAULT_TYPE,
+        game: Game,
+        chat_id: ChatId,
+        requester_id: UserId,
+    ) -> None:
+        """Validate and submit a stop request for the active hand."""
+
+        if game.state == GameState.INITIAL:
+            raise UserException("بازی فعالی برای توقف وجود ندارد.")
+
+        if not any(player.user_id == requester_id for player in game.seated_players()):
+            raise UserException("فقط بازیکنان حاضر می‌توانند درخواست توقف بدهند.")
+
+        await self.request_stop(
+            context=context,
+            game=game,
+            chat_id=chat_id,
+            requester_id=requester_id,
+        )
+        await self._table_manager.save_game(chat_id, game)
+
+    async def request_stop(
+        self,
+        context: ContextTypes.DEFAULT_TYPE,
+        game: Game,
+        chat_id: ChatId,
+        requester_id: UserId,
+    ) -> None:
+        """Create or update a stop request vote and announce it to the chat."""
+
+        active_players = [
+            player
+            for player in game.seated_players()
+            if player.state in (PlayerState.ACTIVE, PlayerState.ALL_IN)
+        ]
+        if not active_players:
+            raise UserException("هیچ بازیکن فعالی برای رأی‌گیری وجود ندارد.")
+
+        stop_request = context.chat_data.get(self.KEY_STOP_REQUEST)
+        if not stop_request or stop_request.get("game_id") != game.id:
+            stop_request = {
+                "game_id": game.id,
+                "active_players": [player.user_id for player in active_players],
+                "votes": set(),
+                "initiator": requester_id,
+                "message_id": None,
+                "manager_override": False,
+            }
+        else:
+            stop_request.setdefault("votes", set())
+            stop_request.setdefault("active_players", [])
+            stop_request.setdefault("manager_override", False)
+            stop_request["active_players"] = [
+                player.user_id for player in active_players
+            ]
+
+        votes: Set[UserId] = set(stop_request.get("votes", set()))
+        if requester_id in stop_request["active_players"]:
+            votes.add(requester_id)
+        stop_request["votes"] = votes
+
+        message_text = self.render_stop_request_message(
+            game=game,
+            stop_request=stop_request,
+            context=context,
+        )
+
+        message_id = await self._safe_edit_message_text(
+            chat_id,
+            stop_request.get("message_id"),
+            message_text,
+            reply_markup=self.build_stop_request_markup(),
+            request_category=RequestCategory.GENERAL,
+        )
+        stop_request["message_id"] = message_id
+        context.chat_data[self.KEY_STOP_REQUEST] = stop_request
+
+    def build_stop_request_markup(self) -> InlineKeyboardMarkup:
+        """Return the inline keyboard used for stop confirmations."""
+
+        keyboard = [
+            [
+                InlineKeyboardButton(
+                    text="تأیید توقف", callback_data=self.STOP_CONFIRM_CALLBACK
+                ),
+                InlineKeyboardButton(
+                    text="ادامه بازی", callback_data=self.STOP_RESUME_CALLBACK
+                ),
+            ]
+        ]
+        return InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+    def render_stop_request_message(
+        self,
+        *,
+        game: Game,
+        stop_request: Dict[str, object],
+        context: ContextTypes.DEFAULT_TYPE,
+    ) -> str:
+        """Build the Markdown message describing the current stop vote."""
+
+        active_ids = set(stop_request.get("active_players", []))
+        votes = set(stop_request.get("votes", set()))
+        active_players = [
+            player
+            for player in game.seated_players()
+            if player.user_id in active_ids
+        ]
+        initiator_id = stop_request.get("initiator")
+        initiator_player = next(
+            (player for player in game.seated_players() if player.user_id == initiator_id),
+            None,
+        )
+        if initiator_player:
+            initiator_text = initiator_player.mention_markdown
+        else:
+            initiator_text = format_mention_markdown(initiator_id, str(initiator_id))
+
+        manager_id = context.chat_data.get("game_manager_id")
+        manager_player = None
+        if manager_id:
+            manager_player = next(
+                (player for player in game.seated_players() if player.user_id == manager_id),
+                None,
+            )
+
+        required_votes = (len(active_players) // 2) + 1 if active_players else 0
+        confirmed_votes = len(votes & {player.user_id for player in active_players})
+
+        active_lines = []
+        for player in active_players:
+            mark = "✅" if player.user_id in votes else "⬜️"
+            active_lines.append(f"{mark} {player.mention_markdown}")
+        if not active_lines:
+            active_lines.append("—")
+
+        lines = [
+            "🛑 *درخواست توقف بازی*",
+            f"درخواست توسط {initiator_text}",
+            "",
+            "بازیکنان فعال:",
+            *active_lines,
+            "",
+        ]
+
+        if active_players:
+            lines.append(f"آراء تأیید: {confirmed_votes}/{required_votes}")
+        else:
+            lines.append("آراء تأیید: 0/0")
+
+        if manager_player:
+            lines.extend(
+                [
+                    "",
+                    f"👤 مدیر بازی: {manager_player.mention_markdown}",
+                    "او می‌تواند به تنهایی رأی توقف را تأیید کند.",
+                ]
+            )
+
+        if votes - {player.user_id for player in active_players}:
+            extra_voters = votes - {player.user_id for player in active_players}
+            voter_mentions = []
+            for voter_id in extra_voters:
+                player = next(
+                    (p for p in game.seated_players() if p.user_id == voter_id),
+                    None,
+                )
+                if player:
+                    voter_mentions.append(player.mention_markdown)
+                else:
+                    voter_mentions.append(
+                        format_mention_markdown(voter_id, str(voter_id))
+                    )
+            lines.extend(
+                [
+                    "",
+                    "رأی سایر افراد:",
+                    *voter_mentions,
+                ]
+            )
+
+        return "\n".join(lines)
+
+    async def cancel_hand(
+        self,
+        game: Game,
+        chat_id: ChatId,
+        context: ContextTypes.DEFAULT_TYPE,
+        stop_request: Dict[str, object],
+    ) -> None:
+        """Cancel the current hand, refund players, and reset the game."""
+
+        original_game_id = game.id
+        players_snapshot = list(game.seated_players())
+
+        for player in players_snapshot:
+            if player.wallet:
+                await player.wallet.cancel(original_game_id)
+
+        game.pot = 0
+
+        active_ids = set(stop_request.get("active_players", []))
+        votes = set(stop_request.get("votes", set()))
+        manager_override = stop_request.get("manager_override", False)
+
+        approved_votes = len(votes & active_ids)
+        required_votes = (len(active_ids) // 2) + 1 if active_ids else 0
+
+        if manager_override:
+            summary_line = "🛑 *مدیر بازی بازی را متوقف کرد.*"
+        else:
+            summary_line = "🛑 *بازی با رأی اکثریت متوقف شد.*"
+
+        details = (
+            f"آراء تأیید: {approved_votes}/{required_votes}"
+            if active_ids
+            else "هیچ رأی فعالی ثبت نشد."
+        )
+
+        await self._safe_edit_message_text(
+            chat_id,
+            stop_request.get("message_id"),
+            "\n".join([summary_line, details]),
+            reply_markup=None,
+            request_category=RequestCategory.GENERAL,
+        )
+
+        context.chat_data.pop(self.KEY_STOP_REQUEST, None)
+
+        await self._request_metrics.end_cycle(
+            self._safe_int(chat_id), cycle_token=game.id
+        )
+        await self._clear_player_anchors(game)
+        game.reset()
+        await self._table_manager.save_game(chat_id, game)
+        await self._view.send_message(chat_id, "🛑 بازی متوقف شد.")

--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -88,10 +88,10 @@ KEY_START_COUNTDOWN_CONTEXT = GameEngine.KEY_START_COUNTDOWN_CONTEXT
 # legacy keys kept for backward compatibility but unused
 KEY_OLD_PLAYERS = "old_players"
 KEY_CHAT_DATA_GAME = "game"
-KEY_STOP_REQUEST = "stop_request"
+KEY_STOP_REQUEST = GameEngine.KEY_STOP_REQUEST
 
-STOP_CONFIRM_CALLBACK = "stop:confirm"
-STOP_RESUME_CALLBACK = "stop:resume"
+STOP_CONFIRM_CALLBACK = GameEngine.STOP_CONFIRM_CALLBACK
+STOP_RESUME_CALLBACK = GameEngine.STOP_RESUME_CALLBACK
 
 # MAX_PLAYERS = 8 (Defined in entities)
 # MIN_PLAYERS = 2 (Defined in entities)
@@ -210,6 +210,7 @@ class PokerBotModel:
             build_identity_from_player=self._build_identity_from_player,
             safe_int=self._safe_int,
             old_players_key=KEY_OLD_PLAYERS,
+            safe_edit_message_text=self._safe_edit_message_text,
             logger=logger.getChild("game_engine"),
         )
 
@@ -1378,173 +1379,12 @@ class PokerBotModel:
             game, chat_id = await self._get_game_by_user(user_id)
             context.chat_data[KEY_CHAT_DATA_GAME] = game
 
-        if game.state == GameState.INITIAL:
-            raise UserException("بازی فعالی برای توقف وجود ندارد.")
-
-        if not any(player.user_id == user_id for player in game.seated_players()):
-            raise UserException("فقط بازیکنان حاضر می‌توانند درخواست توقف بدهند.")
-
-        await self._request_stop(context, game, chat_id, user_id)
-        await self._table_manager.save_game(chat_id, game)
-
-    async def _request_stop(
-        self,
-        context: ContextTypes.DEFAULT_TYPE,
-        game: Game,
-        chat_id: ChatId,
-        requester_id: UserId,
-    ) -> None:
-        """Create or update a stop request vote and announce it to the chat."""
-
-        active_players = [
-            p
-            for p in game.seated_players()
-            if p.state in (PlayerState.ACTIVE, PlayerState.ALL_IN)
-        ]
-        if not active_players:
-            raise UserException("هیچ بازیکن فعالی برای رأی‌گیری وجود ندارد.")
-
-        stop_request = context.chat_data.get(KEY_STOP_REQUEST)
-        if not stop_request or stop_request.get("game_id") != game.id:
-            stop_request = {
-                "game_id": game.id,
-                "active_players": [p.user_id for p in active_players],
-                "votes": set(),
-                "initiator": requester_id,
-                "message_id": None,
-                "manager_override": False,
-            }
-        else:
-            stop_request.setdefault("votes", set())
-            stop_request.setdefault("active_players", [])
-            stop_request.setdefault("manager_override", False)
-            stop_request["active_players"] = [p.user_id for p in active_players]
-
-        votes = set(stop_request.get("votes", set()))
-        if requester_id in stop_request["active_players"]:
-            votes.add(requester_id)
-        stop_request["votes"] = votes
-
-        message_text = self._render_stop_request_message(
-            game=game,
-            stop_request=stop_request,
+        await self._game_engine.stop_game(
             context=context,
+            game=game,
+            chat_id=chat_id,
+            requester_id=user_id,
         )
-
-        message_id = await self._safe_edit_message_text(
-            chat_id,
-            stop_request.get("message_id"),
-            message_text,
-            reply_markup=self._build_stop_request_markup(),
-            request_category=RequestCategory.GENERAL,
-        )
-        stop_request["message_id"] = message_id
-        context.chat_data[KEY_STOP_REQUEST] = stop_request
-
-    def _build_stop_request_markup(self) -> InlineKeyboardMarkup:
-        """Return the inline keyboard used for stop confirmations."""
-
-        keyboard = [
-            [
-                InlineKeyboardButton(
-                    text="تأیید توقف", callback_data=STOP_CONFIRM_CALLBACK
-                ),
-                InlineKeyboardButton(
-                    text="ادامه بازی", callback_data=STOP_RESUME_CALLBACK
-                ),
-            ]
-        ]
-        return InlineKeyboardMarkup(inline_keyboard=keyboard)
-
-    def _render_stop_request_message(
-        self,
-        game: Game,
-        stop_request: Dict[str, object],
-        context: ContextTypes.DEFAULT_TYPE,
-    ) -> str:
-        """Build the Markdown message describing the current stop vote."""
-
-        active_ids = set(stop_request.get("active_players", []))
-        votes = set(stop_request.get("votes", set()))
-        active_players = [
-            player
-            for player in game.seated_players()
-            if player.user_id in active_ids
-        ]
-        initiator_id = stop_request.get("initiator")
-        initiator_player = next(
-            (p for p in game.seated_players() if p.user_id == initiator_id),
-            None,
-        )
-        if initiator_player:
-            initiator_text = initiator_player.mention_markdown
-        else:
-            initiator_text = format_mention_markdown(initiator_id, str(initiator_id))
-
-        manager_id = context.chat_data.get("game_manager_id")
-        manager_player = None
-        if manager_id:
-            manager_player = next(
-                (p for p in game.seated_players() if p.user_id == manager_id),
-                None,
-            )
-
-        required_votes = (len(active_players) // 2) + 1 if active_players else 0
-        confirmed_votes = len(votes & {p.user_id for p in active_players})
-
-        active_lines = []
-        for player in active_players:
-            mark = "✅" if player.user_id in votes else "⬜️"
-            active_lines.append(f"{mark} {player.mention_markdown}")
-        if not active_lines:
-            active_lines.append("—")
-
-        lines = [
-            "🛑 *درخواست توقف بازی*",
-            f"درخواست توسط {initiator_text}",
-            "",
-            "بازیکنان فعال:",
-            *active_lines,
-            "",
-        ]
-
-        if active_players:
-            lines.append(f"آراء تأیید: {confirmed_votes}/{required_votes}")
-        else:
-            lines.append("آراء تأیید: 0/0")
-
-        if manager_player:
-            lines.extend(
-                [
-                    "",
-                    f"👤 مدیر بازی: {manager_player.mention_markdown}",
-                    "او می‌تواند به تنهایی رأی توقف را تأیید کند.",
-                ]
-            )
-
-        if votes - {p.user_id for p in active_players}:
-            extra_voters = votes - {p.user_id for p in active_players}
-            voter_mentions = []
-            for voter_id in extra_voters:
-                player = next(
-                    (p for p in game.seated_players() if p.user_id == voter_id),
-                    None,
-                )
-                if player:
-                    voter_mentions.append(player.mention_markdown)
-                else:
-                    voter_mentions.append(
-                        format_mention_markdown(voter_id, str(voter_id))
-                    )
-            lines.extend(
-                [
-                    "",
-                    "رأی سایر افراد:",
-                    *voter_mentions,
-                ]
-            )
-
-        return "\n".join(lines)
 
     async def confirm_stop_vote(
         self, update: Update, context: ContextTypes.DEFAULT_TYPE
@@ -1569,7 +1409,7 @@ class PokerBotModel:
         stop_request["votes"] = votes
         stop_request["manager_override"] = bool(manager_id and user_id == manager_id)
 
-        message_text = self._render_stop_request_message(
+        message_text = self._game_engine.render_stop_request_message(
             game=game,
             stop_request=stop_request,
             context=context,
@@ -1579,7 +1419,7 @@ class PokerBotModel:
             chat_id,
             stop_request.get("message_id"),
             message_text,
-            reply_markup=self._build_stop_request_markup(),
+            reply_markup=self._game_engine.build_stop_request_markup(),
             request_category=RequestCategory.GENERAL,
         )
         stop_request["message_id"] = message_id
@@ -1589,11 +1429,11 @@ class PokerBotModel:
         required_votes = (len(active_ids) // 2) + 1 if active_ids else 0
 
         if stop_request.get("manager_override"):
-            await self._cancel_hand(game, chat_id, context, stop_request)
+            await self._game_engine.cancel_hand(game, chat_id, context, stop_request)
             return
 
         if active_ids and active_votes >= required_votes:
-            await self._cancel_hand(game, chat_id, context, stop_request)
+            await self._game_engine.cancel_hand(game, chat_id, context, stop_request)
 
     async def resume_stop_vote(
         self, update: Update, context: ContextTypes.DEFAULT_TYPE
@@ -1616,60 +1456,6 @@ class PokerBotModel:
             reply_markup=None,
             request_category=RequestCategory.GENERAL,
         )
-
-    async def _cancel_hand(
-        self,
-        game: Game,
-        chat_id: ChatId,
-        context: ContextTypes.DEFAULT_TYPE,
-        stop_request: Dict[str, object],
-    ) -> None:
-        """Cancel the current hand, refund players, and reset the game."""
-
-        original_game_id = game.id
-        players_snapshot = list(game.seated_players())
-
-        for player in players_snapshot:
-            if player.wallet:
-                await player.wallet.cancel(original_game_id)
-
-        game.pot = 0
-
-        active_ids = set(stop_request.get("active_players", []))
-        votes = set(stop_request.get("votes", set()))
-        manager_override = stop_request.get("manager_override", False)
-
-        approved_votes = len(votes & active_ids)
-        required_votes = (len(active_ids) // 2) + 1 if active_ids else 0
-
-        if manager_override:
-            summary_line = "🛑 *مدیر بازی بازی را متوقف کرد.*"
-        else:
-            summary_line = "🛑 *بازی با رأی اکثریت متوقف شد.*"
-
-        details = (
-            f"آراء تأیید: {approved_votes}/{required_votes}"
-            if active_ids
-            else "هیچ رأی فعالی ثبت نشد."
-        )
-
-        await self._safe_edit_message_text(
-            chat_id,
-            stop_request.get("message_id"),
-            "\n".join([summary_line, details]),
-            reply_markup=None,
-            request_category=RequestCategory.GENERAL,
-        )
-
-        context.chat_data.pop(KEY_STOP_REQUEST, None)
-
-        await self._request_metrics.end_cycle(
-            self._safe_int(chat_id), cycle_token=game.id
-        )
-        await self._clear_player_anchors(game)
-        game.reset()
-        await self._table_manager.save_game(chat_id, game)
-        await self._view.send_message(chat_id, "🛑 بازی متوقف شد.")
 
     async def _start_game(
         self, context: CallbackContext, game: Game, chat_id: ChatId


### PR DESCRIPTION
## Summary
- move the stop request constants and message helpers from PokerBotModel into GameEngine
- expose new GameEngine stop, request stop, and cancel helpers and delegate PokerBotModel workflows to them
- adjust tests to exercise the new GameEngine interfaces for stop flows

## Testing
- pytest tests/test_pokerbotmodel.py -k stop

------
https://chatgpt.com/codex/tasks/task_e_68d2e1fa49e083288f187a3086fd4cb6