### PR TITLE
Integrate adaptive player report cache TTL with event invalidation

### DIFF
--- a/main.py
+++ b/main.py
@@ -121,6 +121,7 @@ def main() -> None:
         stats_service=services.stats_service,
         redis_ops=services.redis_ops,
         player_report_cache=services.player_report_cache,
+        adaptive_player_report_cache=services.adaptive_player_report_cache,
         request_metrics=services.request_metrics,
         private_match_service=services.private_match_service,
         messaging_service_factory=services.messaging_service_factory,

--- a/pokerapp/config.py
+++ b/pokerapp/config.py
@@ -56,6 +56,9 @@ _DEFAULT_GAME_CONSTANTS_DATA: Dict[str, Any] = {
         "private_match_queue_ttl": 180,
         "private_match_state_ttl": 3600,
         "player_report_cache_ttl_seconds": 300,
+        "player_report_ttl_default_seconds": 180,
+        "player_report_ttl_bonus_seconds": 60,
+        "player_report_ttl_post_hand_seconds": 45,
     },
     "engine": {
         "key_old_players": "old_players",
@@ -293,6 +296,36 @@ class Config:
             parsed_player_report_cache_ttl
             if parsed_player_report_cache_ttl is not None
             else default_player_report_cache_ttl
+        )
+        self.PLAYER_REPORT_TTL_DEFAULT = max(
+            self._parse_int_env(
+                os.getenv("POKERBOT_PLAYER_REPORT_TTL_DEFAULT"),
+                default=int(
+                    redis_constants.get("player_report_ttl_default_seconds", 180)
+                ),
+                env_var="POKERBOT_PLAYER_REPORT_TTL_DEFAULT",
+            ),
+            0,
+        )
+        self.PLAYER_REPORT_TTL_BONUS = max(
+            self._parse_int_env(
+                os.getenv("POKERBOT_PLAYER_REPORT_TTL_BONUS"),
+                default=int(
+                    redis_constants.get("player_report_ttl_bonus_seconds", 60)
+                ),
+                env_var="POKERBOT_PLAYER_REPORT_TTL_BONUS",
+            ),
+            0,
+        )
+        self.PLAYER_REPORT_TTL_POST_HAND = max(
+            self._parse_int_env(
+                os.getenv("POKERBOT_PLAYER_REPORT_TTL_POST_HAND"),
+                default=int(
+                    redis_constants.get("player_report_ttl_post_hand_seconds", 45)
+                ),
+                env_var="POKERBOT_PLAYER_REPORT_TTL_POST_HAND",
+            ),
+            0,
         )
         database_url_env = os.getenv("POKERBOT_DATABASE_URL", "").strip()
         if database_url_env:

--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -808,7 +808,9 @@ class GameEngine:
             if player.wallet:
                 await player.wallet.cancel(original_game_id)
 
-        await self._stats_reporter.invalidate_players(player_list)
+        await self._stats_reporter.invalidate_players(
+            player_list, event_type="hand_finished"
+        )
 
     def _build_stop_cancellation_message(
         self, stop_request: Dict[str, object]

--- a/pokerapp/pokerbot.py
+++ b/pokerapp/pokerbot.py
@@ -20,6 +20,7 @@ from pokerapp.utils.telegram_safeops import TelegramSafeOps
 from pokerapp.utils.redis_safeops import RedisSafeOps
 from pokerapp.utils.request_metrics import RequestMetrics
 from pokerapp.utils.player_report_cache import PlayerReportCache
+from pokerapp.utils.cache import AdaptivePlayerReportCache
 
 
 @dataclass(frozen=True)
@@ -60,6 +61,7 @@ class PokerBot:
         stats_service: BaseStatsService,
         redis_ops: RedisSafeOps,
         player_report_cache: PlayerReportCache,
+        adaptive_player_report_cache: AdaptivePlayerReportCache,
         request_metrics: RequestMetrics,
         private_match_service: PrivateMatchService,
         messaging_service_factory: MessagingServiceFactory,
@@ -93,6 +95,7 @@ class PokerBot:
         self._messaging_service_factory = messaging_service_factory
         self._telegram_safeops_factory = telegram_safeops_factory
         self._player_report_cache = player_report_cache
+        self._adaptive_player_report_cache = adaptive_player_report_cache
         self._build_application()
 
     def run(self) -> None:
@@ -234,6 +237,7 @@ class PokerBot:
             stats_service=self._stats_service,
             redis_ops=self._redis_ops,
             player_report_cache=self._player_report_cache,
+            adaptive_player_report_cache=self._adaptive_player_report_cache,
             telegram_safe_ops=telegram_safe_ops,
         )
         self._controller = PokerBotCotroller(self._model, self._application)

--- a/tests/test_game_engine_helpers.py
+++ b/tests/test_game_engine_helpers.py
@@ -84,7 +84,7 @@ async def test_refund_players_cancels_wallets_and_invalidates(game_engine_setup)
     wallet_a.cancel.assert_awaited_once_with("game-123")
     wallet_b.cancel.assert_awaited_once_with("game-123")
     game_engine_setup.stats_reporter.invalidate_players.assert_awaited_once_with(
-        [player_a, player_b]
+        [player_a, player_b], event_type="hand_finished"
     )
 
 


### PR DESCRIPTION
## Summary
- expose configurable player report TTL defaults in the config defaults and environment overrides
- wire the adaptive player report cache through bootstrap, PokerBot, and PokerBotModel so it shares Redis persistence and uses the configured TTLs
- update stats invalidation to pass event types from GameEngine and StatsReporter, and add tests covering event TTL application plus Redis expiration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d399f7f8ec8328be7cfcca8ecbf58f