### PR TITLE
Use timezone-aware datetime helpers

### DIFF
--- a/config/system_constants.json
+++ b/config/system_constants.json
@@ -3,5 +3,6 @@
   "default_webhook_port": 3000,
   "default_webhook_path": "/telegram/webhook-poker2025",
   "default_rate_limit_per_second": 1,
-  "default_rate_limit_per_minute": 20
+  "default_rate_limit_per_minute": 20,
+  "default_timezone_name": "Asia/Tehran"
 }

--- a/pokerapp/bootstrap.py
+++ b/pokerapp/bootstrap.py
@@ -36,18 +36,19 @@ class ApplicationServices:
 
 def _build_stats_service(logger: logging.Logger, cfg: Config) -> BaseStatsService:
     if not cfg.DATABASE_URL:
-        return NullStatsService()
+        return NullStatsService(timezone_name=cfg.TIMEZONE_NAME)
 
     try:
         stats_service = StatsService(
             cfg.DATABASE_URL,
             echo=getattr(cfg, "DATABASE_ECHO", False),
+            timezone_name=cfg.TIMEZONE_NAME,
         )
         stats_service.ensure_ready_blocking()
         return stats_service
     except Exception:  # pragma: no cover - defensive logging
         logger.exception("Failed to initialise StatsService; using NullStatsService")
-        return NullStatsService()
+        return NullStatsService(timezone_name=cfg.TIMEZONE_NAME)
 
 
 def build_services(cfg: Config) -> ApplicationServices:

--- a/pokerapp/logging_config.py
+++ b/pokerapp/logging_config.py
@@ -2,7 +2,7 @@ import json
 import logging
 from typing import Any, Dict
 
-from pokerapp.utils.datetime_utils import utc_now
+from pokerapp.utils.time_utils import now_utc
 
 
 class ContextJsonFormatter(logging.Formatter):
@@ -69,7 +69,7 @@ class ContextJsonFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         log_record: Dict[str, Any] = {
-            "timestamp": utc_now().isoformat(),
+            "timestamp": now_utc().isoformat(),
             "level": record.levelname,
             "logger": record.name,
             "message": record.getMessage(),

--- a/pokerapp/private_match_service.py
+++ b/pokerapp/private_match_service.py
@@ -15,7 +15,7 @@ from pokerapp.player_manager import PlayerManager
 from pokerapp.pokerbotview import PokerBotViewer
 from pokerapp.stats import BaseStatsService, PlayerIdentity
 from pokerapp.table_manager import TableManager
-from pokerapp.utils.datetime_utils import utc_now
+from pokerapp.utils.time_utils import now_utc
 from pokerapp.utils.markdown import escape_markdown_v1
 from pokerapp.utils.request_metrics import RequestMetrics
 from pokerapp.utils.redis_safeops import RedisSafeOps
@@ -143,7 +143,7 @@ class PrivateMatchService:
         return self._decode_hash(data)
 
     async def cleanup_private_queue(self) -> None:
-        now = utc_now()
+        now = now_utc()
         cutoff_ts = int(now.timestamp()) - self._queue_ttl
         expired = await self._redis_ops.safe_zrangebyscore(
             self._queue_key,
@@ -215,7 +215,7 @@ class PrivateMatchService:
             self._build_player_info_from_state(user_id_str, state)
             for user_id_str, state, _ in valid[:2]
         ]
-        now_ts = int(utc_now().timestamp())
+        now_ts = int(now_utc().timestamp())
         for idx, (user_id_str, state, _) in enumerate(valid[:2]):
             opponent = players[1 - idx]
             state_key = self.private_user_key(user_id_str)
@@ -251,7 +251,7 @@ class PrivateMatchService:
                 "opponent": existing_state.get("opponent") if existing_state else None,
             }
 
