### PR TITLE
Externalize game constants to configuration files

### DIFF
--- a/config/game_constants.yaml
+++ b/config/game_constants.yaml
@@ -1,0 +1,44 @@
+game:
+  dice_mult: 10
+  dice_delay_sec: 5
+  bonuses: [5, 20, 40, 80, 160, 320]
+  dices: "⚀⚁⚂⚃⚄⚅"
+  min_players: 2
+  max_players: 8
+  small_blind: 5
+  default_money: 1000
+  max_time_for_turn_seconds: 120
+  auto_start:
+    max_updates_per_minute: 20
+    min_update_interval_seconds: 3
+
+ui:
+  description_file: "assets/description_bot.md"
+  stages_persian: ["پری فلاپ", "فلاپ", "ترن", "ریور"]
+  stage_map:
+    ROUND_PRE_FLOP: "پری فلاپ"
+    PRE_FLOP: "پری فلاپ"
+    PRE-FLOP: "پری فلاپ"
+    ROUND_FLOP: "فلاپ"
+    FLOP: "فلاپ"
+    ROUND_TURN: "ترن"
+    TURN: "ترن"
+    ROUND_RIVER: "ریور"
+    RIVER: "ریور"
+
+redis:
+  private_match_queue_key: "pokerbot:private_matchmaking:queue"
+  private_match_user_key_prefix: "pokerbot:private_matchmaking:user:"
+  private_match_record_key_prefix: "pokerbot:private_matchmaking:match:"
+  private_match_queue_ttl: 180
+  private_match_state_ttl: 3600
+
+engine:
+  key_old_players: "old_players"
+  key_chat_data_game: "game"
+  key_stop_request: "stop_request"
+  key_start_countdown_last_text: "start_countdown_last_text"
+  key_start_countdown_last_timestamp: "start_countdown_last_timestamp"
+  key_start_countdown_context: "start_countdown_context"
+  stop_confirm_callback: "stop:confirm"
+  stop_resume_callback: "stop:resume"

--- a/config/system_constants.json
+++ b/config/system_constants.json
@@ -1,0 +1,7 @@
+{
+  "default_webhook_listen": "127.0.0.1",
+  "default_webhook_port": 3000,
+  "default_webhook_path": "/telegram/webhook-poker2025",
+  "default_rate_limit_per_second": 1,
+  "default_rate_limit_per_minute": 20
+}

--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -5,11 +5,25 @@ import enum
 import datetime
 from typing import Tuple, List, Optional
 from uuid import uuid4
+
 from pokerapp.cards import get_cards
-MAX_PLAYERS = 8
-MIN_PLAYERS = 2
-SMALL_BLIND = 5
-DEFAULT_MONEY = 1000
+from pokerapp.config import get_game_constants
+
+
+_GAME_CONSTANTS = get_game_constants().game
+
+
+def _coerce_int(value, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+MAX_PLAYERS = _coerce_int(_GAME_CONSTANTS.get("max_players", 8), 8)
+MIN_PLAYERS = _coerce_int(_GAME_CONSTANTS.get("min_players", 2), 2)
+SMALL_BLIND = _coerce_int(_GAME_CONSTANTS.get("small_blind", 5), 5)
+DEFAULT_MONEY = _coerce_int(_GAME_CONSTANTS.get("default_money", 1000), 1000)
 
 MessageId = str
 ChatId = str

--- a/pokerapp/pokerbot.py
+++ b/pokerapp/pokerbot.py
@@ -215,6 +215,7 @@ class PokerBot:
             kv=self._kv_async,
             table_manager=self._table_manager,
             logger=logger.getChild("private_match"),
+            constants=self._cfg.constants,
             redis_ops=self._redis_ops,
         )
         self._model = PokerBotModel(

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ python-dotenv==0.20.0
 fakeredis==2.19.0
 cachetools>=5.3
 pytest-asyncio>=1.2
+PyYAML>=6.0

--- a/tests/test_end_hand_persistence.py
+++ b/tests/test_end_hand_persistence.py
@@ -23,15 +23,17 @@ async def test_end_hand_persists_game_and_reuses_instance():
         send_message=AsyncMock(),
         send_message_return_id=AsyncMock(return_value=1),
     )
