### PR TITLE
Refactor game engine responsibilities into dedicated services

### DIFF
--- a/pokerapp/matchmaking_service.py
+++ b/pokerapp/matchmaking_service.py
@@ -1,0 +1,263 @@
+"""Matchmaking and hand lifecycle helpers for the poker engine."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Dict, Optional, Tuple
+
+from pokerapp.entities import ChatId, Game, GameState, Player, PlayerState
+from pokerapp.player_manager import PlayerManager
+from pokerapp.pokerbotview import PokerBotViewer
+from pokerapp.stats_reporter import StatsReporter
+from pokerapp.utils.request_metrics import RequestMetrics
+from pokerapp.lock_manager import LockManager
+
+
+class MatchmakingService:
+    """Encapsulate start-hand orchestration and round progression."""
+
+    def __init__(
+        self,
+        *,
+        view: PokerBotViewer,
+        round_rate,
+        request_metrics: RequestMetrics,
+        player_manager: PlayerManager,
+        stats_reporter: StatsReporter,
+        lock_manager: LockManager,
+        send_turn_message: Callable[[Game, Player, ChatId], Awaitable[None]],
+        safe_int: Callable[[ChatId], int],
+        old_players_key: str,
+        logger: logging.Logger,
+    ) -> None:
+        self._view = view
+        self._round_rate = round_rate
+        self._request_metrics = request_metrics
+        self._player_manager = player_manager
+        self._stats_reporter = stats_reporter
+        self._lock_manager = lock_manager
+        self._send_turn_message = send_turn_message
+        self._safe_int = safe_int
+        self._old_players_key = old_players_key
+        self._logger = logger
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    async def start_game(
+        self,
+        *,
+        context,
+        game: Game,
+        chat_id: ChatId,
+        build_identity_from_player: Callable[[Player], object],
+    ) -> None:
+        await self._player_manager.cleanup_ready_prompt(game, chat_id)
+
+        if not hasattr(game, "dealer_index"):
+            game.dealer_index = -1
+
+        new_dealer_index = game.advance_dealer()
+        if new_dealer_index == -1:
+            new_dealer_index = game.next_occupied_seat(-1)
+            game.dealer_index = new_dealer_index
+
+        if game.dealer_index == -1:
+            self._logger.warning("Cannot start game without an occupied dealer seat")
+            return
+
+        await self._stats_reporter.hand_started(
+            game,
+            chat_id,
+            build_identity_from_player,
+        )
+
+        game.state = GameState.ROUND_PRE_FLOP
+        await self._request_metrics.start_cycle(self._safe_int(chat_id), game.id)
+
+        await self._player_manager.clear_seat_announcement(game, chat_id)
+        await self._player_manager.clear_player_anchors(game)
+
+        await self._divide_cards(game, chat_id)
+        if game.state == GameState.INITIAL:
+            return
+
+        current_player = await self._round_rate.set_blinds(game, chat_id)
+        self._player_manager.assign_role_labels(game)
+
+        await self._stats_reporter.invalidate_players(game.players)
+
+        game.chat_id = chat_id
+
+        async with self._lock_manager.guard(self._stage_lock_key(chat_id), timeout=10):
+            await self._view.send_player_role_anchors(game=game, chat_id=chat_id)
+
+        action_str = "بازی شروع شد"
+        game.last_actions.append(action_str)
+        if len(game.last_actions) > 5:
+            game.last_actions.pop(0)
+
+        if current_player:
+            await self._send_turn_message(game, current_player, chat_id)
+
+        context.chat_data[self._old_players_key] = [p.user_id for p in game.players]
+
+    async def progress_stage(
+        self,
+        *,
+        context,
+        chat_id: ChatId,
+        game: Game,
+        finalize_game: Callable[[Any, Game, ChatId], Awaitable[None]],
+    ) -> bool:
+        game.chat_id = chat_id
+
+        contenders = game.players_by(states=(PlayerState.ACTIVE, PlayerState.ALL_IN))
+        if len(contenders) <= 1:
+            await finalize_game(context=context, game=game, chat_id=chat_id)
+            game.current_player_index = -1
+            return False
+
+        stage_transitions: Dict[GameState, Tuple[GameState, int, str]] = {
+            GameState.ROUND_PRE_FLOP: (GameState.ROUND_FLOP, 3, "🃏 فلاپ"),
+            GameState.ROUND_FLOP: (GameState.ROUND_TURN, 1, "🃏 ترن"),
+            GameState.ROUND_TURN: (GameState.ROUND_RIVER, 1, "🃏 ریور"),
+        }
+
+        while True:
+            self._round_rate.collect_bets_for_pot(game)
+            for player in game.players:
+                player.has_acted = False
+
+            transition = stage_transitions.get(game.state)
+            if transition:
+                next_state, card_count, stage_label = transition
+                self._logger.debug(
+                    "Advancing game %s to %s",
+                    game.id,
+                    self._state_token(next_state),
+                )
+                game.state = next_state
+                await self._add_cards_to_table(
+                    count=card_count,
+                    game=game,
+                    chat_id=chat_id,
+                    street_name=stage_label,
+                    send_message=True,
+                )
+            elif game.state == GameState.ROUND_RIVER:
+                await finalize_game(context=context, game=game, chat_id=chat_id)
+                game.current_player_index = -1
+                return False
+            else:
+                self._logger.warning("Unexpected state %s during stage progression", game.state)
+                game.current_player_index = -1
+                return False
+
+            active_players = game.players_by(states=(PlayerState.ACTIVE,))
+            if not active_players:
+                if game.state == GameState.ROUND_RIVER:
+                    await finalize_game(context=context, game=game, chat_id=chat_id)
+                    game.current_player_index = -1
+                    return False
+                continue
+
+            first_player_index = self._round_rate._find_next_active_player_index(  # type: ignore[attr-defined]
+                game,
+                game.dealer_index,
+            )
+            game.current_player_index = first_player_index
+            if first_player_index == -1:
+                if game.state == GameState.ROUND_RIVER:
+                    await finalize_game(context=context, game=game, chat_id=chat_id)
+                    game.current_player_index = -1
+                    return False
+                continue
+
+            return True
+
+    async def add_cards_to_table(
+        self,
+        *,
+        count: int,
+        game: Game,
+        chat_id: ChatId,
+        street_name: str,
+        send_message: bool,
+    ) -> None:
+        async with self._lock_manager.guard(self._stage_lock_key(chat_id), timeout=10):
+            await self._add_cards_to_table(
+                count=count,
+                game=game,
+                chat_id=chat_id,
+                street_name=street_name,
+                send_message=send_message,
+            )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    async def _divide_cards(self, game: Game, chat_id: ChatId) -> None:
+        for player in game.seated_players():
+            if len(game.remain_cards) < 2:
+                await self._view.send_message(
+                    chat_id, "کارت‌های کافی در دسته وجود ندارد! بازی ریست می‌شود."
+                )
+                await self._request_metrics.end_cycle(
+                    self._safe_int(chat_id), cycle_token=game.id
+                )
+                game.reset()
+                return
+
+            cards = [game.remain_cards.pop(), game.remain_cards.pop()]
+            player.cards = cards
+
+    async def _add_cards_to_table(
+        self,
+        *,
+        count: int,
+        game: Game,
+        chat_id: ChatId,
+        street_name: str,
+        send_message: bool,
+    ) -> None:
+        game.chat_id = chat_id
+        should_refresh_anchors = count > 0
+        if count > 0:
+            for _ in range(count):
+                if game.remain_cards:
+                    game.cards_table.append(game.remain_cards.pop())
+
+        if should_refresh_anchors:
+            await self._view.update_player_anchors_and_keyboards(game)
+
+        if not send_message:
+            return
+
+        if game.board_message_id:
+            try:
+                await self._view.delete_message(chat_id, game.board_message_id)
+                if game.board_message_id in game.message_ids_to_delete:
+                    game.message_ids_to_delete.remove(game.board_message_id)
+            except Exception:  # pragma: no cover - best effort cleanup
+                self._logger.debug(
+                    "Failed to delete board message",
+                    extra={
+                        "chat_id": chat_id,
+                        "message_id": game.board_message_id,
+                    },
+                )
+            game.board_message_id = None
+
+    def _stage_lock_key(self, chat_id: ChatId) -> str:
+        return f"stage:{self._safe_int(chat_id)}"
+
+    @staticmethod
+    def _state_token(state: Optional[GameState]) -> str:
+        name = getattr(state, "name", None)
+        if isinstance(name, str):
+            return name
+        value = getattr(state, "value", None)
+        if isinstance(value, str):
+            return value
+        return str(state)

--- a/pokerapp/player_identity_manager.py
+++ b/pokerapp/player_identity_manager.py
@@ -1,0 +1,272 @@
+"""Player identity management utilities for PokerBot."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any, Callable, Dict, Optional
+
+from telegram import Update, User
+from telegram.ext import ContextTypes
+
+import redis.asyncio as aioredis
+
+from pokerapp.entities import ChatId, Game, Player
+from pokerapp.pokerbotview import PokerBotViewer
+from pokerapp.stats import BaseStatsService, NullStatsService, PlayerIdentity
+from pokerapp.table_manager import TableManager
+from pokerapp.utils.cache import AdaptivePlayerReportCache
+from pokerapp.utils.player_report_cache import (
+    PlayerReportCache as RedisPlayerReportCache,
+)
+
+
+class PlayerIdentityManager:
+    """Handle player identity bookkeeping, registration, and reports."""
+
+    def __init__(
+        self,
+        *,
+        table_manager: TableManager,
+        kv: aioredis.Redis,
+        stats_service: BaseStatsService,
+        player_report_cache: AdaptivePlayerReportCache,
+        shared_report_cache: Optional[RedisPlayerReportCache],
+        shared_report_ttl: int,
+        view: PokerBotViewer,
+        build_private_menu: Callable[[], object],
+        logger: logging.Logger,
+    ) -> None:
+        self._table_manager = table_manager
+        self._kv = kv
+        self._stats_service = stats_service
+        self._player_report_cache = player_report_cache
+        self._shared_report_cache = shared_report_cache
+        self._shared_report_ttl = max(int(shared_report_ttl or 0), 0)
+        self._view = view
+        self._build_private_menu = build_private_menu
+        self._logger = logger
+        self._private_chat_ids: Dict[int, int] = {}
+
+    @staticmethod
+    def _safe_int(value: object) -> int:
+        try:
+            return int(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return 0
+
+    @property
+    def private_chat_ids(self) -> Dict[int, int]:
+        return self._private_chat_ids
+
+    def _stats_enabled(self) -> bool:
+        return not isinstance(self._stats_service, NullStatsService)
+
+    async def send_statistics_report(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        chat = update.effective_chat
+        user = update.effective_user
+        if chat.type != chat.PRIVATE:
+            await self._view.send_message(
+                chat.id,
+                "ℹ️ برای مشاهده آمار دقیق، لطفاً در چت خصوصی ربات از دکمه «📊 آمار بازی» استفاده کنید.",
+            )
+            return
+
+        await self.register_player_identity(user, private_chat_id=chat.id)
+
+        if not self._stats_enabled():
+            await self._view.send_message(
+                chat.id,
+                "⚙️ سیستم آمار در حال حاضر غیرفعال است. لطفاً بعداً دوباره تلاش کنید.",
+                reply_markup=self._build_private_menu(),
+            )
+            return
+
+        user_id_int = self._safe_int(user.id)
+
+        formatted_report: Optional[str] = None
+        if self._shared_report_cache is not None:
+            cached_payload = await self._shared_report_cache.get_report(user_id_int)
+            if isinstance(cached_payload, dict):
+                formatted_report = cached_payload.get("formatted")
+                if formatted_report:
+                    await self._view.send_message(
+                        chat.id,
+                        formatted_report,
+                        reply_markup=self._build_private_menu(),
+                    )
+                    return
+
+        async def _load_report() -> Optional[Any]:
+            return await self._stats_service.build_player_report(user_id_int)
+
+        report = await self._player_report_cache.get_with_context(
+            user_id_int,
+            _load_report,
+        )
+        if report is None or (
+            report.stats.total_games <= 0 and not report.recent_games
+        ):
+            await self._view.send_message(
+                chat.id,
+                "ℹ️ هنوز داده‌ای برای نمایش وجود ندارد. پس از شرکت در چند دست بازی دوباره تلاش کنید.",
+                reply_markup=self._build_private_menu(),
+            )
+            return
+
+        formatted = self._stats_service.format_report(report)
+        if self._shared_report_cache is not None:
+            await self._shared_report_cache.set_report(
+                user_id_int,
+                {"formatted": formatted},
+                ttl_seconds=self._shared_report_ttl,
+            )
+        await self._view.send_message(
+            chat.id,
+            formatted,
+            reply_markup=self._build_private_menu(),
+        )
+
+    async def send_wallet_balance(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        chat = update.effective_chat
+        user = update.effective_user
+
+        if chat.type == chat.PRIVATE:
+            await self.register_player_identity(user, private_chat_id=chat.id)
+        else:
+            await self.register_player_identity(user)
+
+        from pokerapp.pokerbotmodel import WalletManagerModel
+
+        wallet = WalletManagerModel(user.id, self._kv)
+        balance = await wallet.value()
+
+        reply_markup = self._build_private_menu() if chat.type == chat.PRIVATE else None
+        await self._view.send_message(
+            chat.id,
+            f"💰 موجودی فعلی شما: {balance}$",
+            reply_markup=reply_markup,
+        )
+
+    async def _update_private_chat_id_in_active_game(
+        self, player_id: int, private_chat_id: int
+    ) -> None:
+        """Locate active game containing player and update their private chat ID."""
+
+        table_manager = self._table_manager
+        if table_manager is None:
+            return
+
+        try:
+            game = None
+            chat_id: Optional[ChatId] = None
+
+            tables = getattr(table_manager, "_tables", None)
+            if isinstance(tables, dict):
+                for candidate_chat_id, candidate_game in tables.items():
+                    if candidate_game is None:
+                        continue
+                    for candidate_player in getattr(candidate_game, "players", []):
+                        if getattr(candidate_player, "user_id", None) == player_id:
+                            game = candidate_game
+                            chat_id = candidate_chat_id
+                            break
+                    if game is not None:
+                        break
+
+            if game is None:
+                finder = getattr(table_manager, "find_game_by_user", None)
+                if finder is not None:
+                    try:
+                        result = finder(player_id)
+                        if inspect.isawaitable(result):
+                            game, chat_id = await result
+                        elif result:
+                            game, chat_id = result
+                    except LookupError:
+                        game = None
+                        chat_id = None
+
+            if game is None:
+                return
+
+            updated = False
+            for player in getattr(game, "players", []):
+                if getattr(player, "user_id", None) == player_id:
+                    if getattr(player, "private_chat_id", None) != private_chat_id:
+                        player.private_chat_id = private_chat_id
+                        updated = True
+                    break
+
+            if updated and chat_id is not None:
+                saver = getattr(table_manager, "save_game", None)
+                if saver is not None:
+                    try:
+                        save_result = saver(chat_id, game)
+                        if inspect.isawaitable(save_result):
+                            await save_result
+                    except Exception:
+                        self._logger.exception(
+                            "Failed to persist game after updating private chat id",
+                            extra={"chat_id": chat_id, "user_id": player_id},
+                        )
+        except Exception:
+            self._logger.exception(
+                "Failed to update player private chat id in active game",
+                extra={"user_id": player_id},
+            )
+
+    async def _register_stats_identity(
+        self,
+        user: User,
+        private_chat_id: Optional[int],
+        display_name: Optional[str],
+    ) -> None:
+        """Register or update player identity in the stats service."""
+
+        if not self._stats_enabled():
+            return
+
+        identity = PlayerIdentity(
+            user_id=self._safe_int(user.id),
+            display_name=display_name
+            or user.full_name
+            or user.first_name
+            or str(user.id),
+            username=user.username,
+            full_name=user.full_name,
+            private_chat_id=private_chat_id,
+        )
+        await self._stats_service.register_player_profile(identity)
+
+    async def register_player_identity(
+        self,
+        user: User,
+        *,
+        private_chat_id: Optional[int] = None,
+        display_name: Optional[str] = None,
+    ) -> None:
+        player_id = self._safe_int(user.id)
+
+        if private_chat_id:
+            self._private_chat_ids[player_id] = private_chat_id
+            await self._update_private_chat_id_in_active_game(player_id, private_chat_id)
+
+        await self._register_stats_identity(user, private_chat_id, display_name)
+
+    def build_identity_from_player(self, player: Player) -> PlayerIdentity:
+        display_name = getattr(player, "display_name", None) or player.mention_markdown
+        username = getattr(player, "username", None)
+        full_name = getattr(player, "full_name", None)
+        private_chat_id = getattr(player, "private_chat_id", None)
+        return PlayerIdentity(
+            user_id=self._safe_int(player.user_id),
+            display_name=display_name,
+            username=username,
+            full_name=full_name,
+            private_chat_id=private_chat_id,
+        )

--- a/pokerapp/private_match_service.py
+++ b/pokerapp/private_match_service.py
@@ -11,7 +11,7 @@ from telegram import ReplyKeyboardMarkup, User
 from telegram.helpers import mention_markdown as format_mention_markdown
 
 from pokerapp.entities import ChatId, Player, UserId, Wallet
-from pokerapp.player_manager import PlayerManager
+from pokerapp.player_identity_manager import PlayerIdentityManager
 from pokerapp.pokerbotview import PokerBotViewer
 from pokerapp.stats import BaseStatsService, PlayerIdentity
 from pokerapp.table_manager import TableManager
@@ -101,7 +101,7 @@ class PrivateMatchService:
         self._safe_int_fn: Optional[Callable[[UserId], int]] = None
         self._build_private_menu: Optional[Callable[[], ReplyKeyboardMarkup]] = None
         self._view: Optional[PokerBotViewer] = None
-        self._player_manager: Optional[PlayerManager] = None
+        self._player_manager: Optional[PlayerIdentityManager] = None
         self._request_metrics: Optional[RequestMetrics] = None
         self._stats: Optional[BaseStatsService] = None
         self._stats_enabled: Optional[Callable[[], bool]] = None
@@ -115,7 +115,7 @@ class PrivateMatchService:
         safe_int: Callable[[UserId], int],
         build_private_menu: Callable[[], ReplyKeyboardMarkup],
         view: PokerBotViewer,
-        player_manager: PlayerManager,
+        player_manager: PlayerIdentityManager,
         request_metrics: RequestMetrics,
         stats_service: BaseStatsService,
         stats_enabled: Callable[[], bool],
@@ -449,7 +449,7 @@ class PrivateMatchService:
             raise RuntimeError("PrivateMatchService view dependency not configured")
         return self._view
 
-    def _require_player_manager(self) -> PlayerManager:
+    def _require_player_manager(self) -> PlayerIdentityManager:
         if self._player_manager is None:
             raise RuntimeError(
                 "PrivateMatchService player_manager dependency not configured"

--- a/pokerapp/stats_reporter.py
+++ b/pokerapp/stats_reporter.py
@@ -1,0 +1,151 @@
+"""Statistics reporting helpers for the poker game engine."""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Dict, Iterable, Optional, Sequence, Set
+
+from pokerapp.entities import ChatId, Game, Player, PlayerState
+from pokerapp.stats import (
+    BaseStatsService,
+    NullStatsService,
+    PlayerHandResult,
+    PlayerIdentity,
+)
+from pokerapp.utils.player_report_cache import (
+    PlayerReportCache as RedisPlayerReportCache,
+)
+
+
+class StatsReporter:
+    """Encapsulate stats service interactions and report cache invalidation."""
+
+    def __init__(
+        self,
+        *,
+        stats_service: BaseStatsService,
+        player_report_cache: Optional[RedisPlayerReportCache],
+        safe_int: Callable[[ChatId], int],
+        logger: logging.Logger,
+    ) -> None:
+        self._stats = stats_service
+        self._player_report_cache = player_report_cache
+        self._safe_int = safe_int
+        self._logger = logger
+
+    # ------------------------------------------------------------------
+    # Lifecycle helpers
+    # ------------------------------------------------------------------
+    def _stats_enabled(self) -> bool:
+        return not isinstance(self._stats, NullStatsService)
+
+    async def hand_started(
+        self,
+        game: Game,
+        chat_id: ChatId,
+        build_identity_from_player: Callable[[Player], PlayerIdentity],
+    ) -> None:
+        """Notify the stats backend that a hand has started and invalidate caches."""
+
+        if self._stats_enabled():
+            players = [
+                build_identity_from_player(player)
+                for player in game.seated_players()
+            ]
+            await self._stats.start_hand(
+                hand_id=game.id,
+                chat_id=self._safe_int(chat_id),
+                players=players,
+            )
+        await self.invalidate_players(game.seated_players())
+
+    async def hand_finished(
+        self,
+        game: Game,
+        chat_id: ChatId,
+        *,
+        payouts: Dict[int, int],
+        hand_labels: Dict[int, Optional[str]],
+        pot_total: int,
+    ) -> None:
+        """Report final hand statistics and invalidate cached player reports."""
+
+        if self._stats_enabled():
+            results = self._build_hand_results(
+                game=game, payouts=payouts, hand_labels=hand_labels
+            )
+            await self._stats.finish_hand(
+                hand_id=game.id,
+                chat_id=self._safe_int(chat_id),
+                results=results,
+                pot_total=pot_total,
+            )
+        await self.invalidate_players(game.players)
+
+    async def invalidate_players(
+        self, players: Iterable[Player | int]
+    ) -> None:
+        """Invalidate cached stats reports for the supplied ``players``."""
+
+        if not self._player_report_cache:
+            return
+
+        normalized: Set[int] = set()
+        for player in players:
+            user_id = player if isinstance(player, int) else getattr(player, "user_id", None)
+            if user_id is None:
+                continue
+            try:
+                user_id_int = int(user_id)
+            except (TypeError, ValueError):
+                continue
+            if user_id_int:
+                normalized.add(user_id_int)
+
+        if not normalized:
+            return
+
+        await self._player_report_cache.invalidate(normalized)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _build_hand_results(
+        self,
+        *,
+        game: Game,
+        payouts: Dict[int, int],
+        hand_labels: Dict[int, Optional[str]],
+    ) -> Sequence[PlayerHandResult]:
+        results = []
+        for player in game.seated_players():
+            try:
+                user_id = int(getattr(player, "user_id", 0) or 0)
+            except (TypeError, ValueError):
+                user_id = 0
+            total_bet = int(getattr(player, "total_bet", 0))
+            payout = int(payouts.get(user_id, 0))
+            net_profit = payout - total_bet
+            if net_profit > 0 or (payout > 0 and total_bet == 0):
+                result_flag = "win"
+            elif net_profit < 0:
+                result_flag = "loss"
+            else:
+                result_flag = "push"
+            label = hand_labels.get(user_id)
+            if not label and result_flag == "win" and getattr(player, "state", None) == PlayerState.ALL_IN:
+                label = "پیروزی با آل-این"
+            was_all_in = getattr(player, "state", None) == PlayerState.ALL_IN
+            results.append(
+                PlayerHandResult(
+                    user_id=user_id,
+                    display_name=getattr(player, "mention_markdown", str(user_id)),
+                    total_bet=total_bet,
+                    payout=payout,
+                    net_profit=net_profit,
+                    hand_type=label,
+                    was_all_in=was_all_in,
+                    result=result_flag,
+                )
+            )
+        return results

--- a/tests/test_game_engine_finalization.py
+++ b/tests/test_game_engine_finalization.py
@@ -123,8 +123,8 @@ async def test_finalize_game_single_winner_distributes_pot_and_updates_stats():
         stats_service=stats,
     )
     model._game_engine._clear_game_messages = AsyncMock()
-    model._game_engine._clear_player_anchors = AsyncMock()
-    model._game_engine._send_join_prompt = AsyncMock()
+    model._player_manager.clear_player_anchors = AsyncMock()
+    model._player_manager.send_join_prompt = AsyncMock()
 
     game = Game()
     game.state = GameState.ROUND_RIVER
@@ -169,7 +169,7 @@ async def test_finalize_game_single_winner_distributes_pot_and_updates_stats():
     assert context.chat_data[KEY_OLD_PLAYERS] == [winner.user_id, loser.user_id]
     table_manager.save_game.assert_awaited()
     view.send_new_hand_ready_message.assert_awaited_once_with(chat_id)
-    model._game_engine._send_join_prompt.assert_awaited_once()
+    model._player_manager.send_join_prompt.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -193,8 +193,8 @@ async def test_finalize_game_split_pot_between_tied_winners():
         stats_service=stats,
     )
     model._game_engine._clear_game_messages = AsyncMock()
-    model._game_engine._clear_player_anchors = AsyncMock()
-    model._game_engine._send_join_prompt = AsyncMock()
+    model._player_manager.clear_player_anchors = AsyncMock()
+    model._player_manager.send_join_prompt = AsyncMock()
 
     game = Game()
     game.state = GameState.ROUND_RIVER

--- a/tests/test_pokerbotmodel.py
+++ b/tests/test_pokerbotmodel.py
@@ -991,7 +991,7 @@ async def test_showdown_sends_new_hand_message_before_join_prompt():
         private_match_service=private_match_service,
     )
     model._game_engine._clear_game_messages = AsyncMock()
-    model._game_engine._send_join_prompt = AsyncMock(side_effect=record_join_prompt)
+    model._player_manager.send_join_prompt = AsyncMock(side_effect=record_join_prompt)
     model._game_engine._evaluate_contender_hands = MagicMock(return_value=[])
     model._game_engine._determine_winners = MagicMock(return_value=[])
 
@@ -1041,8 +1041,8 @@ async def test_start_game_assigns_blinds_to_occupied_seats():
         table_manager=table_manager,
         private_match_service=private_match_service,
     )
