### PR TITLE
Document game flow architecture and update inline references

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,33 @@ The bot plays role "our admin": he divides cards, adds cards, controlls whose tu
 
 All things that we need to do is adding bot to your group chat on telegram and every member needs to press the join button at the beginning of round. Then the game will be started. Rules of the texas poker you can read briefly below:
 
+## Architecture overview
+
+The production bot is split into three cooperating layers:
+
+- **Infrastructure glue** — [`pokerapp/pokerbot.py`](pokerapp/pokerbot.py) wires the
+  Telegram `Application`, injects shared dependencies (logger, Redis, stats,
+  metrics), and exposes `run_webhook` / `run_polling` entry points.
+- **Game rules** — [`pokerapp/game_engine.py`](pokerapp/game_engine.py) implements
+  the Texas Hold'em state machine, balancing the pot, advancing stages, and
+  finalising results through injected services.
+- **User interface** — [`pokerapp/pokerbotview.py`](pokerapp/pokerbotview.py)
+  renders keyboards, anchors, and throttled Telegram updates through the
+  `MessagingService` facade.
+
+The new dependency-injection centric architecture is documented in depth inside
+[`docs/game_flow.md`](docs/game_flow.md), including ASCII and PlantUML diagrams
+that illustrate how bootstrap code constructs the bot.
+
+## Game flow reference
+
+For a detailed walkthrough of the startup sequence, per-stage lifecycle, and the
+`GameState` transitions (`ROUND_PRE_FLOP` → `ROUND_FLOP` → `ROUND_TURN` →
+`ROUND_RIVER` → `FINISHED`), consult the [Game Flow & Architecture guide](docs/game_flow.md).
+The document expands on the high-level rules below by mapping them back to the
+actual async functions that drive table updates, statistics, and message
+rendering.
+
 **Here is the brief instruction of Texas Poker**\
 Every player has two private cards and on the table has five community cards which are dealt face up in the three stages.
 On the beginning of game, two people which are selected for big and small blinds. This means the blinds are forced to bet, the small blind bet 5\$ and the big blind bet 10\$.