+    cfg = Config()
     private_match_service = PrivateMatchService(
         kv=redis_sync,
         table_manager=table_manager,
         logger=logging.getLogger("test.private_match"),
+        constants=cfg.constants,
     )
     model = PokerBotModel(
         view,
         bot,
-        Config(),
+        cfg,
         redis_sync,
         table_manager,
         private_match_service=private_match_service,

--- a/tests/test_game_engine_finalization.py
+++ b/tests/test_game_engine_finalization.py
@@ -12,6 +12,7 @@ from pokerapp.pokerbotmodel import KEY_OLD_PLAYERS, PokerBotModel
 from pokerapp.stats import BaseStatsService
 from pokerapp.winnerdetermination import HandsOfPoker
 from pokerapp.private_match_service import PrivateMatchService
+from pokerapp.config import get_game_constants
 
 
 def _make_wallet_mock(value: Optional[int] = None) -> MagicMock:
@@ -33,6 +34,7 @@ def _make_private_match_service(kv, table_manager) -> PrivateMatchService:
         kv=kv,
         table_manager=table_manager,
         logger=logging.getLogger("test.private_match"),
+        constants=get_game_constants(),
     )
 
 
@@ -72,6 +74,8 @@ async def test_hand_type_label_includes_translation_and_emoji():
     view = _build_view_mock()
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
+    cfg.constants = get_game_constants()
     kv = fakeredis.aioredis.FakeRedis()
     table_manager = MagicMock()
     stats = _build_stats_service()
@@ -98,6 +102,7 @@ async def test_finalize_game_single_winner_distributes_pot_and_updates_stats():
     view = _build_view_mock()
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
     kv = fakeredis.aioredis.FakeRedis()
     table_manager = MagicMock()
     table_manager.save_game = AsyncMock()

--- a/tests/test_pokerbotmodel.py
+++ b/tests/test_pokerbotmodel.py
@@ -13,7 +13,7 @@ import fakeredis.aioredis
 import pytest
 
 from pokerapp.cards import Cards, Card
-from pokerapp.config import Config
+from pokerapp.config import Config, get_game_constants
 from pokerapp.entities import Money, Player, Game, PlayerState, GameState, PlayerAction
 from pokerapp.pokerbotmodel import (
     PokerBotModel,
@@ -55,6 +55,7 @@ def _make_private_match_service(kv, table_manager) -> PrivateMatchService:
         kv=kv,
         table_manager=table_manager,
         logger=logging.getLogger("test.private_match"),
+        constants=get_game_constants(),
     )
 
 
@@ -233,6 +234,7 @@ def _build_model_with_game():
     view.send_message = AsyncMock()
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
     kv = MagicMock()
     table_manager = MagicMock()
     private_match_service = _make_private_match_service(kv, table_manager)
@@ -280,6 +282,7 @@ async def test_register_player_identity_updates_active_game_private_chat():
     table_manager.save_game = AsyncMock()
 
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
     private_match_service = _make_private_match_service(kv, table_manager)
     model = PokerBotModel(
         view=view,
@@ -315,6 +318,7 @@ async def test_request_stop_creates_vote_prompt():
     view.send_message = AsyncMock()
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
     kv = MagicMock()
     table_manager = MagicMock()
     table_manager.save_game = AsyncMock()
@@ -381,6 +385,7 @@ async def test_confirm_stop_vote_triggers_cancel_on_majority():
     view.send_message = AsyncMock()
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
     kv = MagicMock()
     table_manager = MagicMock()
     table_manager.save_game = AsyncMock()
@@ -446,6 +451,7 @@ async def test_cancel_hand_refunds_wallets_and_announces():
     view.send_message = AsyncMock()
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
     kv = MagicMock()
     table_manager = MagicMock()
     table_manager.save_game = AsyncMock()
@@ -607,6 +613,7 @@ async def test_auto_start_tick_starts_prestart_countdown_and_updates_state():
     view = _prepare_view_mock(MagicMock())
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
     kv = MagicMock()
     table_manager = MagicMock()
     game = Game()
@@ -664,6 +671,7 @@ async def test_auto_start_tick_does_not_restart_on_regular_tick():
     view = _prepare_view_mock(MagicMock())
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
     kv = MagicMock()
     table_manager = MagicMock()
     game = Game()
@@ -707,6 +715,7 @@ async def test_auto_start_tick_restarts_when_countdown_increases():
     view = _prepare_view_mock(MagicMock())
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
     kv = MagicMock()
     table_manager = MagicMock()
     game = Game()
@@ -753,6 +762,7 @@ async def test_auto_start_tick_triggers_game_start_when_zero():
     view = _prepare_view_mock(MagicMock())
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
     kv = MagicMock()
     table_manager = MagicMock()
     game = Game()
@@ -803,6 +813,7 @@ async def test_auto_start_tick_creates_message_when_missing():
     view.send_message_return_id = AsyncMock(return_value=999)
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
     kv = MagicMock()
     table_manager = MagicMock()
     game = Game()
@@ -850,6 +861,7 @@ async def test_auto_start_tick_does_not_start_when_message_creation_fails():
     view.send_message_return_id = AsyncMock(return_value=None)
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
     kv = MagicMock()
     table_manager = MagicMock()
     game = Game()
@@ -898,6 +910,7 @@ async def test_safe_edit_message_text_logs_bad_request(caplog):
     view.send_message_return_id = AsyncMock(return_value=999)
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
     kv = MagicMock()
     table_manager = MagicMock()
 
@@ -958,6 +971,7 @@ async def test_showdown_sends_new_hand_message_before_join_prompt():
     )
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
     kv = MagicMock()
     table_manager = MagicMock()
     table_manager.save_game = AsyncMock()
