### PR TITLE
Load translations and redis keys from external files

### DIFF
--- a/config/data/redis_keys.json
+++ b/config/data/redis_keys.json
@@ -1,0 +1,6 @@
+{
+  "engine": {
+    "stage_lock_prefix": "stage:",
+    "stop_request": "stop_request"
+  }
+}

--- a/config/data/translations.json
+++ b/config/data/translations.json
@@ -1,0 +1,165 @@
+{
+  "default_language": "fa",
+  "roles": {
+    "dealer": {
+      "fa": "دیلر",
+      "en": "Dealer"
+    },
+    "small_blind": {
+      "fa": "بلایند کوچک",
+      "en": "Small blind"
+    },
+    "big_blind": {
+      "fa": "بلایند بزرگ",
+      "en": "Big blind"
+    },
+    "player": {
+      "fa": "بازیکن",
+      "en": "Player"
+    }
+  },
+  "hands": {
+    "ROYAL_FLUSH": {
+      "fa": "رویال فلاش",
+      "en": "Royal Flush",
+      "emoji": "👑"
+    },
+    "STRAIGHT_FLUSH": {
+      "fa": "استریت فلاش",
+      "en": "Straight Flush",
+      "emoji": "💎"
+    },
+    "FOUR_OF_A_KIND": {
+      "fa": "کاره (چهار تایی)",
+      "en": "Four of a Kind",
+      "emoji": "💣"
+    },
+    "FULL_HOUSE": {
+      "fa": "فول هاوس",
+      "en": "Full House",
+      "emoji": "🏠"
+    },
+    "FLUSH": {
+      "fa": "فلاش (رنگ)",
+      "en": "Flush",
+      "emoji": "🎨"
+    },
+    "STRAIGHT": {
+      "fa": "استریت (ردیف)",
+      "en": "Straight",
+      "emoji": "🚀"
+    },
+    "THREE_OF_A_KIND": {
+      "fa": "سه تایی",
+      "en": "Three of a Kind",
+      "emoji": "🧩"
+    },
+    "TWO_PAIR": {
+      "fa": "دو پِر",
+      "en": "Two Pair",
+      "emoji": "✌️"
+    },
+    "PAIR": {
+      "fa": "پِر (جفت)",
+      "en": "Pair",
+      "emoji": "🔗"
+    },
+    "HIGH_CARD": {
+      "fa": "کارت بالا",
+      "en": "High Card",
+      "emoji": "🃏"
+    }
+  },
+  "stop_vote": {
+    "buttons": {
+      "confirm": {
+        "fa": "تأیید توقف",
+        "en": "Confirm stop"
+      },
+      "resume": {
+        "fa": "ادامه بازی",
+        "en": "Resume game"
+      }
+    },
+    "messages": {
+      "title": {
+        "fa": "🛑 *درخواست توقف بازی*",
+        "en": "🛑 *Stop game request*"
+      },
+      "initiated_by": {
+        "fa": "درخواست توسط {initiator}",
+        "en": "Requested by {initiator}"
+      },
+      "active_players_label": {
+        "fa": "بازیکنان فعال:",
+        "en": "Active players:"
+      },
+      "vote_counts": {
+        "fa": "آراء تأیید: {confirmed}/{required}",
+        "en": "Approval votes: {confirmed}/{required}"
+      },
+      "manager_label": {
+        "fa": "👤 مدیر بازی: {manager}",
+        "en": "👤 Game manager: {manager}"
+      },
+      "manager_override_hint": {
+        "fa": "او می‌تواند به تنهایی رأی توقف را تأیید کند.",
+        "en": "They can approve the stop vote alone."
+      },
+      "other_votes_label": {
+        "fa": "رأی سایر افراد:",
+        "en": "Other voters:"
+      },
+      "resume_text": {
+        "fa": "✅ رأی به ادامه‌ی بازی داده شد. بازی ادامه می‌یابد.",
+        "en": "✅ The game will continue."
+      },
+      "manager_override_summary": {
+        "fa": "🛑 *مدیر بازی بازی را متوقف کرد.*",
+        "en": "🛑 *The manager stopped the game.*"
+      },
+      "majority_stop_summary": {
+        "fa": "🛑 *بازی با رأی اکثریت متوقف شد.*",
+        "en": "🛑 *The game was stopped by majority vote.*"
+      },
+      "vote_summary": {
+        "fa": "آراء تأیید: {approved}/{required}",
+        "en": "Approval votes: {approved}/{required}"
+      },
+      "no_votes": {
+        "fa": "هیچ رأی فعالی ثبت نشد.",
+        "en": "No active votes were recorded."
+      },
+      "stopped_notification": {
+        "fa": "🛑 بازی متوقف شد.",
+        "en": "🛑 The game has been stopped."
+      }
+    },
+    "errors": {
+      "no_active_game": {
+        "fa": "بازی فعالی برای توقف وجود ندارد.",
+        "en": "There is no active game to stop."
+      },
+      "not_in_game": {
+        "fa": "فقط بازیکنان حاضر می‌توانند درخواست توقف بدهند.",
+        "en": "Only seated players can request to stop the game."
+      },
+      "no_active_players": {
+        "fa": "هیچ بازیکن فعالی برای رأی‌گیری وجود ندارد.",
+        "en": "There are no active players to vote."
+      },
+      "no_request_to_resume": {
+        "fa": "درخواست توقفی برای لغو وجود ندارد.",
+        "en": "There is no stop request to resume."
+      },
+      "no_active_request": {
+        "fa": "درخواست توقف فعالی وجود ندارد.",
+        "en": "There is no active stop request."
+      },
+      "not_allowed_to_vote": {
+        "fa": "تنها بازیکنان فعال یا مدیر می‌توانند رأی دهند.",
+        "en": "Only active players or the manager may vote."
+      }
+    }
+  }
+}