-    model._game_engine._divide_cards = AsyncMock()
-    model._game_engine._send_turn_message = AsyncMock()
+    model._matchmaking_service._divide_cards = AsyncMock()
+    model._matchmaking_service._send_turn_message = AsyncMock()
     model._round_rate._set_player_blind = AsyncMock()
 
     game = Game()
@@ -1092,8 +1092,8 @@ async def test_start_game_assigns_blinds_to_occupied_seats():
     view.send_player_role_anchors.assert_awaited_once_with(game=game, chat_id=chat_id)
     view.sync_player_private_keyboards.assert_not_awaited()
 
-    model._game_engine._send_turn_message.assert_awaited_once()
-    send_call = model._game_engine._send_turn_message.await_args
+    model._matchmaking_service._send_turn_message.assert_awaited_once()
+    send_call = model._matchmaking_service._send_turn_message.await_args
     assert send_call.args[1].user_id == player_b.user_id
     assert send_call.args[2] == chat_id
 
@@ -1118,7 +1118,7 @@ async def test_start_game_keeps_ready_message_id_when_deletion_fails():
         table_manager=table_manager,
         private_match_service=private_match_service,
     )
-    model._game_engine._divide_cards = AsyncMock()
+    model._matchmaking_service._divide_cards = AsyncMock()
     model._round_rate.set_blinds = AsyncMock(return_value=None)
 
     game = Game()
@@ -1144,7 +1144,7 @@ async def test_start_game_keeps_ready_message_id_when_deletion_fails():
     view.delete_message.assert_awaited_once_with(chat_id, ready_message_id)
     assert game.ready_message_main_id == ready_message_id
     assert game.ready_message_main_text == ""
-    model._game_engine._divide_cards.assert_awaited_once_with(game, chat_id)
+    model._matchmaking_service._divide_cards.assert_awaited_once_with(game, chat_id)
     model._round_rate.set_blinds.assert_awaited_once_with(game, chat_id)
     view.send_player_role_anchors.assert_awaited_once_with(game=game, chat_id=chat_id)
     view.sync_player_private_keyboards.assert_not_awaited()


### PR DESCRIPTION
## Summary
- introduce lifecycle PlayerManager, MatchmakingService, and StatsReporter services and wire them into the game engine
- move player identity logic into a dedicated PlayerIdentityManager module and adjust consumers
- update tests to cover the new service boundaries and expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d385ff8e688328923fa8222fc1ab6e