### PR TITLE
Add architecture and game flow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ The bot plays role "our admin": he divides cards, adds cards, controlls whose tu
 
 All things that we need to do is adding bot to your group chat on telegram and every member needs to press the join button at the beginning of round. Then the game will be started. Rules of the texas poker you can read briefly below:
 
+## Documentation
+
+- [Architecture overview](docs/architecture.md) — explains how `bootstrap.py` wires the runtime services and which collaborators the engine receives.
+- [Game flow](docs/game_flow.md) — visualises the state machine, lock usage, cache invalidations, and early exit paths for each hand.
+
 ## Architecture overview
 
 The production bot is split into three cooperating layers:

--- a/docs/game_flow.md
+++ b/docs/game_flow.md
@@ -1,169 +1,84 @@
 # PokerBot Game Flow
 
-This document expands on the concise state machine reference at the top of
-[`pokerapp/game_engine.py`](../pokerapp/game_engine.py). It links the public
-coroutines that drive the table lifecycle with the collaborating services that
-persist chat state, talk to Telegram, and record statistics. Hands always start
-in `WAITING`, travel through the betting stages, and conclude when
-`finalize_game()` resets the chat back to the lobby.
+This guide expands the lightweight state-machine summary found at the top of
+[`pokerapp/game_engine.py`](../pokerapp/game_engine.py). It explains how a poker
+hand progresses, which coroutine triggers move the table between stages, and how
+the supporting services keep Redis, Telegram, and analytics in sync.
 
-## State progression at a glance
-
-The poker bot advances through well-defined `GameState` values. Hands start in
-`WAITING` (players join) and finish when `finalize_game()` runs. The diagram
-below shows the happy-path transition sequence alongside the coroutines that
-move the state machine forward. Early exits (for example when everyone folds)
-are also handled by `finalize_game()`. The Mermaid source lives in
-[`docs/diagrams/game_flow_sequence.mmd`](diagrams/game_flow_sequence.mmd) so the
-image can be regenerated without editing this narrative.
+## State machine
 
 ```mermaid
-sequenceDiagram
-    autonumber
-    participant TG as Telegram
-    participant PM as PlayerManager
-    participant GE as GameEngine
-    participant MS as MatchmakingService
-    participant TM as TableManager
-    participant SS as StatsService/Reporter
+stateDiagram-v2
+    [*] --> WAITING
+    WAITING --> ROUND_PRE_FLOP: start_game()
+    ROUND_PRE_FLOP --> ROUND_FLOP: progress_stage()
+    ROUND_FLOP --> ROUND_TURN: progress_stage()
+    ROUND_TURN --> ROUND_RIVER: progress_stage()
+    ROUND_RIVER --> WAITING: finalize_game()
 
-    Note over TG,GE: WAITING — lobby is open
-    TG->>PM: /start & Join button callbacks
-    PM->>TM: save_game(chat_id, game)
-    PM->>GE: request start when seats ready
-
-    Note over GE,MS: ROUND_PRE_FLOP setup
-    GE->>MS: start_game(context, game, chat)
-    MS->>TM: persist dealer/blind rotations
-    MS->>SS: hand_started(...)
-    MS->>TG: deal hole cards via PokerBotViewer
-
-    loop Betting cycle per stage
-        Note over GE,MS: progress_stage() called
-        GE->>MS: progress_stage(context, game, chat)
-        MS->>MS: collect bets & reset has_acted
-        alt ROUND_PRE_FLOP → ROUND_FLOP
-            MS->>GE: add_cards_to_table(3)
-            GE->>TG: broadcast flop snapshot
-        else ROUND_FLOP → ROUND_TURN
-            MS->>GE: add_cards_to_table(1)
-            GE->>TG: broadcast turn snapshot
-        else ROUND_TURN → ROUND_RIVER
-            MS->>GE: add_cards_to_table(1)
-            GE->>TG: broadcast river snapshot
-        else ROUND_RIVER → finalize_game()
-            MS->>GE: finalize_game(...)
-        end
-        GE->>TM: save_game(chat_id, game)
-    end
-
-    Note over GE,SS: finalize_game()
-    GE->>GE: finalize_game(context, game, chat)
-    GE->>TG: send_showdown_results()
-    GE->>SS: hand_finished(payouts, hand_labels)
-    GE->>TM: reset+save_game(chat_id, game)
-    GE->>PM: send_join_prompt() → back to WAITING
+    ROUND_PRE_FLOP --> WAITING: finalize_game()\n• stop_vote approved\n• <2 contenders
+    ROUND_FLOP --> WAITING: finalize_game()\n• stop_vote approved\n• <2 contenders
+    ROUND_TURN --> WAITING: finalize_game()\n• stop_vote approved\n• <2 contenders
+    ROUND_RIVER --> WAITING: finalize_game()\n• stop_vote approved\n• <2 contenders
+    WAITING --> WAITING: finalize_game()\n(stop request cleanup)
 ```
 
