### PR TITLE
Improve lock hierarchy enforcement and observability

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -205,7 +205,10 @@ class PokerBotModel:
             self._stats = NullStatsService(timezone_name=cfg_timezone)
         self._timezone_name = cfg_timezone
         self._stats.bind_player_report_cache(self._player_report_cache)
-        self._lock_manager = LockManager(logger=logger.getChild("lock_manager"))
+        self._lock_manager = LockManager(
+            logger=logger.getChild("lock_manager"),
+            category_timeouts=getattr(cfg, "LOCK_TIMEOUTS", None),
+        )
         self._player_identity_manager = PlayerIdentityManager(
             table_manager=self._table_manager,
             kv=self._kv,


### PR DESCRIPTION
## Summary
- enforce the new hierarchical lock levels, track acquisitions per task with contextvars, and emit richer structured logging and metrics from the lock manager
- load per-category lock timeouts from configuration and feed them into the lock manager wiring

## Testing
- pytest tests/test_lock_manager.py
- pytest tests/test_config_resources.py

------
https://chatgpt.com/codex/tasks/task_e_68d3b8d0aed08328a7b36d6209a29a65