--- a/pokerapp/player_manager.py
+++ b/pokerapp/player_manager.py
@@ -8,19 +8,40 @@ from typing import Iterable, Optional
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 from pokerapp.entities import ChatId, Game, GameState, Player, UserId
+from pokerapp.config import get_game_constants
 from pokerapp.pokerbotview import PokerBotViewer
 from pokerapp.table_manager import TableManager
+
+
+_CONSTANTS = get_game_constants()
+_TRANSLATIONS = _CONSTANTS.translations
+_DEFAULT_LANGUAGE = _TRANSLATIONS.get("default_language", "fa")
+_LANGUAGE_ORDER = tuple(dict.fromkeys([_DEFAULT_LANGUAGE, "fa", "en"]))
+_ROLE_TRANSLATIONS = _TRANSLATIONS.get("roles", {})
+
+
+def _resolve_role_label(key: str, fallback: str) -> str:
+    entry = _ROLE_TRANSLATIONS.get(key, {})
+    if isinstance(entry, dict):
+        for lang in _LANGUAGE_ORDER:
+            text = entry.get(lang)
+            if isinstance(text, str) and text:
+                return text
+    return fallback
+
+
+_ROLE_LABELS = {
+    "dealer": _resolve_role_label("dealer", "Dealer"),
+    "small_blind": _resolve_role_label("small_blind", "Small blind"),
+    "big_blind": _resolve_role_label("big_blind", "Big blind"),
+    "player": _resolve_role_label("player", "Player"),
+}
 
 
 class PlayerManager:
     """Coordinate player seating, role assignment, and anchor maintenance."""
 