-        timestamp = int(utc_now().timestamp())
+        timestamp = int(now_utc().timestamp())
         display_name = (
             user.full_name
             or user.first_name
@@ -325,7 +325,7 @@ class PrivateMatchService:
                 self._require_player_manager().private_chat_ids[safe_user_id] = info.chat_id
         await self._table_manager.save_game(chat_id, game)
 
-        started_at = utc_now()
+        started_at = now_utc()
         match_key = self.private_match_key(match_id)
         match_extra = {"match_id": match_id, "chat_id": chat_id}
         await self._redis_ops.safe_hset(

--- a/pokerapp/utils/messaging_service.py
+++ b/pokerapp/utils/messaging_service.py
@@ -32,7 +32,7 @@ try:  # pragma: no cover - prometheus_client optional
 except Exception:  # pragma: no cover - optional dependency missing
     Counter = None  # type: ignore[assignment]
 
-from pokerapp.utils.datetime_utils import utc_now
+from pokerapp.utils.time_utils import now_utc
 from pokerapp.utils.debug_trace import trace_telegram_api_call
 from pokerapp.utils.request_metrics import RequestCategory, RequestMetrics
 
@@ -743,7 +743,7 @@ class MessagingService:
                     if not waiter.future.done():
                         waiter.future.set_result(result)
             finally:
-                timestamp = utc_now()
+                timestamp = now_utc()
                 self._last_edit_timestamp[key] = timestamp
                 async with state.guard:
                     state.last_flush = time.monotonic()

--- a/pokerapp/utils/time_utils.py
+++ b/pokerapp/utils/time_utils.py
@@ -1,0 +1,81 @@
+"""Timezone-aware datetime helpers used across the poker application."""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from functools import lru_cache
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEZONE_NAME = "Asia/Tehran"
+UTC = dt.timezone.utc
+
+
+def now_utc() -> dt.datetime:
+    """Return the current time as an aware ``datetime`` in UTC."""
+
+    return dt.datetime.now(UTC)
+
+
+def _ensure_aware_utc(value: dt.datetime) -> dt.datetime:
+    """Coerce ``value`` to an aware UTC datetime without altering the instant."""
+
+    if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+@lru_cache(maxsize=32)
+def _resolve_zoneinfo(name: str) -> dt.tzinfo:
+    """Return a ``tzinfo`` for ``name`` falling back to UTC on failure."""
+
+    candidate = name or DEFAULT_TIMEZONE_NAME
+    try:
+        return ZoneInfo(candidate)
+    except ZoneInfoNotFoundError:
+        if candidate != DEFAULT_TIMEZONE_NAME:
+            logger.warning(
+                "Unknown timezone %s; falling back to %s", candidate, DEFAULT_TIMEZONE_NAME
+            )
+            return _resolve_zoneinfo(DEFAULT_TIMEZONE_NAME)
+        logger.warning("Unknown timezone %s; falling back to UTC", candidate)
+        return UTC
+
+
+def to_local(value: dt.datetime, tz_name: str = DEFAULT_TIMEZONE_NAME) -> dt.datetime:
+    """Convert ``value`` to the target timezone, assuming UTC when naive."""
+
+    aware_utc = _ensure_aware_utc(value)
+    zone = _resolve_zoneinfo(tz_name)
+    return aware_utc.astimezone(zone)
+
+
+def format_local(
+    value: dt.datetime, fmt: str, tz_name: str = DEFAULT_TIMEZONE_NAME
+) -> str:
+    """Return ``value`` formatted in the requested timezone using ``fmt``."""
+
+    localized = to_local(value, tz_name=tz_name)
+    return localized.strftime(fmt)
+
+
+def countdown_delta(end_time: dt.datetime, start_time: dt.datetime) -> dt.timedelta:
+    """Return the timedelta between ``end_time`` and ``start_time`` in UTC."""
+
+    end_utc = _ensure_aware_utc(end_time)
+    start_utc = _ensure_aware_utc(start_time)
+    return end_utc - start_utc
+
+
+__all__ = [
+    "DEFAULT_TIMEZONE_NAME",
+    "UTC",
+    "now_utc",
+    "to_local",
+    "format_local",
+    "countdown_delta",
+]
+

--- a/tests/test_private_matchmaking.py
+++ b/tests/test_private_matchmaking.py
@@ -1,4 +1,3 @@
-import datetime
 from types import SimpleNamespace
 from typing import Tuple
 from unittest.mock import AsyncMock, MagicMock
@@ -14,6 +13,7 @@ from pokerapp.stats import BaseStatsService
 from pokerapp.table_manager import TableManager
 from pokerapp.private_match_service import PrivateMatchService
 from pokerapp.utils.request_metrics import RequestMetrics
+from pokerapp.utils.time_utils import now_utc
 
 
 def _build_update(
@@ -136,7 +136,7 @@ async def test_private_matchmaking_timeout_notifies_user():
 
     await kv.zadd(
         model._private_match_service.queue_key,
-        {str(404): int(datetime.datetime.now().timestamp()) - 1000},
+        {str(404): int(now_utc().timestamp()) - 1000},
     )
 
     view.send_message.reset_mock()

--- a/tests/test_statistics_integration.py
+++ b/tests/test_statistics_integration.py
@@ -186,6 +186,21 @@ async def test_statistics_command_formats_report(tmp_path):
         assert "📝 پنج دست اخیر:" in message
         assert "👤 نام: user\\_\\[test]" in message
         assert kwargs.get("reply_markup") is not None
+
+        player_report = await service.build_player_report(identity.user_id)
+        assert player_report is not None
+        if player_report.stats.last_game_at is not None:
+            tzinfo = player_report.stats.last_game_at.tzinfo
+            assert tzinfo is not None
+            assert tzinfo.utcoffset(player_report.stats.last_game_at) == dt.timedelta(0)
+        if player_report.stats.last_bonus_at is not None:
+            tzinfo = player_report.stats.last_bonus_at.tzinfo
+            assert tzinfo is not None
+            assert tzinfo.utcoffset(player_report.stats.last_bonus_at) == dt.timedelta(0)
+        for row in player_report.recent_games:
+            if row.finished_at is not None:
+                assert row.finished_at.tzinfo is not None
+                assert row.finished_at.tzinfo.utcoffset(row.finished_at) == dt.timedelta(0)
     finally:
         await service.close()
 

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,0 +1,37 @@
+import datetime as dt
+
+from pokerapp.utils.time_utils import countdown_delta, format_local, now_utc, to_local
+
+
+def test_now_utc_returns_aware_datetime():
+    value = now_utc()
+    assert value.tzinfo is not None
+    assert value.tzinfo.utcoffset(value) == dt.timedelta(0)
+
+
+def test_to_local_handles_european_dst_transition():
+    before_dst = to_local(
+        dt.datetime(2024, 3, 31, 0, 30, tzinfo=dt.timezone.utc), tz_name="Europe/Berlin"
+    )
+    after_dst = to_local(
+        dt.datetime(2024, 3, 31, 1, 30, tzinfo=dt.timezone.utc), tz_name="Europe/Berlin"
+    )
+
+    assert before_dst.hour == 1
+    assert before_dst.minute == 30
+    assert before_dst.utcoffset() == dt.timedelta(hours=1)
+
+    assert after_dst.hour == 3
+    assert after_dst.minute == 30
+    assert after_dst.utcoffset() == dt.timedelta(hours=2)
+
+
+def test_format_local_and_countdown_delta_use_utc_baseline():
+    start = dt.datetime(2024, 1, 1, 12, 0)
+    end = start + dt.timedelta(minutes=5)
+
+    delta = countdown_delta(end, start)
+    assert delta == dt.timedelta(minutes=5)
+
+    formatted = format_local(start, "%H:%M", tz_name="Asia/Tehran")
+    assert formatted == "15:30"


### PR DESCRIPTION
## Summary
- add a dedicated timezone-aware datetime helper module and corresponding unit tests
- plumb timezone configuration through Config/bootstrap so logging, services and models use UTC internally and format output in the configured locale
- update StatsService and supporting components to normalise timestamps in UTC and render user-facing text in the local timezone

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d31d9314a08328a3629a30716deec8