-### State triggers, exits, and responsibilities
+* `start_game()` is invoked by the model once the lobby has enough seated
+  players. It transitions the persisted `Game` record from `WAITING` into
+  `ROUND_PRE_FLOP` after blinds are posted and hole cards are dealt.
+* `progress_stage()` advances the game through the betting streets while holding
+  the stage lock. It calls into `MatchmakingService.progress_stage`, which either
+  hands control back for the next betting cycle or triggers `finalize_game()`
+  when the river is complete or an early exit condition is met.
+* `finalize_game()` resets the chat to `WAITING`, posts results, and re-primes
+  the lobby for the next hand.
 
-| Stage | Entry trigger | Exit conditions | Key responsibilities |
-| ----- | ------------- | --------------- | ------------------- |
-| `WAITING` | `finalize_game()` completes or a brand-new chat initializes a persisted `Game` record. `PlayerManager.send_join_prompt` keeps the lobby visible. | `MatchmakingService.start_game` is invoked after a `/start` request and enough ready seats exist. | Accept join requests, persist the waiting game via `TableManager`, broadcast countdown updates. |
-| `ROUND_PRE_FLOP` | `GameEngine.start_game` acquires the stage lock, rotates blinds, and delegates to `MatchmakingService.start_game`. | All active players act (call/raise/fold) and the betting cycle resolves, or every contender but one folds. In both cases `progress_stage` returns control. | Assign dealer/blind roles, post blinds, deal hole cards, trigger `RequestMetrics.start_cycle`, persist the updated `Game` snapshot. |
-| `ROUND_FLOP` | `progress_stage` advances from pre-flop and burns + deals three community cards under the stage lock. | Betting cycle completes with at least two contenders, or the table short-circuits to `finalize_game()` when only one player remains. | Reset `has_acted`, publish flop snapshots via `PokerBotViewer`, save state through `TableManager`. |
-| `ROUND_TURN` | Triggered by `progress_stage` immediately after the flop round resolves. | Stage betting resolves with multiple contenders, or the hand ends early because everyone but one folded/timed out. | Deal the turn card, refresh betting order, keep telemetry/logging via `RequestMetrics`. |
-| `ROUND_RIVER` | Reached when turn betting finalises while at least two active players remain. | Betting cycle completes; if more than one contender survives, `progress_stage` calls `finalize_game()` for showdown, otherwise the single remaining player wins immediately. | Deal the river card, instruct the viewer to render the full board, persist the final betting state. |
-| `finalize_game()` | Called from `progress_stage`, `request_stop`, or timeout/error handlers whenever a hand needs to settle. | `GameEngine._reset_game_state` saves the `WAITING` state and `PlayerManager.send_join_prompt` re-opens the lobby. | Determine winners, distribute payouts, emit statistics, invalidate caches, clean up Telegram anchors, and reset timers/locks. |
+### Locking & cache lifecycle by stage
 
-`MatchmakingService.progress_stage` enforces stage order while holding the
-`LockManager` stage lock so that Telegram callbacks, background jobs, and rate
-limited retries cannot interleave inconsistent mutations. If at any point only
-one player remains (everyone else folded or timed out) the engine short-circuits
-to `finalize_game()` even if community cards are still undealt.
+| Stage | How we get here | LockManager role | Cache invalidations |
+| ----- | --------------- | ---------------- | ------------------- |
+| `WAITING` | `finalize_game()` or a brand-new chat creates a waiting `Game`. | The stage lock is idle; only table-level locks protect joins and seat assignments. | None; caches stay warm so `/stats` requests remain fast between hands. |
+| `ROUND_PRE_FLOP` | `start_game()` acquires the stage lock and rotates dealer/blinds before cards are dealt. | LockManager guards the stage while the matchmaking service posts blinds, deals hole cards, and broadcasts turns to avoid interleaved Telegram callbacks. | No invalidation yet; analytics rely on pre-hand data to track participation. |
+| `ROUND_FLOP` | `progress_stage()` collects bets, burns/deals three community cards, and re-schedules turns. | Stage lock stays held during dealing and viewer updates to ensure Redis snapshots and Telegram keyboards stay in sync. | None. |
+| `ROUND_TURN` | Triggered by another `progress_stage()` call once flop betting resolves. | Stage lock serialises the single-card deal, bet resets, and viewer snapshot updates. | None. |
+| `ROUND_RIVER` | Entered when the turn round finishes with ≥2 contenders. | LockManager continues to guard the stage while the final community card is revealed and players are prompted. | None. |
+| `WAITING` (post-hand) | `finalize_game()` or `_reset_game_state_after_stop()` completes. | The stage lock is released; timers for the auto-start countdown can resume. | `AdaptivePlayerReportCache.invalidate_on_event(..., "hand_finished")` and `StatsReporter.invalidate_players(..., "hand_finished")` ensure next-stat requests rebuild from the latest results. |
 
-## Transition rules and safeguards
+### Early exits
 
