### PR TITLE
Refactor PokerBot to use injected infrastructure services

### DIFF
--- a/pokerapp/bootstrap.py
+++ b/pokerapp/bootstrap.py
@@ -1,0 +1,116 @@
+"""Application composition root for the Poker Telegram bot."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Callable, Dict, Set
+
+import redis.asyncio as aioredis
+
+from pokerapp.config import Config
+from pokerapp.logging_config import setup_logging
+from pokerapp.stats import BaseStatsService, NullStatsService, StatsService
+from pokerapp.table_manager import TableManager
+from pokerapp.private_match_service import PrivateMatchService
+from pokerapp.utils.messaging_service import MessagingService
+from pokerapp.utils.redis_safeops import RedisSafeOps
+from pokerapp.utils.request_metrics import RequestMetrics
+
+
+@dataclass(frozen=True)
+class ApplicationServices:
+    """Container for infrastructure dependencies shared across the bot."""
+
+    logger: logging.Logger
+    kv_async: aioredis.Redis
+    redis_ops: RedisSafeOps
+    table_manager: TableManager
+    stats_service: BaseStatsService
+    request_metrics: RequestMetrics
+    private_match_service: PrivateMatchService
+    messaging_service_factory: Callable[..., MessagingService]
+
+
+def _build_stats_service(logger: logging.Logger, cfg: Config) -> BaseStatsService:
+    if not cfg.DATABASE_URL:
+        return NullStatsService()
+
+    try:
+        stats_service = StatsService(
+            cfg.DATABASE_URL,
+            echo=getattr(cfg, "DATABASE_ECHO", False),
+        )
+        stats_service.ensure_ready_blocking()
+        return stats_service
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("Failed to initialise StatsService; using NullStatsService")
+        return NullStatsService()
+
+
+def build_services(cfg: Config) -> ApplicationServices:
+    """Initialise logging and infrastructure dependencies for the bot."""
+
+    setup_logging(logging.INFO, debug_mode=cfg.DEBUG)
+    logger = logging.getLogger("pokerbot")
+
+    kv_async = aioredis.Redis(
+        host=cfg.REDIS_HOST,
+        port=cfg.REDIS_PORT,
+        db=cfg.REDIS_DB,
+        password=cfg.REDIS_PASS or None,
+    )
+
+    redis_ops = RedisSafeOps(kv_async, logger=logger.getChild("redis_safeops"))
+
+    table_manager = TableManager(
+        kv_async,
+        redis_ops=redis_ops,
+        wallet_redis_ops=redis_ops,
+    )
+
+    stats_service = _build_stats_service(logger.getChild("stats"), cfg)
+
+    request_metrics = RequestMetrics(logger_=logger.getChild("metrics"))
+
+    private_match_service = PrivateMatchService(
+        kv_async,
+        table_manager,
+        logger=logger.getChild("private_match"),
+        constants=cfg.constants,
+        redis_ops=redis_ops,
+    )
+
+    def messaging_service_factory(
+        *,
+        bot,
+        deleted_messages: Set[int],
+        deleted_messages_lock,
+        last_message_hash: Dict[int, str],
+        last_message_hash_lock,
+        cache_ttl: int = 3,
+        cache_maxsize: int = 500,
+    ) -> MessagingService:
+        return MessagingService(
+            bot,
+            cache_ttl=cache_ttl,
+            cache_maxsize=cache_maxsize,
+            logger_=logger.getChild("messaging_service"),
+            request_metrics=request_metrics,
+            deleted_messages=deleted_messages,
+            deleted_messages_lock=deleted_messages_lock,
+            last_message_hash=last_message_hash,
+            last_message_hash_lock=last_message_hash_lock,
+        )
+
+    return ApplicationServices(
+        logger=logger,
+        kv_async=kv_async,
+        redis_ops=redis_ops,
+        table_manager=table_manager,
+        stats_service=stats_service,
+        request_metrics=request_metrics,
+        private_match_service=private_match_service,
+        messaging_service_factory=messaging_service_factory,
+    )
+

--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -175,10 +175,7 @@ class PokerBotModel:
         self._countdown_cache_lock = asyncio.Lock()
         metrics_candidate = getattr(self._view, "request_metrics", None)
         if not isinstance(metrics_candidate, RequestMetrics):
-            metrics_candidate = RequestMetrics(
-                logger_=logger.getChild("request_metrics")
-            )
-            setattr(self._view, "request_metrics", metrics_candidate)
+            raise ValueError("PokerBotViewer must expose a RequestMetrics instance")
         self._request_metrics = metrics_candidate
         self._private_match_service.configure(
             safe_int=self._safe_int,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,65 @@
 """Pytest configuration shared across the test suite."""
 
+import logging
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+import pytest
+
+from pokerapp.pokerbotview import PokerBotViewer
+from pokerapp.utils.messaging_service import MessagingService
+from pokerapp.utils.request_metrics import RequestMetrics
+
+
+@pytest.fixture(autouse=True)
+def _inject_viewer_dependencies(monkeypatch):
+    """Provide default dependencies for PokerBotViewer in unit tests."""
+
+    original_init = PokerBotViewer.__init__
+
+    def _wrapped(self, *args, **kwargs):
+        metrics = kwargs.get("request_metrics")
+        if not isinstance(metrics, RequestMetrics):
+            metrics = RequestMetrics(
+                logger_=logging.getLogger("tests.request_metrics")
+            )
+            kwargs["request_metrics"] = metrics
+
+        factory = kwargs.get("messaging_service_factory")
+
+        if factory is None:
+
+            def _factory(
+                *,
+                bot,
+                deleted_messages,
+                deleted_messages_lock,
+                last_message_hash,
+                last_message_hash_lock,
+                cache_ttl: int = 3,
+                cache_maxsize: int = 500,
+            ) -> MessagingService:
+                return MessagingService(
+                    bot,
+                    cache_ttl=cache_ttl,
+                    cache_maxsize=cache_maxsize,
+                    logger_=logging.getLogger("tests.messaging_service"),
+                    request_metrics=metrics,
+                    deleted_messages=deleted_messages,
+                    deleted_messages_lock=deleted_messages_lock,
+                    last_message_hash=last_message_hash,
+                    last_message_hash_lock=last_message_hash_lock,
+                )
+
+            kwargs["messaging_service_factory"] = _factory
+
+        return original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(PokerBotViewer, "__init__", _wrapped)
+    yield
+    monkeypatch.setattr(PokerBotViewer, "__init__", original_init)
 

--- a/tests/test_end_hand_persistence.py
+++ b/tests/test_end_hand_persistence.py
@@ -9,6 +9,7 @@ from pokerapp.config import Config
 from pokerapp.table_manager import TableManager
 from pokerapp.pokerbotmodel import PokerBotModel, KEY_CHAT_DATA_GAME
 from pokerapp.private_match_service import PrivateMatchService
+from pokerapp.utils.request_metrics import RequestMetrics
 
 
 @pytest.mark.asyncio
@@ -22,6 +23,9 @@ async def test_end_hand_persists_game_and_reuses_instance():
     view = SimpleNamespace(
         send_message=AsyncMock(),
         send_message_return_id=AsyncMock(return_value=1),
+        request_metrics=RequestMetrics(
+            logger_=logging.getLogger("test.end_hand.request_metrics")
+        ),
     )
     cfg = Config()
     private_match_service = PrivateMatchService(

--- a/tests/test_game_engine_finalization.py
+++ b/tests/test_game_engine_finalization.py
@@ -13,6 +13,7 @@ from pokerapp.stats import BaseStatsService
 from pokerapp.winnerdetermination import HandsOfPoker
 from pokerapp.private_match_service import PrivateMatchService
 from pokerapp.config import get_game_constants
+from pokerapp.utils.request_metrics import RequestMetrics
 
 
 def _make_wallet_mock(value: Optional[int] = None) -> MagicMock:
@@ -54,6 +55,9 @@ def _build_view_mock() -> MagicMock:
     view.update_turn_message = AsyncMock()
     view.send_showdown_results = AsyncMock()
     view.send_new_hand_ready_message = AsyncMock()
+    view.request_metrics = RequestMetrics(
+        logger_=logging.getLogger("test.game_engine.request_metrics")
+    )
     return view
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -7,7 +7,7 @@ import pytest
 
 from pokerapp.logging_config import ContextJsonFormatter
 from pokerapp.utils.messaging_service import MessagingService
-from pokerapp.utils.request_metrics import RequestCategory
+from pokerapp.utils.request_metrics import RequestCategory, RequestMetrics
 
 
 class _DummyBot:
@@ -52,7 +52,12 @@ def test_context_json_formatter_includes_common_fields():
 @pytest.mark.asyncio
 async def test_messaging_service_logs_include_context(caplog):
     logger = logging.getLogger("test.messaging.service")
-    service = MessagingService(_DummyBot(), logger_=logger)
+    metrics = RequestMetrics(logger_=logger)
+    service = MessagingService(
+        _DummyBot(),
+        logger_=logger,
+        request_metrics=metrics,
+    )
 
     context = {"game_id": "game-123", "stage": "TURN"}
 
@@ -77,7 +82,12 @@ async def test_messaging_service_logs_include_context(caplog):
 @pytest.mark.asyncio
 async def test_messaging_service_logs_errors_with_context(caplog):
     logger = logging.getLogger("test.messaging.service.error")
-    service = MessagingService(_FailingBot(), logger_=logger)
+    metrics = RequestMetrics(logger_=logger)
+    service = MessagingService(
+        _FailingBot(),
+        logger_=logger,
+        request_metrics=metrics,
+    )
 
     with pytest.raises(ValueError):
         with caplog.at_level(logging.ERROR, logger="test.messaging.service.error"):

--- a/tests/test_pokerbot.py
+++ b/tests/test_pokerbot.py
@@ -1,5 +1,7 @@
 import logging
 from types import SimpleNamespace
+import logging
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -12,6 +14,7 @@ def _create_bot(allow_polling_fallback: bool) -> PokerBot:
     bot = PokerBot.__new__(PokerBot)
     bot._cfg = SimpleNamespace(ALLOW_POLLING_FALLBACK=allow_polling_fallback)
     bot._build_application = Mock()
+    bot._logger = logging.getLogger("test.pokerbot")
     return bot
 
 

--- a/tests/test_pokerbotmodel.py
+++ b/tests/test_pokerbotmodel.py
@@ -28,8 +28,10 @@ from pokerapp.pokerbotmodel import (
 )
 from pokerapp.pokerbotview import TurnMessageUpdate, PokerBotViewer
 from pokerapp.private_match_service import PrivateMatchService
+from pokerapp.utils.request_metrics import RequestMetrics
 from telegram.error import BadRequest
 from telegram import InlineKeyboardMarkup
+import logging
 
 
 HANDS_FILE = "./tests/hands.txt"
@@ -78,6 +80,9 @@ def _prepare_view_mock(view: MagicMock) -> MagicMock:
             call_action=PlayerAction.CHECK,
             board_line="",
         )
+    )
+    view.request_metrics = RequestMetrics(
+        logger_=logging.getLogger("test.pokerbotmodel.request_metrics")
     )
     return view
 

--- a/tests/test_pokerbotviewer.py
+++ b/tests/test_pokerbotviewer.py
@@ -522,11 +522,11 @@ def test_delete_message_allows_anchor_cleanup_after_hand():
         )
     )
 
-    viewer._messenger.delete_message.assert_awaited_once_with(
-        chat_id=chat_id,
-        message_id=message_id,
-        request_category=RequestCategory.DELETE,
-    )
+    viewer._messenger.delete_message.assert_awaited_once()
+    delete_kwargs = viewer._messenger.delete_message.await_args.kwargs
+    assert delete_kwargs["chat_id"] == chat_id
+    assert delete_kwargs["message_id"] == message_id
+    assert delete_kwargs["request_category"] is RequestCategory.DELETE
     viewer._mark_message_deleted.assert_awaited_once_with(message_id)
 
 

--- a/tests/test_private_matchmaking.py
+++ b/tests/test_private_matchmaking.py
@@ -13,6 +13,7 @@ from pokerapp.pokerbotmodel import PokerBotModel
 from pokerapp.stats import BaseStatsService
 from pokerapp.table_manager import TableManager
 from pokerapp.private_match_service import PrivateMatchService
+from pokerapp.utils.request_metrics import RequestMetrics
 
 
 def _build_update(
@@ -44,6 +45,9 @@ async def _build_model():
     view.send_message_return_id = AsyncMock(return_value=None)
     view.update_player_anchors_and_keyboards = AsyncMock()
     view.clear_all_player_anchors = AsyncMock(return_value=None)
+    view.request_metrics = RequestMetrics(
+        logger_=logging.getLogger("test.private_matchmaking.request_metrics")
+    )
     bot = MagicMock()
     cfg = Config()
     table_manager = TableManager(kv)

--- a/tests/test_statistics_integration.py
+++ b/tests/test_statistics_integration.py
@@ -12,6 +12,7 @@ from pokerapp.pokerbotmodel import PokerBotModel
 from pokerapp.stats import PlayerHandResult, PlayerIdentity, StatsService
 from pokerapp.private_match_service import PrivateMatchService
 from pokerapp.config import get_game_constants
+from pokerapp.utils.request_metrics import RequestMetrics
 
 
 def _build_model(stats_service: StatsService):
@@ -25,6 +26,9 @@ def _build_model(stats_service: StatsService):
     send_message.side_effect = safe_send_message
     view = SimpleNamespace(
         send_message=send_message,
+        request_metrics=RequestMetrics(
+            logger_=logging.getLogger("test.statistics.request_metrics")
+        ),
     )
     bot = SimpleNamespace()
     cfg = SimpleNamespace(DEBUG=False, constants=get_game_constants())


### PR DESCRIPTION
## Summary
- add a bootstrap composition root that wires logging, Redis, statistics, metrics, and messaging services once at startup
- refactor PokerBot, PokerBotViewer, and MessagingService to operate on injected dependencies rather than constructing infrastructure internally
- update tests and fixtures to supply the required request metrics and messaging factory dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3143797408328ac67c9e4f307202a