--- a/docs/game_flow.md
+++ b/docs/game_flow.md
@@ -1,0 +1,299 @@
+# PokerBot Game Flow & Architecture
+
+This guide documents the current decoupled architecture of the Poker Telegram Bot.
+It cross-references the runtime entry points, lifecycle methods, and supporting
+services that collaborate to run a single hand of Texas Hold'em. The goal is to
+explain how infrastructure dependencies are injected, how the game progresses
+through its stages, and how presentation updates reach Telegram clients.
+
+The documentation is intentionally grounded in the production implementation:
+
+- [`pokerapp/pokerbot.py`](../pokerapp/pokerbot.py) hosts the Telegram
+  orchestration (`run_webhook`, `run_polling`, `_build_application`).
+- [`pokerapp/pokerbotview.py`](../pokerapp/pokerbotview.py) renders inline
+  keyboards and manages anchor caches for efficient message edits.
+- [`pokerapp/game_engine.py`](../pokerapp/game_engine.py) encapsulates the state
+  machine (`start_game`, `progress_stage`, `finalize_game`).
+- [`README.md`](../README.md) captures player-facing rules and the daily bonus
+  table that contextualise the stages below.
+
+## Architecture Modules & Roles
+
+| Module | Responsibility | Injected Collaborators |
+| ------ | --------------- | ---------------------- |
+| `PokerBot` | Builds the `Application` object and wires controllers, handlers, and job queue. | `logging.Logger`, `RequestMetrics`, `RedisSafeOps`, Redis connection (`kv_async`), `TableManager`, `BaseStatsService`, `PrivateMatchService`, `MessagingServiceFactory`. |
+| `PokerBotModel` | Business rules bridging Telegram updates and the game engine. | `PokerBotViewer`, `TableManager`, `BaseStatsService`, Redis (`kv`), `Config`. |
+| `PokerBotViewer` | Presentation layer for players and spectators (inline keyboards, card renders, throttled edits). | `RequestMetrics`, `MessagingService`, Telegram `Bot`. |
+| `GameEngine` | Game state machine, table orchestration, persistence, and statistics updates. | `TableManager`, `PokerBotViewer`, `WinnerDetermination`, `RequestMetrics`, `BaseStatsService`, `LockManager`, logger. |
+| Supporting Services | Infra dependencies created during bootstrap. | Redis (`kv_async`), Postgres-backed `StatsService`, metrics collectors, messaging adapters. |
+
+The bootstrap script (`main.py`) remains responsible for configuring logging,
+instantiating Redis, stats, and metrics clients, and injecting them into the
+`PokerBot` constructor. All runtime objects now share these singletons rather
+than creating ad-hoc connections internally.
+
+## High-Level Architecture Diagram
+
+```
+                  ┌───────────────────────────────┐
+                  │        main.py / bootstrap    │
+                  │  • load Config & logging      │
+                  │  • build Redis / metrics      │
+                  │  • construct StatsService     │
+                  │  • instantiate PokerBot      │
+                  └──────────────┬────────────────┘
+                                 │  injected deps
+                                 ▼
+                   ┌───────────────────────────────┐
+                   │           PokerBot            │
+                   │  • PTB Application builder    │
+                   │  • run_webhook / run_polling  │
+                   │  • controller wiring          │
+                   └──────┬───────────────┬────────┘
+                          │               │
+                          ▼               ▼
+               ┌────────────────┐   ┌────────────────┐
+               │ PokerBotModel  │   │ PokerBotViewer │
+               │ • state & DI   │   │ • UI rendering │
+               │ • GameEngine   │   │ • anchor cache │
+               └──────┬─────────┘   └────────┬───────┘
+                      │                      │
+                      ▼                      │
+               ┌────────────────┐            │
+               │  GameEngine    │◄───────────┘
+               │ • game states  │
+               │ • TableManager │
+               │ • StatsService │
+               │ • metrics/logs │
+               └────────────────┘
+```
+
+### PlantUML (architecture)
+
+```plantuml
+@startuml PokerBotArchitecture
+!pragma layout smetana
+skinparam componentStyle rectangle
+
+package "Bootstrap" {
+  [main.py]
+}
+
+component PokerBot
+component PokerBotModel
+component PokerBotViewer
+component GameEngine
+component TableManager
+component BaseStatsService as StatsService
+component RequestMetrics
+component MessagingService
+component Logger
+component Redis
+component WinnerDetermination
+
+[main.py] --> PokerBot : inject logger / metrics / redis / stats
+PokerBot --> PokerBotModel : create
+PokerBot --> PokerBotViewer : create
+PokerBot --> RequestMetrics
+PokerBot --> MessagingService
+PokerBotModel --> GameEngine : orchestrate
+PokerBotModel --> TableManager
+PokerBotModel --> StatsService
+GameEngine --> TableManager
+GameEngine --> PokerBotViewer
+GameEngine --> WinnerDetermination
+GameEngine --> StatsService
+GameEngine --> RequestMetrics
+PokerBotViewer --> MessagingService
+PokerBotViewer --> RequestMetrics
+
+Logger -[#blue]-> PokerBot
+Redis -[#blue]-> PokerBot
+@enduml
+```
+
+## Sequence Diagram — Bot Startup & Dependency Injection
+
+The following diagram traces control as bootstrap code builds the Telegram
+Application and wires the decoupled services.
+
+```
+main.py            PokerBot           PTB Application        PokerBotViewer   PokerBotModel   GameEngine
+   |                  |                      |                     |               |              |
+   | configure cfg    |                      |                     |               |              |
+   | build logger     |                      |                     |               |              |
+   | build redis ---->| __init__             |                     |               |              |
+   | build stats ---->|  _build_application  |                     |               |              |
+   | build metrics -->|--------------------->| builder             |               |              |
+   |                  |  create viewer --------------------------->|               |              |
+   |                  |  create model ------------------------------------------->| injects      |
+   |                  |  wire controller     |                     |               |              |
+   |                  |  add handlers       |                     |               |              |
+   |                  |  return Application |                     |               |              |
+   |                  | ready to run        |                     |               |              |
+```
+
+### PlantUML (startup sequence)
+
+```plantuml
+@startuml StartupSequence
+actor Bootstrap as main
+participant PokerBot
+participant "PTB Application" as Application
+participant PokerBotViewer as Viewer
+participant PokerBotModel as Model
+participant GameEngine as Engine
+
+main -> PokerBot : __init__(token, cfg, logger, redis,...)
+activate PokerBot
+PokerBot -> PokerBot : _build_application()
+PokerBot -> Application : builder.build()
+activate Application
+PokerBot -> Viewer : create(view deps)
+activate Viewer
+Viewer --> PokerBot : instance
+deactivate Viewer
+PokerBot -> Model : create(view, table_manager, stats,...)
+activate Model
+Model -> Engine : create(table_manager, view, metrics,...)
+activate Engine
+Engine --> Model : instance
+deactivate Engine
+Model --> PokerBot : instance
+deactivate Model
+Application --> PokerBot : instance
+deactivate Application
+PokerBot --> main : ready
+@enduml
+```
+
+## Sequence Diagram — Game Start → Stage Progression → Finalization
+
+This flow describes what happens after players tap `/start` and the bot begins a
+hand.
+
+```
+Player/Telegram   PokerBotController   PokerBotModel        GameEngine           PokerBotViewer     TableManager   StatsService
+       |                |                    |                   |                     |                 |              |
+       | /start command |                    |                   |                     |                 |              |
+       |--------------->| handle_start       |                   |                     |                 |              |
+       |                |------------------->| start_game_async  |                   |                     |              |
+       |                |                    |------------------>| start_game         | send anchors ---->| persist      | hand_start
+       |                |                    |                   | deal blinds/cards  | update board      |              |
+       | bet actions    |                    | progress_stage    |------------------->| stage change      | update state |
+       |----------------|------------------->|------------------>| collect bets       | refresh anchors   | store pot    |
+       |                |                    |                   | advance GameState  | notify players    |              |
+       | showdown       |                    | finalize_game     |------------------->| final summary     | reset table  | record stats
+       |                |                    |                   | determine winners  | post winners      | cleanup      | finish_hand
+```
+
+### PlantUML (game lifecycle)
+
+```plantuml
+@startuml GameLifecycle
+actor Player
+participant PokerBotController as Controller
+participant PokerBotModel as Model
+participant GameEngine as Engine
+participant PokerBotViewer as Viewer
+participant TableManager as Tables
+participant BaseStatsService as Stats
+
+Player -> Controller : /start
+Controller -> Model : handle_start()
+Model -> Engine : start_game(context, game, chat)
+Engine -> Viewer : send_join_prompt / anchors
+Engine -> Tables : persist game state
+Engine -> Stats : record hand_start
+
+Player -> Controller : betting callbacks
+Controller -> Model : apply_action()
+Model -> Engine : progress_stage(context, chat, game)
+Engine -> Viewer : update stage anchors
+Engine -> Tables : sync stage & pot
+
+Model -> Engine : finalize_game()
+Engine -> Viewer : send_results()
+Engine -> Stats : finish_hand()
+Engine -> Tables : reset_table()
+@enduml
+```
+
+## Poker Game State Machine
+
+`GameEngine.ACTIVE_GAME_STATES` and `_progress_stage_locked` control the allowed
+transitions. The ASCII state diagram below matches the actual implementation,
+including early termination rules.
+
+```
+┌────────┐
+│WAITING │  (lobby / gathering players)
+└──┬─────┘
+   │ start_game()
+   ▼
+┌─────────────────┐
+│ROUND_PRE_FLOP   │ --deal hole cards--> assigns blinds, sets current player
+└──────┬──────────┘
+       │ progress_stage()
+       ▼
+┌─────────────────┐    ┌────────────────┐    ┌────────────────┐
+│ROUND_FLOP       │ -> │ROUND_TURN      │ -> │ROUND_RIVER     │
+└──────┬──────────┘    └──────┬─────────┘    └──────┬─────────┘
+       │ add community cards         │ add final card      │ showdown
+       ▼                             ▼                    ▼
+┌─────────────────┐
+│FINISHED         │ <- finalize_game() updates stats, payouts, summaries
+└──────┬──────────┘
+       │ reset_table()
+       ▼
+┌─────────────────┐
+│WAITING_NEW_HAND │ (anchors cleared, ready for next /start)
+└─────────────────┘
+```
+
+### PlantUML (state machine)
+
+```plantuml
+@startuml GameStateMachine
+hide empty description
+[*] --> WAITING
+WAITING --> ROUND_PRE_FLOP : start_game()
+ROUND_PRE_FLOP --> ROUND_FLOP : progress_stage()
+ROUND_FLOP --> ROUND_TURN : progress_stage()
+ROUND_TURN --> ROUND_RIVER : progress_stage()
+ROUND_RIVER --> FINISHED : finalize_game()
+FINISHED --> WAITING_NEW_HAND : reset_table()
+
+ROUND_PRE_FLOP --> FINISHED : folds or <2 contenders
+ROUND_FLOP --> FINISHED : folds or <2 contenders
+ROUND_TURN --> FINISHED : folds or <2 contenders
+ROUND_RIVER --> FINISHED : folds, showdown, bankroll zero
+@enduml
+```
+
+## Dependency Injection & Instrumentation
+
+- **Logger** — Propagated from bootstrap to `PokerBot` and further into
+  `GameEngine` for diagnostic events (stage transitions, retry warnings).
+- **Redis / TableManager** — `PokerBotModel` and `GameEngine` use the shared
+  Redis pool for persisting tables, stage locks, and ready messages. Safe
+  operations flow through `RedisSafeOps` to centralise retry policies.
+- **RequestMetrics** — Counted in `PokerBotViewer` (Telegram API throughput) and
+  `GameEngine` (stage progression, join prompts) for operational dashboards.
+- **StatsService** — Called during `start_game` (identity caching) and
+  `finalize_game` (`finish_hand`, payouts) to track leaderboard data.
+- **MessagingService** — Created by `PokerBot` and consumed by `PokerBotViewer`
+  to abstract over send/edit/delete operations with automatic retries.
+
+## In-Code Cross References
+
+New inline documentation points back to this guide:
+
+- `PokerBot` class docstring summarises dependency injection and links here.
+- `GameEngine` module docstring contains the ASCII state machine.
+- `PokerBotViewer` module docstring references the architecture and UI sections.
+- Inline comments inside `_build_application` describe how the Application wires
+  the view and model.
+
+Consult these markers to jump between code and documentation when extending the
+bot or preparing tests.

