### PR TITLE
Implement centralized Telegram safe operations with retries

### DIFF
--- a/main.py
+++ b/main.py
@@ -124,6 +124,7 @@ def main() -> None:
         request_metrics=services.request_metrics,
         private_match_service=services.private_match_service,
         messaging_service_factory=services.messaging_service_factory,
+        telegram_safeops_factory=services.telegram_safeops_factory,
     )
     if use_polling:
         bot.run_polling()

--- a/pokerapp/pokerbot.py
+++ b/pokerapp/pokerbot.py
@@ -16,6 +16,7 @@ from pokerapp.table_manager import TableManager
 from pokerapp.stats import BaseStatsService
 from pokerapp.private_match_service import PrivateMatchService
 from pokerapp.utils.messaging_service import MessagingService
+from pokerapp.utils.telegram_safeops import TelegramSafeOps
 from pokerapp.utils.redis_safeops import RedisSafeOps
 from pokerapp.utils.request_metrics import RequestMetrics
 from pokerapp.utils.player_report_cache import PlayerReportCache
@@ -34,6 +35,7 @@ if TYPE_CHECKING:
 
 
 MessagingServiceFactory = Callable[..., MessagingService]
+TelegramSafeOpsFactory = Callable[..., TelegramSafeOps]
 
 
 class PokerBot:
@@ -61,6 +63,7 @@ class PokerBot:
         request_metrics: RequestMetrics,
         private_match_service: PrivateMatchService,
         messaging_service_factory: MessagingServiceFactory,
+        telegram_safeops_factory: TelegramSafeOpsFactory,
     ):
         self._cfg = cfg
         self._token = token
@@ -88,6 +91,7 @@ class PokerBot:
         self._request_metrics = request_metrics
         self._private_match_service = private_match_service
         self._messaging_service_factory = messaging_service_factory
+        self._telegram_safeops_factory = telegram_safeops_factory
         self._player_report_cache = player_report_cache
         self._build_application()
 
@@ -219,6 +223,7 @@ class PokerBot:
             request_metrics=self._request_metrics,
             messaging_service_factory=self._messaging_service_factory,
         )
+        telegram_safe_ops = self._telegram_safeops_factory(view=self._view)
         self._model = PokerBotModel(
             view=self._view,
             bot=self._application.bot,
@@ -229,6 +234,7 @@ class PokerBot:
             stats_service=self._stats_service,
             redis_ops=self._redis_ops,
             player_report_cache=self._player_report_cache,
+            telegram_safe_ops=telegram_safe_ops,
         )
         self._controller = PokerBotCotroller(self._model, self._application)
 

--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -3818,6 +3818,8 @@ class PokerBotViewer:
         text: str,
         reply_markup: ReplyKeyboardMarkup = None,
         request_category: RequestCategory = RequestCategory.GENERAL,
+        *,
+        suppress_exceptions: bool = True,
     ) -> Optional[MessageId]:
         """Sends a message and returns its ID, or None if not applicable."""
         context = self._build_context("send_message_return_id", chat_id=chat_id)
@@ -3859,6 +3861,8 @@ class PokerBotViewer:
                     "request_params": {"text": text},
                 },
             )
