### PR TITLE
Fix lint issues

### DIFF
--- a/pokerapp/utils/cache.py
+++ b/pokerapp/utils/cache.py
@@ -498,7 +498,7 @@ class AdaptivePlayerReportCache(PlayerReportCache):
                 expire=max(ttl, 0) or None,
                 log_extra=self._build_log_extra(
                     user_id=user_id,
-                    cache_event="persistent_store", 
+                    cache_event="persistent_store",
                     ttl_event_type=event_type,
                 ),
             )

--- a/tests/test_game_engine_finalization.py
+++ b/tests/test_game_engine_finalization.py
@@ -216,6 +216,7 @@ async def test_process_showdown_results_populates_payouts_and_labels():
     payouts = defaultdict(int)
     hand_labels: Dict[int, Optional[str]] = {}
     chat_id = -654
+
     async def _passthrough_send_message_safe(*, call, **_kwargs):
         return await call()
 
@@ -292,6 +293,7 @@ async def test_process_showdown_results_handles_empty_winners():
 
     payouts = defaultdict(int)
     hand_labels: Dict[int, Optional[str]] = {}
+
     async def _passthrough_send_message_safe(*, call, **_kwargs):
         return await call()
 


### PR DESCRIPTION
## Summary
- remove trailing whitespace from the cache persistence logging call
- add required blank lines before nested async helper definitions in showdown tests

## Testing
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68d3de5f64308328a6d8a6a8915e54b9