-- **Waiting for quorum** — `PlayerManager` triggers the first transition only
-  when the lobby has at least the configured minimum number of ready players and
-  blinds can be assigned. Duplicate `/start` requests are coalesced behind the
-  stage lock.
-- **Betting cycles** — Each stage waits for every non-folded player to either
-  match the highest wager, raise, or fold. The lock ensures callbacks such as
-  `fold` or `all-in` are processed sequentially.
-- **Community card dealing** — `MatchmakingService.add_cards_to_table` is only
-  invoked while holding the stage lock, guaranteeing that snapshots published by
-  `PokerBotViewer` match the persisted `Game` state.
-- **Finalisation** — `GameEngine.finalize_game()` is responsible for both normal
-  showdowns and early finishes. It computes winners, writes statistics, and
-  resets the chat back to `WAITING`.
+* **Stop votes** — Active players (or the table manager) can request a stop via
+  `/stop`. When a majority confirms, `cancel_hand()` refunds wallets, invalidates
+  caches as if a hand finished, and immediately resets the state to `WAITING`
+  without revealing additional cards.
+* **Fewer than two contenders** — `MatchmakingService.progress_stage()` checks the
+  active/all-in roster before every transition. If only one contender remains,
+  it bypasses additional dealing, calls `finalize_game()`, and declares the
+  remaining player the winner.
+* **Stage anomalies** — If dealing fails (for example due to depleted decks) or
+  a timeout leaves no active players, the service also escalates to
+  `finalize_game()` so the next hand starts from a clean slate.
 
-## Swimlane — collaborating components
+### Responsibilities per transition
 
-The following swimlane diagram captures how the main services collaborate during
-one full hand. Each lane highlights the responsibilities that the class owns or
-delegates.
+1. **`start_game()`**
+   - Cleans up any lingering join prompts.
+   - Rotates dealer/blind positions and posts forced bets.
+   - Deals hole cards while the stage lock prevents overlapping callbacks.
+   - Signals `StatsReporter.hand_started` so lifetime statistics reflect the new
+     hand.
+2. **`progress_stage()`**
+   - Collects wagers into the pot, resets `has_acted`, and advances to the next
+     state if enough contenders remain.
+   - Deals community cards using `MatchmakingService.add_cards_to_table`, which
+     itself runs under the stage lock.
+   - Persists the `Game` snapshot through `TableManager` so reconnecting players
+     receive the updated board.
+3. **`finalize_game()`**
+   - Computes winners (including side pots) and distributes payouts.
+   - Invalidates player-report caches and statistics, ensuring the next
+     `/stats` lookup renders fresh data.
+   - Clears pinned anchors and prompts the lobby so `WAITING` restarts with
+     accurate seating information.
 
-```plantuml
-@startuml GameFlowSwimlane
-|Telegram|
-start
-:Players tap /start and join buttons;
-|PlayerManager|
-:Record join intent;
-:Persist ready prompt via TableManager;
-|GameEngine|
-:detect required players;
-:acquire stage lock;
-|MatchmakingService|
-:start_game();
-:assign dealer & blinds;
-:deal_hole_cards();
-|PokerBotViewer|
-:send private hole cards;
-|GameEngine|
-:progress_stage();
-|MatchmakingService|
-:collect_bets_for_pot();
-:transition ROUND_PRE_FLOP→ROUND_FLOP;
-|PokerBotViewer|
-:announce flop;
-|GameEngine|
-:progress_stage();
-|MatchmakingService|
-:transition to turn & river;
-|PokerBotViewer|
-:update community cards;
-|GameEngine|
-:finalize_game();
-|StatsService|
-:hand_finished(payouts);
-|TableManager|
-:reset & save game;
-|PlayerManager|
-:send_join_prompt();
-|Telegram|
-:Players ready for next hand;
-stop
-@enduml
-```
-
-The PlantUML source for the swimlane diagram is stored at
-[`docs/diagrams/game_flow_swimlane.puml`](diagrams/game_flow_swimlane.puml).
-
-## Supporting services referenced
-
-- **TableManager** keeps one `Game` object per chat persisted to Redis so that
-  reconnections and bot restarts recover ongoing hands.
-- **PlayerManager** renders the join prompt, manages seat assignments, and keeps
-  localized role labels (dealer, small blind, big blind) up to date.
-- **PokerBotViewer** is the façade around the messaging layer. It batches edits
-  and renders translated templates for table messages and anchors.
-- **StatsService** (via `StatsReporter`) records per-hand statistics and drives
-  bonus eligibility caches using `AdaptivePlayerReportCache`.
-- **RequestMetrics** records timing and outcome metadata for each major player
-  interaction so incidents can be diagnosed.
-
-Together these components allow the state machine to remain small and
-cohesively focused on poker rules while infra concerns (persistence, retries,
-metrics, localization) remain testable in isolation.
+With these safeguards the poker flow remains deterministic even when Telegram
+callbacks arrive concurrently or administrators stop a hand mid-round.


### PR DESCRIPTION
## Summary
- replace the game flow guide with a state-machine focused walkthrough covering locks, cache invalidation, and early exits
- refresh the architecture guide with a bootstrap-centric diagram and dependency descriptions
- link the new documentation set from the README for quick discovery

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d415f2fccc8328a3d69ce75025a5f7