### PR TITLE
Align time utilities with configured timezone

### DIFF
--- a/pokerapp/utils/time_utils.py
+++ b/pokerapp/utils/time_utils.py
@@ -7,10 +7,12 @@ import logging
 from functools import lru_cache
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from pokerapp.config import DEFAULT_TIMEZONE_NAME as CONFIG_DEFAULT_TIMEZONE_NAME
+
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_TIMEZONE_NAME = "Asia/Tehran"
+DEFAULT_TIMEZONE_NAME = CONFIG_DEFAULT_TIMEZONE_NAME
 UTC = dt.timezone.utc
 
 

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,5 +1,6 @@
 import datetime as dt
 
+from pokerapp.config import DEFAULT_TIMEZONE_NAME
 from pokerapp.utils.time_utils import countdown_delta, format_local, now_utc, to_local
 
 
@@ -35,3 +36,12 @@ def test_format_local_and_countdown_delta_use_utc_baseline():
 
     formatted = format_local(start, "%H:%M", tz_name="Asia/Tehran")
     assert formatted == "15:30"
+
+
+def test_to_local_uses_config_default_when_timezone_missing():
+    base = dt.datetime(2024, 6, 1, 12, 0, tzinfo=dt.timezone.utc)
+
+    expected = to_local(base, tz_name=DEFAULT_TIMEZONE_NAME)
+    actual = to_local(base)
+
+    assert actual == expected


### PR DESCRIPTION
## Summary
- align the `time_utils` module's default timezone with the configured default
- extend unit coverage so `to_local` falls back to the configured timezone when unspecified

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3a2f0069c8328bb3c25eb3211943e