### PR TITLE
Add adaptive player report cache with event-driven invalidation

### DIFF
--- a/pokerapp/player_manager.py
+++ b/pokerapp/player_manager.py
@@ -15,7 +15,7 @@ from pokerapp.entities import ChatId, Game, Player
 from pokerapp.pokerbotview import PokerBotViewer
 from pokerapp.stats import BaseStatsService, NullStatsService, PlayerIdentity
 from pokerapp.table_manager import TableManager
-from pokerapp.utils.cache import PlayerReportCache
+from pokerapp.utils.cache import AdaptivePlayerReportCache
 
 
 class PlayerManager:
@@ -34,7 +34,7 @@ class PlayerManager:
         table_manager: TableManager,
         kv: aioredis.Redis,
         stats_service: BaseStatsService,
-        player_report_cache: PlayerReportCache,
+        player_report_cache: AdaptivePlayerReportCache,
         view: PokerBotViewer,
         build_private_menu: Callable[[], object],
         logger: logging.Logger,
@@ -89,7 +89,10 @@ class PlayerManager:
         async def _load_report() -> Optional[Any]:
             return await self._stats_service.build_player_report(user_id_int)
 
-        report = await self._player_report_cache.get(user_id_int, _load_report)
+        report = await self._player_report_cache.get_with_context(
+            user_id_int,
+            _load_report,
+        )
         if report is None or (
             report.stats.total_games <= 0 and not report.recent_games
         ):


### PR DESCRIPTION
## Summary
- introduce AdaptivePlayerReportCache with change-type TTLs, persistent warm storage, and structured metrics/logging
- bind the adaptive cache into StatsService, PokerBotModel, and PlayerManager, invalidating stats on hands and bonus events
- add targeted tests covering cache hits, event-driven invalidation, persistent store interactions, and concurrency safety
- update performance documentation to reflect the adaptive caching strategy

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3015219648328aeb90e89071c34bd