### PR TITLE
Allow zero when coercing non-negative floats

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -126,7 +126,7 @@ def _non_negative_float(value: Any, default: float) -> float:
         value,
         default,
         converter=float,
-        is_valid=lambda parsed: parsed > 0,
+        is_valid=lambda parsed: parsed >= 0,
     )
 
 


### PR DESCRIPTION
## Summary
- treat zero as valid when coercing non-negative float configuration values

## Testing
- python3 -m unittest discover -s ./tests

------
https://chatgpt.com/codex/tasks/task_e_68d3e39f7eb0832884e886a462d01f09