### PR TITLE
Refactor stop vote translations into config

### DIFF
--- a/config/data/translations.json
+++ b/config/data/translations.json
@@ -94,6 +94,10 @@
         "fa": "بازیکنان فعال:",
         "en": "Active players:"
       },
+      "active_player_line": {
+        "fa": "{mark} {player}",
+        "en": "{mark} {player}"
+      },
       "vote_counts": {
         "fa": "آراء تأیید: {confirmed}/{required}",
         "en": "Approval votes: {confirmed}/{required}"
@@ -129,6 +133,10 @@
       "no_votes": {
         "fa": "هیچ رأی فعالی ثبت نشد.",
         "en": "No active votes were recorded."
+      },
+      "no_active_players_placeholder": {
+        "fa": "—",
+        "en": "—"
       },
       "stopped_notification": {
         "fa": "🛑 بازی متوقف شد.",


### PR DESCRIPTION
## Summary
- load stop vote text from GameConstants at runtime and expose instance-level templates
- add translation entries for stop vote player lines and placeholders
- update tests to exercise instance translations and ensure custom translation files are honored

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3b41399e88328a401d0eb19f27db0