### PR TITLE
Refactor locking with centralized manager and add timeout handling

### DIFF
--- a/pokerapp/lock_manager.py
+++ b/pokerapp/lock_manager.py
@@ -1,0 +1,139 @@
+"""Centralized asynchronous lock management for the poker bot."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Dict, Optional
+
+from pokerapp.utils.locks import ReentrantAsyncLock
+
+
+class LockManager:
+    """Manage keyed re-entrant async locks with timeout and retry support."""
+
+    def __init__(
+        self,
+        *,
+        logger: logging.Logger,
+        default_timeout_seconds: Optional[float] = 5,
+        max_retries: int = 3,
+        retry_backoff_seconds: float = 1,
+    ) -> None:
+        self._logger = logger
+        self._default_timeout_seconds = default_timeout_seconds
+        self._max_retries = max(0, max_retries)
+        self._retry_backoff_seconds = max(0.0, retry_backoff_seconds)
+        self._locks: Dict[str, ReentrantAsyncLock] = {}
+        self._locks_guard = asyncio.Lock()
+
+    async def _get_lock(self, key: str) -> ReentrantAsyncLock:
+        async with self._locks_guard:
+            lock = self._locks.get(key)
+            if lock is None:
+                lock = ReentrantAsyncLock()
+                self._locks[key] = lock
+            return lock
+
+    async def acquire(self, key: str, timeout: Optional[float] = None) -> bool:
+        """Attempt to acquire the lock identified by ``key``."""
+
+        lock = await self._get_lock(key)
+        total_timeout = self._default_timeout_seconds if timeout is None else timeout
+        deadline: Optional[float]
+        loop = asyncio.get_running_loop()
+        if total_timeout is None:
+            deadline = None
+        else:
+            deadline = loop.time() + max(0.0, total_timeout)
+
+        attempts = self._max_retries + 1
+        for attempt in range(attempts):
+            attempt_start = loop.time()
+            attempt_timeout: Optional[float]
+            if deadline is None:
+                attempt_timeout = None
+            else:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    break
+                remaining_attempts = attempts - attempt
+                attempt_timeout = remaining / remaining_attempts
+                if attempt_timeout <= 0:
+                    break
+
+            try:
+                if attempt_timeout is None:
+                    await lock.acquire()
+                else:
+                    await asyncio.wait_for(lock.acquire(), timeout=attempt_timeout)
+                elapsed = loop.time() - attempt_start
+                if attempt == 0 and elapsed < 0.1:
+                    self._logger.info(
+                        "Lock '%s' acquired quickly in %.3fs", key, elapsed
+                    )
+                else:
+                    self._logger.info(
+                        "Lock '%s' acquired after %d attempt(s) in %.3fs",
+                        key,
+                        attempt + 1,
+                        elapsed,
+                    )
+                return True
+            except asyncio.TimeoutError:
+                remaining = None
+                if deadline is not None:
+                    remaining = max(0.0, deadline - loop.time())
+                self._logger.warning(
+                    "Timeout acquiring lock '%s' on attempt %d (remaining %.3fs)",
+                    key,
+                    attempt + 1,
+                    remaining if remaining is not None else float("inf"),
+                )
+            except asyncio.CancelledError:
+                self._logger.warning(
+                    "Lock acquisition for '%s' cancelled on attempt %d", key, attempt + 1
+                )
+                raise
+
+            if attempt < attempts - 1:
+                backoff = self._retry_backoff_seconds * (2**attempt)
+                if backoff > 0:
+                    if deadline is None:
+                        await asyncio.sleep(backoff)
+                    else:
+                        remaining_sleep = deadline - loop.time()
+                        if remaining_sleep <= 0:
+                            break
+                        await asyncio.sleep(min(backoff, remaining_sleep))
+
+        self._logger.error("Failed to acquire lock '%s' after %d attempts", key, attempts)
+        return False
+
+    @asynccontextmanager
+    async def guard(self, key: str, timeout: Optional[float] = None) -> AsyncIterator[None]:
+        acquired = await self.acquire(key, timeout=timeout)
+        if not acquired:
+            message = f"Timeout acquiring lock '{key}'"
+            self._logger.warning(message)
+            raise TimeoutError(message)
+        try:
+            yield
+        finally:
+            self.release(key)
+
+    def release(self, key: str) -> None:
+        lock = self._locks.get(key)
+        if lock is None:
+            self._logger.debug("Release requested for unknown lock '%s'", key)
+            return
+        try:
+            lock.release()
+        except RuntimeError:
+            self._logger.exception(
+                "Failed to release lock '%s' due to ownership mismatch", key
+            )
+            raise
+
+__all__ = ["LockManager"]

--- a/tests/test_lock_manager.py
+++ b/tests/test_lock_manager.py
@@ -1,0 +1,91 @@
+import asyncio
+import logging
+from typing import List
+
+import pytest
+
+from pokerapp.lock_manager import LockManager
+
+
+class _ListHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: List[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - trivial
+        self.records.append(record)
+
+
+@pytest.mark.asyncio
+async def test_lock_manager_acquire_when_free() -> None:
+    logger = logging.getLogger("lock_manager_test_free")
+    manager = LockManager(logger=logger, default_timeout_seconds=1)
+
+    key = "stage:free"
+    acquired = await manager.acquire(key, timeout=0.5)
+    assert acquired
+    manager.release(key)
+
+
+@pytest.mark.asyncio
+async def test_lock_manager_retries_before_acquire() -> None:
+    logger = logging.getLogger("lock_manager_test_retry")
+    handler = _ListHandler()
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    manager = LockManager(
+        logger=logger,
+        default_timeout_seconds=0.5,
+        max_retries=2,
+        retry_backoff_seconds=0.05,
+    )
+
+    key = "stage:retry"
+
+    async def holder() -> None:
+        async with manager.guard(key, timeout=1):
+            await asyncio.sleep(0.3)
+
+    hold_task = asyncio.create_task(holder())
+    await asyncio.sleep(0.05)
+
+    try:
+        acquired = await manager.acquire(key, timeout=0.5)
+        assert acquired
+        manager.release(key)
+        await hold_task
+
+        assert any(
+            "Timeout acquiring lock" in record.getMessage()
+            for record in handler.records
+        )
+    finally:
+        if not hold_task.done():
+            await hold_task
+        logger.removeHandler(handler)
+
+
+@pytest.mark.asyncio
+async def test_lock_manager_guard_timeout() -> None:
+    logger = logging.getLogger("lock_manager_test_timeout")
+    manager = LockManager(
+        logger=logger,
+        default_timeout_seconds=0.1,
+        max_retries=1,
+        retry_backoff_seconds=0.05,
+    )
+
+    key = "stage:timeout"
+
+    async def holder() -> None:
+        async with manager.guard(key, timeout=1):
+            await asyncio.sleep(0.3)
+
+    hold_task = asyncio.create_task(holder())
+    await asyncio.sleep(0.05)
+
+    with pytest.raises(TimeoutError):
+        async with manager.guard(key, timeout=0.1):
+            pass
+
+    await hold_task


### PR DESCRIPTION
## Summary
- add a shared LockManager that manages re-entrant async locks with timeout, retry, and backoff logic
- wire the new manager into PokerBotModel and GameEngine so chat and stage critical sections use guarded contexts
- exercise the new behavior with lock manager tests covering successful acquisition, retry logging, and timeout handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2f933a2808328892e6f9c7632c299