### PR TITLE
Document game flow states and dependency wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ without editing the Markdown guides.
 ## Game flow reference
 
 For a detailed walkthrough of the startup sequence, per-stage lifecycle, and the
-`GameState` transitions (`ROUND_PRE_FLOP` → `ROUND_FLOP` → `ROUND_TURN` →
-`ROUND_RIVER` → `FINISHED`), consult the [Game Flow guide](docs/game_flow.md).
-High-level dependency injection, data flow, and lock hierarchy information lives
-in the [Architecture overview](docs/architecture.md). Both documents expand on
-the high-level rules below by mapping them back to the actual async functions
-that drive table updates, statistics, and message rendering.
+`GameState` transitions (`WAITING` → `ROUND_PRE_FLOP` → `ROUND_FLOP` →
+`ROUND_TURN` → `ROUND_RIVER`)—plus the `finalize_game()` cleanup that returns the
+table to `WAITING`—consult the [Game Flow guide](docs/game_flow.md). High-level
+dependency injection, data flow, and lock hierarchy information lives in the
+[Architecture overview](docs/architecture.md). Both documents expand on the
+high-level rules below by mapping them back to the actual async functions that
+drive table updates, statistics, and message rendering.
 
 **Here is the brief instruction of Texas Poker**\
 Every player has two private cards and on the table has five community cards which are dealt face up in the three stages.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,10 @@ dataclass with everything required by [`pokerapp/pokerbot.py`](../pokerapp/poker
 
 Bootstrap reads configuration, sets up logging, and instantiates infrastructure
 clients once. Those singletons are then threaded through factories so higher
-layers never reach out to global state.
+layers never reach out to global state. The Mermaid graph below is generated
+from the relationships encoded inside `bootstrap.build_services`, making it a
+developer-friendly snapshot of how runtime wiring flows from configuration into
+the bot, model, and engine layers.
 
 ```mermaid
 flowchart TD


### PR DESCRIPTION
## Summary
- expand the game flow guide with entry triggers, exit conditions, and an explicit finalize_game() stage
- highlight that the dependency-injection diagram mirrors bootstrap.build_services wiring
- update the README to reference the WAITING→ROUND_RIVER lifecycle and the finalize_game() reset

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d3ed52f3bc8328adf936dbda333ddb