### PR TITLE
Document game flow and architecture diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ The new dependency-injection centric architecture is documented in depth inside
 [`docs/architecture.md`](docs/architecture.md), including Mermaid diagrams that
 illustrate how `bootstrap.py` wires shared services. For a visual walkthrough of
 the per-hand lifecycle consult [`docs/game_flow.md`](docs/game_flow.md), which
-contains sequence and swimlane diagrams of the round progression.
+contains sequence and swimlane diagrams of the round progression. All diagram
+sources live under [`docs/diagrams/`](docs/diagrams) so they can be regenerated
+without editing the Markdown guides.
 
 ## Game flow reference
 

--- a/docs/diagrams/architecture_data_flow.mmd
+++ b/docs/diagrams/architecture_data_flow.mmd
@@ -1,0 +1,35 @@
+flowchart LR
+    subgraph Telegram Layer
+        TG[Telegram API]
+        VIEW[PokerBotViewer]
+    end
+
+    subgraph Game Layer
+        MODEL[PokerBotModel]
+        ENGINE[GameEngine]
+        PM[PlayerManager]
+        MATCH[MatchmakingService]
+        TABLE[TableManager]
+        STATS[StatsReporter/StatsService]
+        METRIC[RequestMetrics]
+    end
+
+    subgraph Persistence
+        REDIS[(Redis)]
+        DB[(Database)]
+    end
+
+    TG <--> VIEW
+    VIEW --> MODEL : callbacks / updates
+    MODEL --> ENGINE : start_game, progress_stage, finalize_game
+    ENGINE --> MATCH : orchestration
+    MATCH --> TABLE : save_game
+    ENGINE --> TABLE
+    TABLE --> REDIS
+    ENGINE --> PM : seat/role updates
+    PM --> VIEW : join prompt & anchors
+    ENGINE --> VIEW : table snapshots
+    ENGINE --> STATS : hand_started / hand_finished
+    STATS --> DB
+    ENGINE --> METRIC : cycle tracking
+    METRIC --> REDIS : counters

--- a/docs/diagrams/architecture_di_overview.mmd
+++ b/docs/diagrams/architecture_di_overview.mmd
@@ -1,0 +1,49 @@
+flowchart TD
+    subgraph Bootstrap[bootstrap.build_services]
+        CFG[Config]
+        LOG[setup_logging]
+        REDIS[(Redis connection)]
+        OPS[RedisSafeOps]
+        TM[TableManager]
+        STATS[StatsService or NullStatsService]
+        CACHE[AdaptivePlayerReportCache]
+        REPORT_CACHE[PlayerReportCache]
+        METRICS[RequestMetrics]
+        PRIV[PrivateMatchService]
+        MSGFACT[messaging_service_factory]
+        SAFEFACT[telegram_safeops_factory]
+    end
+
+    CFG --> LOG
+    LOG --> REDIS
+    REDIS --> OPS
+    OPS --> TM
+    OPS --> PRIV
+    REDIS --> PRIV
+    LOG --> STATS
+    CFG --> STATS
+    STATS --> CACHE
+    CACHE --> REPORT_CACHE
+    OPS --> REPORT_CACHE
+    LOG --> METRICS
+    METRICS --> MSGFACT
+    METRICS --> PRIV
+    REDIS --> TM
+
+    subgraph Application[PokerBot]
+        APP_SVC[ApplicationServices]
+        BOT[PokerBot]
+        VIEWER[PokerBotViewer]
+        MODEL[PokerBotModel]
+        ENGINE[GameEngine]
+        PM[PlayerManager]
+        MS[MatchmakingService]
+    end
+
+    Bootstrap --> APP_SVC
+    APP_SVC --> BOT
+    APP_SVC --> VIEWER
+    APP_SVC --> MODEL
+    MODEL --> ENGINE
+    ENGINE --> PM
+    ENGINE --> MS