--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -1,4 +1,15 @@
-"""Core game engine utilities for PokerBot."""
+"""Core game engine utilities for PokerBot.
+
+State machine overview (mirrors :func:`_progress_stage_locked`):
+
+    WAITING ──start_game()──▶ ROUND_PRE_FLOP ─┬─▶ ROUND_FLOP ─┬─▶ ROUND_TURN ─┬─▶ ROUND_RIVER
+      ▲                                       │               │               │
+      └──────── finalize_game() ◀─────────────┴───────────────┴───────────────┘
+
+`finalize_game` also handles early exits when fewer than two contenders remain
+or a table is stopped. A more detailed, annotated diagram lives in
+``docs/game_flow.md`` for onboarding and design reference.
+"""
 
 from __future__ import annotations
 

--- a/pokerapp/pokerbot.py
+++ b/pokerapp/pokerbot.py
@@ -36,7 +36,15 @@ MessagingServiceFactory = Callable[..., MessagingService]
 
 
 class PokerBot:
-    """Telegram bot wrapper using PTB v20 async Application."""
+    """Telegram bot wrapper using PTB v20 async Application.
+
+    The bootstrap layer (`main.py`) injects infrastructure singletons such as
+    the logger, Redis pool, metrics collector, and stats service. ``PokerBot``
+    remains responsible for wiring the Presentation (``PokerBotViewer``) and
+    domain model (``PokerBotModel``) around the shared ``Application`` instance.
+    See ``docs/game_flow.md`` for the architecture and sequence diagrams that
+    map these responsibilities.
+    """
 
     def __init__(
         self,
@@ -197,6 +205,9 @@ class PokerBot:
         self._application = builder.build()
         self._application.add_error_handler(self._handle_error)
 
+        # Viewer and model are created here so that both receive the injected
+        # infrastructure dependencies (Redis, stats, metrics, messaging). The
+        # controller then binds Telegram handlers to delegate into the model.
         self._view = PokerBotViewer(
             bot=self._application.bot,
             admin_chat_id=self._cfg.ADMIN_CHAT_ID,

--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+"""Telegram-facing presentation helpers for PokerBot.
+
+The viewer composes inline keyboards, manages anchor caches, and delegates to
+``MessagingService`` for send/edit/delete operations. Architectural diagrams and
+sequence flows that place this module alongside ``PokerBot`` and ``GameEngine``
+are available in ``docs/game_flow.md``.
+"""
 
 from telegram import (
     Message,


### PR DESCRIPTION
## Summary
- add a comprehensive docs/game_flow.md guide with architecture and lifecycle diagrams
- extend the README with architecture and game flow sections pointing to the new guide
- cross-link the codebase to the documentation via docstrings and comments in PokerBot, GameEngine, and PokerBotViewer

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d31771c8f48328805f373a56e94128