### PR TITLE
Refactor game flow helpers and add unit tests

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -266,7 +266,7 @@ class PokerBotModel:
         """Serialize stateful operations for a chat while allowing nesting."""
 
         key = f"chat:{self._safe_int(chat_id)}"
-        async with self._lock_manager.guard(key, timeout=10):
+        async with self._lock_manager.guard(key, timeout=10, level=0):
             yield
 
     def assign_role_labels(self, game: Game) -> None:

--- a/tests/test_game_engine_helpers.py
+++ b/tests/test_game_engine_helpers.py
@@ -1,0 +1,176 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pokerapp.entities import Game, GameState, Player
+from pokerapp.game_engine import GameEngine
+
+
+@pytest.fixture
+def game_engine_setup():
+    table_manager = MagicMock()
+    table_manager.save_game = AsyncMock()
+
+    view = MagicMock()
+    view.send_message = AsyncMock()
+
+    request_metrics = MagicMock()
+    request_metrics.end_cycle = AsyncMock()
+
+    stats_reporter = MagicMock()
+    stats_reporter.invalidate_players = AsyncMock()
+
+    player_manager = MagicMock()
+    player_manager.clear_player_anchors = AsyncMock()
+
+    safe_edit_message_text = AsyncMock(return_value=None)
+
+    engine = GameEngine(
+        table_manager=table_manager,
+        view=view,
+        winner_determination=MagicMock(),
+        request_metrics=request_metrics,
+        round_rate=MagicMock(),
+        player_manager=player_manager,
+        matchmaking_service=MagicMock(),
+        stats_reporter=stats_reporter,
+        clear_game_messages=AsyncMock(),
+        build_identity_from_player=lambda player: player,
+        safe_int=int,
+        old_players_key="old_players",
+        safe_edit_message_text=safe_edit_message_text,
+        lock_manager=MagicMock(),
+        logger=MagicMock(),
+    )
+
+    return SimpleNamespace(
+        engine=engine,
+        view=view,
+        table_manager=table_manager,
+        request_metrics=request_metrics,
+        stats_reporter=stats_reporter,
+        player_manager=player_manager,
+        safe_edit_message_text=safe_edit_message_text,
+    )
+
+
+@pytest.mark.asyncio
+async def test_refund_players_cancels_wallets_and_invalidates(game_engine_setup):
+    wallet_a = MagicMock()
+    wallet_a.cancel = AsyncMock()
+    player_a = Player(
+        user_id=1,
+        mention_markdown="@a",
+        wallet=wallet_a,
+        ready_message_id="r1",
+    )
+
+    wallet_b = MagicMock()
+    wallet_b.cancel = AsyncMock()
+    player_b = Player(
+        user_id=2,
+        mention_markdown="@b",
+        wallet=wallet_b,
+        ready_message_id="r2",
+    )
+
+    await game_engine_setup.engine._refund_players(
+        [player_a, player_b], "game-123"
+    )
+
+    wallet_a.cancel.assert_awaited_once_with("game-123")
+    wallet_b.cancel.assert_awaited_once_with("game-123")
+    game_engine_setup.stats_reporter.invalidate_players.assert_awaited_once_with(
+        [player_a, player_b]
+    )
+
+
+@pytest.mark.asyncio
+async def test_finalize_stop_request_updates_message_and_clears_context(
+    game_engine_setup,
+):
+    context = SimpleNamespace(chat_data={"stop_request": "keep"})
+    context.chat_data[game_engine_setup.engine.KEY_STOP_REQUEST] = {
+        "game_id": "game-1"
+    }
+
+    stop_request = {
+        "message_id": 42,
+        "active_players": {1},
+        "votes": {1},
+        "manager_override": False,
+    }
+
+    await game_engine_setup.engine._finalize_stop_request(
+        context=context,
+        chat_id=-500,
+        stop_request=stop_request,
+    )
+
+    game_engine_setup.safe_edit_message_text.assert_awaited_once()
+    assert (
+        game_engine_setup.engine.KEY_STOP_REQUEST not in context.chat_data
+    )
+
+
+@pytest.mark.asyncio
+async def test_reset_game_state_clears_pot_and_persists(game_engine_setup):
+    game = Game()
+    game.pot = 300
+
+    await game_engine_setup.engine._reset_game_state(
+        game=game, chat_id=-400, context=SimpleNamespace(chat_data={})
+    )
+
+    assert game.pot == 0
+    assert game.state == GameState.INITIAL
+    game_engine_setup.request_metrics.end_cycle.assert_awaited_once()
+    game_engine_setup.player_manager.clear_player_anchors.assert_awaited_once_with(game)
+    game_engine_setup.table_manager.save_game.assert_awaited_once_with(-400, game)
+    game_engine_setup.view.send_message.assert_awaited_once_with(
+        -400, "🛑 بازی متوقف شد."
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_votes_and_message_tracks_manager_override(game_engine_setup):
+    context = SimpleNamespace(chat_data={})
+    stop_request = {"message_id": 5, "votes": set(), "active_players": {1}}
+
+    updated = await game_engine_setup.engine._update_votes_and_message(
+        context=context,
+        game=Game(),
+        chat_id=-10,
+        stop_request=stop_request,
+        voter_id="manager",
+        manager_id="manager",
+        votes=set(),
+    )
+
+    assert updated["manager_override"] is True
+    assert "manager" in updated["votes"]
+    assert (
+        context.chat_data[game_engine_setup.engine.KEY_STOP_REQUEST] is updated
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_if_stop_passes_triggers_cancel(game_engine_setup):
+    engine = game_engine_setup.engine
+    engine.cancel_hand = AsyncMock()
+
+    stop_request = {
+        "votes": {1, 2},
+        "manager_override": False,
+    }
+
+    await engine._check_if_stop_passes(
+        game=Game(),
+        chat_id=-1,
+        context=SimpleNamespace(chat_data={}),
+        stop_request=stop_request,
+        active_ids={1, 2, 3},
+    )
+
+    engine.cancel_hand.assert_awaited_once()

--- a/tests/test_matchmaking_service_helpers.py
+++ b/tests/test_matchmaking_service_helpers.py
@@ -1,0 +1,184 @@
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pokerapp.entities import Game, GameState, Player
+from pokerapp.matchmaking_service import MatchmakingService
+
+
+class DummyLockManager:
+    def __init__(self) -> None:
+        self.calls = []
+
+    @asynccontextmanager
+    async def _guard(self, key: str, timeout: int):
+        self.calls.append((key, timeout))
+        yield
+
+    def guard(self, key: str, timeout: int):
+        return self._guard(key, timeout)
+
+
+@pytest.fixture
+def matchmaking_setup():
+    view = MagicMock()
+    view.send_player_role_anchors = AsyncMock()
+
+    round_rate = MagicMock()
+    round_rate.set_blinds = AsyncMock()
+
+    request_metrics = MagicMock()
+    request_metrics.start_cycle = AsyncMock()
+
+    player_manager = MagicMock()
+    player_manager.clear_seat_announcement = AsyncMock()
+    player_manager.clear_player_anchors = AsyncMock()
+    player_manager.assign_role_labels = MagicMock()
+
+    stats_reporter = MagicMock()
+    stats_reporter.invalidate_players = AsyncMock()
+
+    send_turn_message = AsyncMock()
+
+    lock_manager = DummyLockManager()
+
+    service = MatchmakingService(
+        view=view,
+        round_rate=round_rate,
+        request_metrics=request_metrics,
+        player_manager=player_manager,
+        stats_reporter=stats_reporter,
+        lock_manager=lock_manager,
+        send_turn_message=send_turn_message,
+        safe_int=int,
+        old_players_key="old_players",
+        logger=MagicMock(),
+    )
+
+    return SimpleNamespace(
+        service=service,
+        view=view,
+        round_rate=round_rate,
+        request_metrics=request_metrics,
+        player_manager=player_manager,
+        stats_reporter=stats_reporter,
+        send_turn_message=send_turn_message,
+        lock_manager=lock_manager,
+    )
+
+
+def test_ensure_dealer_position_requires_seated_players(matchmaking_setup):
+    service = matchmaking_setup.service
+    service._logger.warning = MagicMock()
+
+    game = Game()
+    game.seats = [None for _ in game.seats]
+    game.dealer_index = -1
+
+    assert service._ensure_dealer_position(game) is False
+    service._logger.warning.assert_called_once()
+
+
+def test_ensure_dealer_position_advances_to_occupied_seat(matchmaking_setup):
+    service = matchmaking_setup.service
+    game = Game()
+    player = Player(
+        user_id=1,
+        mention_markdown="@p",
+        wallet=MagicMock(),
+        ready_message_id="r",
+    )
+    game.add_player(player, seat_index=0)
+
+    assert service._ensure_dealer_position(game) is True
+    assert game.dealer_index == 0
+
+
+@pytest.mark.asyncio
+async def test_initialize_hand_state_sets_state_and_metrics(matchmaking_setup):
+    service = matchmaking_setup.service
+    game = Game()
+
+    await service._initialize_hand_state(game, "-55")
+
+    assert game.state == GameState.ROUND_PRE_FLOP
+    matchmaking_setup.request_metrics.start_cycle.assert_awaited_once_with(
+        -55, game.id
+    )
+
+
+@pytest.mark.asyncio
+async def test_clear_seat_state_invokes_player_manager(matchmaking_setup):
+    service = matchmaking_setup.service
+    game = Game()
+
+    await service._clear_seat_state(game, -100)
+
+    matchmaking_setup.player_manager.clear_seat_announcement.assert_awaited_once_with(
+        game, -100
+    )
+    matchmaking_setup.player_manager.clear_player_anchors.assert_awaited_once_with(game)
+
+
+@pytest.mark.asyncio
+async def test_deal_hole_cards_delegates_to_divide(matchmaking_setup):
+    service = matchmaking_setup.service
+    service._divide_cards = AsyncMock()
+
+    game = Game()
+    await service._deal_hole_cards(game, -200)
+
+    service._divide_cards.assert_awaited_once_with(game, -200)
+
+
+@pytest.mark.asyncio
+async def test_post_blinds_assigns_roles_and_invalidates(matchmaking_setup):
+    service = matchmaking_setup.service
+    game = Game()
+    player = Player(
+        user_id=1,
+        mention_markdown="@p",
+        wallet=MagicMock(),
+        ready_message_id="r",
+    )
+    game.add_player(player, seat_index=0)
+
+    matchmaking_setup.round_rate.set_blinds.return_value = player
+
+    current = await service._post_blinds_and_prepare_players(game, -300)
+
+    assert current is player
+    matchmaking_setup.player_manager.assign_role_labels.assert_called_once_with(game)
+    matchmaking_setup.stats_reporter.invalidate_players.assert_awaited_once_with(
+        game.players
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_post_start_notifications_sends_updates(matchmaking_setup):
+    service = matchmaking_setup.service
+    game = Game()
+    player = Player(
+        user_id=1,
+        mention_markdown="@p",
+        wallet=MagicMock(),
+        ready_message_id="r",
+    )
+    game.add_player(player, seat_index=0)
+
+    context = SimpleNamespace(chat_data={})
+    await service._handle_post_start_notifications(
+        context=context,
+        game=game,
+        chat_id=-400,
+        current_player=player,
+    )
+
+    assert game.chat_id == -400
+    matchmaking_setup.view.send_player_role_anchors.assert_awaited_once()
+    matchmaking_setup.send_turn_message.assert_awaited_once_with(game, player, -400)
+    assert context.chat_data["old_players"] == [player.user_id]
+    assert game.last_actions[-1] == "بازی شروع شد"
+


### PR DESCRIPTION
## Summary
- refactor stop vote confirmation and hand cancellation flows into granular helpers
- split matchmaking start_game orchestration into dedicated seat, dealing, and blind helpers
- add unit tests covering new helper behaviors and adjust chat guard lock level

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d38fcbf60c8328836a9fa2c08a80c2