### PR TITLE
Route game engine Telegram calls through safe ops

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -687,9 +687,20 @@ class GameEngine:
         if folded_count:
             fold_phrase = f"{fold_phrase} ({folded_count} نفر)"
 
-        await self._view.send_message(
-            chat_id,
-            f"🏆 {fold_phrase}! {winner.mention_markdown} برنده {amount}$ شد.",
+        message_text = (
+            f"🏆 {fold_phrase}! {winner.mention_markdown} برنده {amount}$ شد."
+        )
+        await self._telegram_ops.send_message_safe(
+            call=lambda text=message_text: self._view.send_message(chat_id, text),
+            chat_id=chat_id,
+            operation="announce_fold_win_message",
+            log_extra=self._build_telegram_log_extra(
+                chat_id=chat_id,
+                message_id=None,
+                game_id=getattr(game, "id", None),
+                operation="announce_fold_win_message",
+                request_category=RequestCategory.GENERAL,
+            ),
         )
 
     async def _process_showdown_results(
@@ -732,9 +743,20 @@ class GameEngine:
                         if winner_label and player_id not in hand_labels:
                             hand_labels[player_id] = winner_label
         else:
-            await self._view.send_message(
-                chat_id,
-                "ℹ️ هیچ برنده‌ای در این دست مشخص نشد. مشکلی در منطق بازی رخ داده است.",
+            message_text = (
+                "ℹ️ هیچ برنده‌ای در این دست مشخص نشد. مشکلی در منطق بازی رخ داده است."
+            )
+            await self._telegram_ops.send_message_safe(
+                call=lambda text=message_text: self._view.send_message(chat_id, text),
+                chat_id=chat_id,
+                operation="announce_showdown_warning",
+                log_extra=self._build_telegram_log_extra(
+                    chat_id=chat_id,
+                    message_id=None,
+                    game_id=getattr(game, "id", None),
+                    operation="announce_showdown_warning",
+                    request_category=RequestCategory.GENERAL,
+                ),
             )
 
         await self._telegram_ops.send_message_safe(
@@ -800,7 +822,20 @@ class GameEngine:
         game.reset()
         await self._table_manager.save_game(chat_id, game)
         if send_stop_notification:
-            await self._view.send_message(chat_id, self.STOPPED_NOTIFICATION)
+            await self._telegram_ops.send_message_safe(
+                call=lambda text=self.STOPPED_NOTIFICATION: self._view.send_message(
+                    chat_id, text
+                ),
+                chat_id=chat_id,
+                operation="send_stop_notification",
+                log_extra=self._build_telegram_log_extra(
+                    chat_id=chat_id,
+                    message_id=None,
+                    game_id=getattr(game, "id", None),
+                    operation="send_stop_notification",
+                    request_category=RequestCategory.GENERAL,
+                ),
+            )
 
     def _evaluate_contender_hands(
         self, game: Game, contenders: Iterable[Player]
@@ -1332,4 +1367,17 @@ class GameEngine:
             chat_id=chat_id,
             send_stop_notification=False,
         )
-        await self._view.send_message(chat_id, self.STOPPED_NOTIFICATION)
+        await self._telegram_ops.send_message_safe(
+            call=lambda text=self.STOPPED_NOTIFICATION: self._view.send_message(
+                chat_id, text
+            ),
+            chat_id=chat_id,
+            operation="send_stop_notification",
+            log_extra=self._build_telegram_log_extra(
+                chat_id=chat_id,
+                message_id=None,
+                game_id=getattr(game, "id", None),
+                operation="send_stop_notification",
+                request_category=RequestCategory.GENERAL,
+            ),
+        )

--- a/tests/test_game_engine_finalization.py
+++ b/tests/test_game_engine_finalization.py
@@ -315,7 +315,11 @@ async def test_process_showdown_results_handles_empty_winners():
     )
 
     view.send_message.assert_awaited_once()
-    send_message_safe.assert_awaited_once()
+    assert send_message_safe.await_count == 2
+    assert [
+        recorded_call.kwargs.get("operation")
+        for recorded_call in send_message_safe.await_args_list
+    ] == ["announce_showdown_warning", "send_showdown_results"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_game_engine_helpers.py
+++ b/tests/test_game_engine_helpers.py
@@ -28,8 +28,12 @@ def game_engine_setup():
     player_manager = MagicMock()
     player_manager.clear_player_anchors = AsyncMock()
 
+    async def _passthrough_send_message_safe(*, call, **_kwargs):
+        return await call()
+
     telegram_safe_ops = SimpleNamespace(
-        edit_message_text=AsyncMock(return_value=None)
+        edit_message_text=AsyncMock(return_value=None),
+        send_message_safe=AsyncMock(side_effect=_passthrough_send_message_safe),
     )
 
     engine = GameEngine(


### PR DESCRIPTION
## Summary
- wrap remaining GameEngine message sends with TelegramSafeOps helpers
- add structured log context for the new safe operations
- update unit tests to stub TelegramSafeOps send wrappers and reflect new call counts

## Testing
- pytest tests/test_game_engine_helpers.py tests/test_game_engine_finalization.py

------
https://chatgpt.com/codex/tasks/task_e_68d3e89eaeb88328b86534f43174dacb