-    ROLE_TRANSLATIONS = {
-        "dealer": "دیلر",
-        "small_blind": "بلایند کوچک",
-        "big_blind": "بلایند بزرگ",
-        "player": "بازیکن",
-    }
+    ROLE_TRANSLATIONS = _ROLE_LABELS
 
     def __init__(
         self,

--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -78,6 +78,13 @@ _GAME_CONSTANTS = get_game_constants()
 _GAME_SECTION = _GAME_CONSTANTS.game
 _UI_SECTION = _GAME_CONSTANTS.ui
 _ENGINE_SECTION = _GAME_CONSTANTS.engine
+_REDIS_KEYS = _GAME_CONSTANTS.redis_keys
+if isinstance(_REDIS_KEYS, dict):
+    _ENGINE_REDIS_KEYS = _REDIS_KEYS.get("engine", {})
+    if not isinstance(_ENGINE_REDIS_KEYS, dict):
+        _ENGINE_REDIS_KEYS = {}
+else:
+    _ENGINE_REDIS_KEYS = {}
 
 DICE_MULT = int(_GAME_SECTION.get("dice_mult", 10))
 DICE_DELAY_SEC = int(_GAME_SECTION.get("dice_delay_sec", 5))
@@ -101,6 +108,11 @@ KEY_STOP_REQUEST = GameEngine.KEY_STOP_REQUEST
 
 STOP_CONFIRM_CALLBACK = GameEngine.STOP_CONFIRM_CALLBACK
 STOP_RESUME_CALLBACK = GameEngine.STOP_RESUME_CALLBACK
+
+STAGE_LOCK_PREFIX = _ENGINE_REDIS_KEYS.get(
+    "stage_lock_prefix",
+    GameEngine.STAGE_LOCK_PREFIX,
+)
 
 # MAX_PLAYERS = 8 (Defined in entities)
 # MIN_PLAYERS = 2 (Defined in entities)
@@ -1246,7 +1258,7 @@ class PokerBotModel:
         """پیام نوبت را ارسال کرده و شناسه آن را برای حذف در آینده ذخیره می‌کند."""
         async with self._chat_guard(chat_id):
             async with self._lock_manager.guard(
-                f"stage:{self._safe_int(chat_id)}", timeout=10
+                f"{STAGE_LOCK_PREFIX}{self._safe_int(chat_id)}", timeout=10
             ):
                 game.chat_id = chat_id
                 await self._view.update_player_anchors_and_keyboards(game)

--- a/pokerapp/winnerdetermination.py
+++ b/pokerapp/winnerdetermination.py
@@ -2,12 +2,28 @@
 
 import enum
 from itertools import combinations
-from typing import List, Tuple, Dict
+from typing import Dict, List, Tuple
 
 from pokerapp.cards import Card, Cards
 from pokerapp.entities import Score
+from pokerapp.config import get_game_constants
 
 HAND_RANK_MULTIPLIER = 15**5
+
+
+_CONSTANTS = get_game_constants()
+_TRANSLATIONS = _CONSTANTS.translations.get("hands", {})
+
+
+def _load_hand_translations() -> Dict["HandsOfPoker", Dict[str, str]]:
+    mapping: Dict[HandsOfPoker, Dict[str, str]] = {}
+    for hand in HandsOfPoker:
+        entry = _TRANSLATIONS.get(hand.name, {})
+        if isinstance(entry, dict):
+            mapping[hand] = dict(entry)
+        else:
+            mapping[hand] = {}
+    return mapping
 
 class HandsOfPoker(enum.Enum):
     ROYAL_FLUSH = 10
@@ -21,19 +37,7 @@ class HandsOfPoker(enum.Enum):
     PAIR = 2
     HIGH_CARD = 1
 
-# --- دیکشنری برای نمایش نتایج با ایموجی و ترجمه ---
-HAND_NAMES_TRANSLATIONS: Dict[HandsOfPoker, Dict[str, str]] = {
-    HandsOfPoker.ROYAL_FLUSH:     {"fa": "رویال فلاش", "en": "Royal Flush", "emoji": "👑"},
-    HandsOfPoker.STRAIGHT_FLUSH:  {"fa": "استریت فلاش", "en": "Straight Flush", "emoji": "💎"},
-    HandsOfPoker.FOUR_OF_A_KIND:  {"fa": "کاره (چهار تایی)", "en": "Four of a Kind", "emoji": "💣"},
-    HandsOfPoker.FULL_HOUSE:      {"fa": "فول هاوس", "en": "Full House", "emoji": "🏠"},
-    HandsOfPoker.FLUSH:           {"fa": "فلاش (رنگ)", "en": "Flush", "emoji": "🎨"},
-    HandsOfPoker.STRAIGHT:        {"fa": "استریت (ردیف)", "en": "Straight", "emoji": "🚀"},
-    HandsOfPoker.THREE_OF_A_KIND: {"fa": "سه تایی", "en": "Three of a Kind", "emoji": "🧩"},
-    HandsOfPoker.TWO_PAIR:        {"fa": "دو پِر", "en": "Two Pair", "emoji": "✌️"},
-    HandsOfPoker.PAIR:            {"fa": "پِر (جفت)", "en": "Pair", "emoji": "🔗"},
-    HandsOfPoker.HIGH_CARD:       {"fa": "کارت بالا", "en": "High Card", "emoji": "🃏"},
-}
+HAND_NAMES_TRANSLATIONS: Dict[HandsOfPoker, Dict[str, str]] = _load_hand_translations()
 
 class WinnerDetermination:
     """

--- a/tests/test_config_resources.py
+++ b/tests/test_config_resources.py
@@ -1,0 +1,27 @@
+import json
+
+from pokerapp.config import GameConstants
+
+
+def test_game_constants_loads_external_resources(tmp_path):
+    translations_path = tmp_path / "translations.json"
+    translations_payload = {
+        "default_language": "en",
+        "roles": {
+            "dealer": {"en": "DealerX"}
+        },
+    }
+    translations_path.write_text(json.dumps(translations_payload), encoding="utf-8")
+
+    redis_path = tmp_path / "redis_keys.json"
+    redis_payload = {"engine": {"stage_lock_prefix": "custom:", "stop_request": "custom_stop"}}
+    redis_path.write_text(json.dumps(redis_payload), encoding="utf-8")
+
+    constants = GameConstants(
+        translations_path=str(translations_path),
+        redis_keys_path=str(redis_path),
+    )
+
+    assert constants.translations["roles"]["dealer"]["en"] == "DealerX"
+    assert constants.redis_keys["engine"]["stage_lock_prefix"] == "custom:"
+    assert constants.redis_keys["engine"]["stop_request"] == "custom_stop"

--- a/tests/test_pokerbotviewer.py
+++ b/tests/test_pokerbotviewer.py
@@ -16,12 +16,16 @@ from pokerapp.config import (
 )
 from pokerapp.entities import Game, GameState, Player, PlayerAction
 from pokerapp.pokerbotview import PokerBotViewer, build_player_cards_keyboard
+from pokerapp.player_manager import PlayerManager
 from pokerapp.utils.request_metrics import RequestCategory
 
 
 MENTION_LINK = "tg://user?id=123"
 MENTION_MARKDOWN = f"[Player]({MENTION_LINK})"
 HIDDEN_MENTION_TEXT = f"[\u2063]({MENTION_LINK})\u2063"
+
+ROLE_DEALER = PlayerManager.ROLE_TRANSLATIONS["dealer"]
+ROLE_BIG_BLIND = PlayerManager.ROLE_TRANSLATIONS["big_blind"]
 
 
 def run(coro):
@@ -199,8 +203,8 @@ def test_update_player_anchors_and_keyboards_highlights_active_player():
     player_two.cards = [Card('9♣'), Card('9♦')]
     player_one.display_name = 'Player One'
     player_two.display_name = 'Player Two'
-    player_one.role_label = 'دیلر'
-    player_two.role_label = 'بلایند بزرگ'
+    player_one.role_label = ROLE_DEALER
+    player_two.role_label = ROLE_BIG_BLIND
 
     player_one.anchor_message = (game.chat_id, 101)
     player_two.anchor_message = (game.chat_id, 202)
@@ -282,7 +286,7 @@ def test_update_player_anchors_and_keyboards_highlights_active_player():
     assert "🟢 نوبت این بازیکن است." in first_text or "🔴 نوبت این بازیکن است." in first_text
     assert 'Player One' in first_text
     assert '🪑 صندلی: 1' in first_text
-    assert '🎖️ نقش: دیلر' in first_text
+    assert f"🎖️ نقش: {ROLE_DEALER}" in first_text
     assert isinstance(first_call.kwargs['reply_markup'], ReplyKeyboardMarkup)
     assert first_call.kwargs['force_send'] is True
     first_keyboard = first_call.kwargs['reply_markup']


### PR DESCRIPTION
## Summary
- add JSON-backed translations and redis key datasets to the configuration bundle
- update the game engine and supporting services to use externalized strings and key prefixes
- add regression tests to cover configuration loading and translated stop-vote messaging

## Testing
- pytest tests/test_game_engine_helpers.py tests/test_pokerbotviewer.py tests/test_config_resources.py tests/test_matchmaking_service_helpers.py tests/test_pokerbotmodel.py tests/test_winnerdetermination.py

------
https://chatgpt.com/codex/tasks/task_e_68d39eebff0c8328858a9edb1e07a244