### PR TITLE
Improve lock ordering enforcement and logging

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -229,6 +229,7 @@ class PokerBotModel:
         self._lock_manager = LockManager(
             logger=logger.getChild("lock_manager"),
             category_timeouts=getattr(cfg, "LOCK_TIMEOUTS", None),
+            config=cfg,
         )
         self._player_identity_manager = PlayerIdentityManager(
             table_manager=self._table_manager,


### PR DESCRIPTION
## Summary
- add a concrete lock hierarchy with stage, wallet, and stats levels, derive contextual lock identities, and consume configured timeouts inside `LockManager`
- forward the application `Config` into the lock manager bootstrap path so category timeouts are reused without reloading
- expand the lock manager tests to validate safe/unsafe orderings and the enriched structured logging output

## Testing
- pytest tests/test_lock_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d3e4a895188328af33e546e01ab286