@@ -1009,6 +1023,7 @@ async def test_start_game_assigns_blinds_to_occupied_seats():
     view.delete_message = AsyncMock()
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
     kv = MagicMock()
     table_manager = MagicMock()
 
@@ -1085,6 +1100,7 @@ async def test_start_game_keeps_ready_message_id_when_deletion_fails():
     view.delete_message = AsyncMock(side_effect=BadRequest("not found"))
     bot = MagicMock()
     cfg = MagicMock(DEBUG=False)
+    cfg.constants = get_game_constants()
     kv = MagicMock()
     table_manager = MagicMock()
 

--- a/tests/test_private_match_service.py
+++ b/tests/test_private_match_service.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import fakeredis.aioredis
 
 from pokerapp.private_match_service import PrivateMatchService
+from pokerapp.config import get_game_constants
 
 
 def test_private_match_service_constants():
@@ -11,6 +12,7 @@ def test_private_match_service_constants():
         kv=fakeredis.aioredis.FakeRedis(),
         table_manager=MagicMock(),
         logger=logging.getLogger("test.private_match"),
+        constants=get_game_constants(),
     )
     assert service.PRIVATE_MATCH_QUEUE_TTL > 0
     assert service.PRIVATE_MATCH_STATE_TTL > 0

--- a/tests/test_private_matchmaking.py
+++ b/tests/test_private_matchmaking.py
@@ -57,6 +57,7 @@ async def _build_model():
         kv=kv,
         table_manager=table_manager,
         logger=logging.getLogger("test.private_match"),
+        constants=cfg.constants,
     )
     model = PokerBotModel(
         view=view,
@@ -114,7 +115,7 @@ async def test_private_matchmaking_cancellation_removes_user_from_queue():
     cancel_call = view.send_message.await_args_list[0]
     assert "از صف" in cancel_call.args[1]
     queue_members = await kv.zrange(
-        PrivateMatchService.PRIVATE_MATCH_QUEUE_KEY, 0, -1
+        model._private_match_service.queue_key, 0, -1
     )
     assert queue_members == []
 
@@ -130,7 +131,7 @@ async def test_private_matchmaking_timeout_notifies_user():
     await model.handle_private_matchmaking_request(update, context)
 
     await kv.zadd(
-        PrivateMatchService.PRIVATE_MATCH_QUEUE_KEY,
+        model._private_match_service.queue_key,
         {str(404): int(datetime.datetime.now().timestamp()) - 1000},
     )
 
@@ -141,7 +142,7 @@ async def test_private_matchmaking_timeout_notifies_user():
     timeout_call = view.send_message.await_args_list[0]
     assert "زمان انتظار" in timeout_call.args[1]
     queue_members = await kv.zrange(
-        PrivateMatchService.PRIVATE_MATCH_QUEUE_KEY, 0, -1
+        model._private_match_service.queue_key, 0, -1
     )
     assert queue_members == []
 

--- a/tests/test_statistics_integration.py
+++ b/tests/test_statistics_integration.py
@@ -11,6 +11,7 @@ from telegram.error import BadRequest
 from pokerapp.pokerbotmodel import PokerBotModel
 from pokerapp.stats import PlayerHandResult, PlayerIdentity, StatsService
 from pokerapp.private_match_service import PrivateMatchService
+from pokerapp.config import get_game_constants
 
 
 def _build_model(stats_service: StatsService):
@@ -26,13 +27,14 @@ def _build_model(stats_service: StatsService):
         send_message=send_message,
     )
     bot = SimpleNamespace()
-    cfg = SimpleNamespace(DEBUG=False)
+    cfg = SimpleNamespace(DEBUG=False, constants=get_game_constants())
     kv = fakeredis.aioredis.FakeRedis()
     table_manager = MagicMock()
     private_match_service = PrivateMatchService(
         kv=kv,
         table_manager=table_manager,
         logger=logging.getLogger("test.private_match"),
+        constants=cfg.constants,
     )
     model = PokerBotModel(
         view,


### PR DESCRIPTION
## Summary
- add YAML/JSON configuration files for game mechanics, UI labels, Redis keys, and system defaults
- extend the configuration module with a reusable GameConstants loader and update core modules to fetch constants from it
- adapt services, bot setup, and tests to the new configuration-based constants and add PyYAML dependency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d305214c1c8328a97bb77ebac949b4