+            if not suppress_exceptions:
+                raise
         return None
 
     async def last_message_edit_at(
@@ -4029,6 +4033,8 @@ class PokerBotViewer:
         parse_mode: str = ParseMode.MARKDOWN,
         disable_web_page_preview: bool = False,
         request_category: RequestCategory = RequestCategory.GENERAL,
+        *,
+        suppress_exceptions: bool = True,
     ) -> Optional[MessageId]:
         """Edit a message using the central ``MessagingService``.
 
@@ -4074,7 +4080,9 @@ class PokerBotViewer:
                     "context": context,
                 },
             )
-            return None
+            if suppress_exceptions:
+                return None
+            raise
 
     async def delete_message(
         self,
@@ -4084,6 +4092,7 @@ class PokerBotViewer:
         allow_anchor_deletion: bool = False,
         anchor_reason: Optional[str] = None,
         game: Optional[Game] = None,
+        suppress_exceptions: bool = True,
     ) -> None:
         """Delete a message while keeping the cache in sync."""
         normalized_message = self._safe_int(message_id)
@@ -4230,6 +4239,8 @@ class PokerBotViewer:
                         "message_id": message_id,
                     },
                 )
+                if not suppress_exceptions:
+                    raise
                 return
             finally:
                 await self._clear_callback_tokens_for_message(

--- a/pokerapp/utils/telegram_safeops.py
+++ b/pokerapp/utils/telegram_safeops.py
@@ -1,0 +1,307 @@
+"""Robust wrappers around Telegram messaging operations.
+
+This module centralises retry and backoff behaviour for Telegram API calls.
+It augments the existing :class:`PokerBotViewer` helpers by retrying common
+transient failures (``RetryAfter``, ``TimedOut``, ``NetworkError``) with
+configurable exponential backoff while emitting structured logs for
+observability.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable, Optional, TypeVar
+
+from telegram.constants import ParseMode
+from telegram.error import BadRequest, NetworkError, RetryAfter, TelegramError, TimedOut
+
+from pokerapp.entities import ChatId, MessageId
+from pokerapp.utils.request_metrics import RequestCategory
+
+T = TypeVar("T")
+
+
+class TelegramSafeOps:
+    """Execute Telegram operations with retry and structured logging."""
+
+    _MIN_DELAY = 0.05
+
+    def __init__(
+        self,
+        view: Any,
+        *,
+        logger: logging.Logger,
+        max_retries: int,
+        base_delay: float,
+        max_delay: float,
+        backoff_multiplier: float,
+    ) -> None:
+        if view is None:
+            raise ValueError("view dependency must be provided")
+        if logger is None:
+            raise ValueError("logger dependency must be provided")
+
+        self._view = view
+        self._logger = logger
+        self._max_retries = max(0, int(max_retries))
+        self._base_delay = max(float(base_delay), self._MIN_DELAY)
+        self._max_delay = max(float(max_delay), self._base_delay)
+        self._multiplier = max(float(backoff_multiplier), 1.0)
+
+    async def edit_message_text(
+        self,
+        chat_id: ChatId,
+        message_id: MessageId,
+        text: str,
+        *,
+        reply_markup: Optional[Any] = None,
+        parse_mode: str = ParseMode.MARKDOWN,
+        log_context: Optional[str] = None,
+        request_category: RequestCategory = RequestCategory.GENERAL,
+    ) -> Optional[MessageId]:
+        """Safely edit a message, retrying transient failures when required."""
+
+        if not message_id:
+            return await self._send_message_return_id(
+                chat_id,
+                text,
+                reply_markup=reply_markup,
+                request_category=request_category,
+            )
+
+        try:
+            result = await self._execute(
+                operation="edit_message_text",
+                chat_id=chat_id,
+                message_id=message_id,
+                call=lambda: self._view.edit_message_text(  # type: ignore[misc]
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    text=text,
+                    reply_markup=reply_markup,
+                    request_category=request_category,
+                    parse_mode=parse_mode,
+                    suppress_exceptions=False,
+                ),
+            )
+        except BadRequest as exc:
+            self._log_bad_request(chat_id, message_id, text, log_context, exc)
+            result = None
+        except TelegramError as exc:
+            self._logger.error(
+                "TelegramError when editing message; will send a replacement",
+                extra=self._build_extra(
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    operation="edit_message_text",
+                    context=log_context,
+                    error_type=type(exc).__name__,
+                ),
+            )
+            result = None
+        except Exception as exc:
+            self._logger.error(
+                "Unexpected error when editing message; will send a replacement",
+                extra=self._build_extra(
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    operation="edit_message_text",
+                    context=log_context,
+                    error_type=type(exc).__name__,
+                ),
+            )
+            raise
+        else:
+            if result:
+                return result
+
+        new_id = await self._send_message_return_id(
+            chat_id,
+            text,
+            reply_markup=reply_markup,
+            request_category=request_category,
+        )
+
+        if new_id and message_id and new_id != message_id:
+            try:
+                await self._execute(
+                    operation="delete_message",
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    call=lambda: self._view.delete_message(  # type: ignore[misc]
+                        chat_id,
+                        message_id,
+                        suppress_exceptions=False,
+                    ),
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                self._logger.debug(
+                    "Failed to delete message after replacement",
+                    extra=self._build_extra(
+                        chat_id=chat_id,
+                        message_id=message_id,
+                        operation="delete_message",
+                        error_type=type(exc).__name__,
+                    ),
+                )
+
+            self._logger.info(
+                "Sent replacement message after edit failure",
+                extra=self._build_extra(
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    operation="edit_message_text",
+                    new_message_id=new_id,
+                ),
+            )
+
+        return new_id
+
+    async def _send_message_return_id(
+        self,
+        chat_id: ChatId,
+        text: str,
+        *,
+        reply_markup: Optional[Any] = None,
+        request_category: RequestCategory = RequestCategory.GENERAL,
+    ) -> Optional[MessageId]:
+        return await self._execute(
+            operation="send_message_return_id",
+            chat_id=chat_id,
+            message_id=None,
+            call=lambda: self._view.send_message_return_id(  # type: ignore[misc]
+                chat_id,
+                text,
+                reply_markup=reply_markup,
+                request_category=request_category,
+                suppress_exceptions=False,
+            ),
+        )
+
+    async def _execute(
+        self,
+        *,
+        operation: str,
+        call: Callable[[], Awaitable[T]],
+        chat_id: Optional[ChatId],
+        message_id: Optional[MessageId],
+    ) -> T:
+        max_attempts = self._max_retries + 1
+        attempt = 0
+        delay = self._base_delay
+
+        while True:
+            try:
+                return await call()
+            except asyncio.CancelledError:  # pragma: no cover - propagate cancellation
+                raise
+            except RetryAfter as exc:
+                attempt += 1
+                wait_time = float(getattr(exc, "retry_after", delay) or delay)
+                self._logger.warning(
+                    "RetryAfter received from Telegram; backing off",
+                    extra=self._build_extra(
+                        chat_id=chat_id,
+                        message_id=message_id,
+                        operation=operation,
+                        attempt=attempt,
+                        max_attempts=max_attempts,
+                        retry_after=wait_time,
+                        error_type=type(exc).__name__,
+                    ),
+                )
+                if attempt >= max_attempts:
+                    self._logger.error(
+                        "RetryAfter exceeded retry budget",
+                        extra=self._build_extra(
+                            chat_id=chat_id,
+                            message_id=message_id,
+                            operation=operation,
+                            attempt=attempt,
+                            max_attempts=max_attempts,
+                            retry_after=wait_time,
+                            error_type=type(exc).__name__,
+                        ),
+                    )
+                    raise
+                await asyncio.sleep(wait_time)
+                delay = self._base_delay
+                continue
+            except (TimedOut, NetworkError) as exc:
+                if isinstance(exc, BadRequest):
+                    raise
+                attempt += 1
+                if attempt >= max_attempts:
+                    self._logger.error(
+                        "Telegram operation failed after retries",
+                        extra=self._build_extra(
+                            chat_id=chat_id,
+                            message_id=message_id,
+                            operation=operation,
+                            attempt=attempt,
+                            max_attempts=max_attempts,
+                            error_type=type(exc).__name__,
+                        ),
+                    )
+                    raise
+                self._logger.warning(
+                    "Transient Telegram error; retrying",
+                    extra=self._build_extra(
+                        chat_id=chat_id,
+                        message_id=message_id,
+                        operation=operation,
+                        attempt=attempt,
+                        max_attempts=max_attempts,
+                        error_type=type(exc).__name__,
+                        delay=delay,
+                    ),
+                )
+                await asyncio.sleep(delay)
+                delay = min(delay * self._multiplier, self._max_delay)
+                continue
+
+    def _build_extra(
+        self,
+        *,
+        chat_id: Optional[ChatId],
+        message_id: Optional[MessageId],
+        operation: str,
+        context: Optional[str] = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        extra: dict[str, Any] = {
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "operation": operation,
+        }
+        if context is not None:
+            extra["context"] = context
+        extra.update(kwargs)
+        return extra
+
+    def _log_bad_request(
+        self,
+        chat_id: ChatId,
+        message_id: MessageId,
+        text: str,
+        context: Optional[str],
+        exc: BadRequest,
+    ) -> None:
+        preview = text
+        max_preview_length = 120
+        if len(preview) > max_preview_length:
+            preview = preview[: max_preview_length - 3] + "..."
+        error_message = getattr(exc, "message", None) or str(exc)
+        self._logger.warning(
+            "BadRequest when editing message; will send a replacement",
+            extra=self._build_extra(
+                chat_id=chat_id,
+                message_id=message_id,
+                operation="edit_message_text",
+                context=context or "general",
+                error_message=error_message,
+                text_preview=preview,
+            ),
+        )
+

--- a/tests/test_game_engine_helpers.py
+++ b/tests/test_game_engine_helpers.py
@@ -24,7 +24,9 @@ def game_engine_setup():
     player_manager = MagicMock()
     player_manager.clear_player_anchors = AsyncMock()
 
-    safe_edit_message_text = AsyncMock(return_value=None)
+    telegram_safe_ops = SimpleNamespace(
+        edit_message_text=AsyncMock(return_value=None)
+    )
 
     engine = GameEngine(
         table_manager=table_manager,
@@ -39,7 +41,7 @@ def game_engine_setup():
         build_identity_from_player=lambda player: player,
         safe_int=int,
         old_players_key="old_players",
-        safe_edit_message_text=safe_edit_message_text,
+        telegram_safe_ops=telegram_safe_ops,
         lock_manager=MagicMock(),
         logger=MagicMock(),
     )
@@ -51,7 +53,7 @@ def game_engine_setup():
         request_metrics=request_metrics,
         stats_reporter=stats_reporter,
         player_manager=player_manager,
-        safe_edit_message_text=safe_edit_message_text,
+        telegram_safe_ops=telegram_safe_ops,
     )
 
 
@@ -108,7 +110,7 @@ async def test_finalize_stop_request_updates_message_and_clears_context(
         stop_request=stop_request,
     )
 
-    game_engine_setup.safe_edit_message_text.assert_awaited_once()
+    game_engine_setup.telegram_safe_ops.edit_message_text.assert_awaited_once()
     assert (
         game_engine_setup.engine.KEY_STOP_REQUEST not in context.chat_data
     )

--- a/tests/test_telegram_safeops.py
+++ b/tests/test_telegram_safeops.py
@@ -1,0 +1,168 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram.error import BadRequest, RetryAfter, TimedOut
+
+from pokerapp.utils.request_metrics import RequestCategory
+from pokerapp.utils.telegram_safeops import TelegramSafeOps
+
+
+class _DummyView:
+    def __init__(self):
+        self.calls = SimpleNamespace(edit=0, send=0, delete=0)
+        self._edit_side_effects = []
+        self._send_result = None
+
+    def queue_edit_side_effects(self, *effects):
+        self._edit_side_effects = list(effects)
+
+    def set_send_result(self, value):
+        self._send_result = value
+
+    async def edit_message_text(
+        self,
+        *,
+        chat_id,
+        message_id,
+        text,
+        reply_markup,
+        request_category,
+        parse_mode,
+        suppress_exceptions,
+    ):
+        self.calls.edit += 1
+        if self._edit_side_effects:
+            effect = self._edit_side_effects.pop(0)
+            if isinstance(effect, Exception):
+                raise effect
+            return effect
+        return message_id
+
+    async def send_message_return_id(
+        self,
+        chat_id,
+        text,
+        reply_markup,
+        request_category,
+        suppress_exceptions,
+    ):
+        self.calls.send += 1
+        return self._send_result
+
+    async def delete_message(
+        self,
+        chat_id,
+        message_id,
+        *,
+        suppress_exceptions,
+        **_kwargs,
+    ):
+        self.calls.delete += 1
+        return None
+
+
+@pytest.fixture
+def logger():
+    logging.basicConfig(level=logging.DEBUG)
+    return logging.getLogger("telegram_safeops.test")
+
+
+@pytest.mark.asyncio
+async def test_retry_after_triggers_sleep(monkeypatch, logger):
+    view = _DummyView()
+    view.queue_edit_side_effects(RetryAfter(retry_after=1), 42)
+
+    sleep_calls = []
+
+    async def fake_sleep(duration):
+        sleep_calls.append(duration)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    safe_ops = TelegramSafeOps(
+        view,
+        logger=logger,
+        max_retries=3,
+        base_delay=0.2,
+        max_delay=1.0,
+        backoff_multiplier=2.0,
+    )
+
+    result = await safe_ops.edit_message_text(
+        chat_id=100,
+        message_id=200,
+        text="test",
+        request_category=RequestCategory.GENERAL,
+    )
+
+    assert result == 42
+    assert sleep_calls == [1]
+    assert view.calls.edit == 2
+
+
+@pytest.mark.asyncio
+async def test_network_error_exhausts_retries(monkeypatch, logger):
+    view = _DummyView()
+    view.queue_edit_side_effects(
+        TimedOut("timeout"), TimedOut("timeout"), TimedOut("timeout")
+    )
+
+    sleep_calls = []
+
+    async def fake_sleep(duration):
+        sleep_calls.append(duration)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    safe_ops = TelegramSafeOps(
+        view,
+        logger=logger,
+        max_retries=2,
+        base_delay=0.5,
+        max_delay=1.5,
+        backoff_multiplier=2.0,
+    )
+
+    result = await safe_ops.edit_message_text(
+        chat_id=10,
+        message_id=20,
+        text="boom",
+        request_category=RequestCategory.GENERAL,
+    )
+
+    assert result is None
+    assert sleep_calls == [0.5, 1.0]
+    assert view.calls.edit == 3  # initial + 2 retries
+    assert view.calls.send == 1
+
+
+@pytest.mark.asyncio
+async def test_bad_request_falls_back_to_send(monkeypatch, logger):
+    view = _DummyView()
+    view.queue_edit_side_effects(BadRequest("bad"))
+    view.set_send_result(555)
+
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    safe_ops = TelegramSafeOps(
+        view,
+        logger=logger,
+        max_retries=1,
+        base_delay=0.1,
+        max_delay=0.2,
+        backoff_multiplier=2.0,
+    )
+
+    result = await safe_ops.edit_message_text(
+        chat_id=5,
+        message_id=6,
+        text="fallback",
+        request_category=RequestCategory.GENERAL,
+    )
+
+    assert result == 555
+    assert view.calls.send == 1
+    assert view.calls.delete == 1


### PR DESCRIPTION
## Summary
- add a TelegramSafeOps helper that centralizes retry/backoff handling for Telegram edits, sends and deletions
- wire the safe ops through configuration, bootstrap and bot components so game messaging uses the new logic
- let the viewer expose optional exception propagation hooks and add unit tests covering retry, fallback and integration paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d39383348483288ea1f8fc53c00a2a