--- a/docs/diagrams/game_flow_sequence.mmd
+++ b/docs/diagrams/game_flow_sequence.mmd
@@ -1,0 +1,45 @@
+sequenceDiagram
+    autonumber
+    participant TG as Telegram
+    participant PM as PlayerManager
+    participant GE as GameEngine
+    participant MS as MatchmakingService
+    participant TM as TableManager
+    participant SS as StatsService/Reporter
+
+    Note over TG,GE: WAITING — lobby is open
+    TG->>PM: /start & Join button callbacks
+    PM->>TM: save_game(chat_id, game)
+    PM->>GE: request start when seats ready
+
+    Note over GE,MS: ROUND_PRE_FLOP setup
+    GE->>MS: start_game(context, game, chat)
+    MS->>TM: persist dealer/blind rotations
+    MS->>SS: hand_started(...)
+    MS->>TG: deal hole cards via PokerBotViewer
+
+    loop Betting cycle per stage
+        Note over GE,MS: progress_stage() called
+        GE->>MS: progress_stage(context, game, chat)
+        MS->>MS: collect bets & reset has_acted
+        alt ROUND_PRE_FLOP → ROUND_FLOP
+            MS->>GE: add_cards_to_table(3)
+            GE->>TG: broadcast flop snapshot
+        else ROUND_FLOP → ROUND_TURN
+            MS->>GE: add_cards_to_table(1)
+            GE->>TG: broadcast turn snapshot
+        else ROUND_TURN → ROUND_RIVER
+            MS->>GE: add_cards_to_table(1)
+            GE->>TG: broadcast river snapshot
+        else ROUND_RIVER → FINISHED
+            MS->>GE: finalize_game(...)
+        end
+        GE->>TM: save_game(chat_id, game)
+    end
+
+    Note over GE,SS: finalize_game()
+    GE->>GE: finalize_game(context, game, chat)
+    GE->>TG: send_showdown_results()
+    GE->>SS: hand_finished(payouts, hand_labels)
+    GE->>TM: reset+save_game(chat_id, game)
+    GE->>PM: send_join_prompt() → back to WAITING

--- a/docs/diagrams/game_flow_swimlane.puml
+++ b/docs/diagrams/game_flow_swimlane.puml
@@ -1,0 +1,41 @@
+@startuml GameFlowSwimlane
+|Telegram|
+start
+:Players tap /start and join buttons;
+|PlayerManager|
+:Record join intent;
+:Persist ready prompt via TableManager;
+|GameEngine|
+:detect required players;
+:acquire stage lock;
+|MatchmakingService|
+:start_game();
+:assign dealer & blinds;
+:deal_hole_cards();
+|PokerBotViewer|
+:send private hole cards;
+|GameEngine|
+:progress_stage();
+|MatchmakingService|
+:collect_bets_for_pot();
+:transition ROUND_PRE_FLOP→ROUND_FLOP;
+|PokerBotViewer|
+:announce flop;
+|GameEngine|
+:progress_stage();
+|MatchmakingService|
+:transition to turn & river;
+|PokerBotViewer|
+:update community cards;
+|GameEngine|
+:finalize_game();
+|StatsService|
+:hand_finished(payouts);
+|TableManager|
+:reset & save game;
+|PlayerManager|
+:send_join_prompt();
+|Telegram|
+:Players ready for next hand;
+stop
+@enduml

--- a/docs/diagrams/lock_hierarchy.mmd
+++ b/docs/diagrams/lock_hierarchy.mmd
@@ -1,0 +1,5 @@
+graph TD
+    A[global lock\nlevel 0] --> B[stage lock\nlevel 10]
+    B --> C[table lock\nlevel 20]
+    C --> D[player lock\nlevel 30]
+    D --> E[hand lock\nlevel 40]


### PR DESCRIPTION
## Summary
- expand docs/game_flow.md with transition conditions, safeguards, and diagram source references
- flesh out docs/architecture.md with stats/cache details and link diagrams to reproducible sources
- add docs/diagrams mermaid/plantuml files and update README to point to the new documentation

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d3dc58b56883289f7e3d22ac39398c