### PR TITLE
Refactor finalize_game orchestration helpers

### DIFF
--- a/tests/test_game_engine_helpers.py
+++ b/tests/test_game_engine_helpers.py
@@ -149,7 +149,7 @@ async def test_reset_game_state_clears_pot_and_persists(game_engine_setup):
     game = Game()
     game.pot = 300
 
-    await game_engine_setup.engine._reset_game_state(
+    await game_engine_setup.engine._reset_core_game_state(
         game=game,
         chat_id=-400,
         context=SimpleNamespace(chat_data={}),

--- a/tests/test_pokerbotmodel.py
+++ b/tests/test_pokerbotmodel.py
@@ -993,7 +993,7 @@ async def test_showdown_sends_new_hand_message_before_join_prompt():
     model._game_engine._clear_game_messages = AsyncMock()
     model._player_manager.send_join_prompt = AsyncMock(side_effect=record_join_prompt)
     model._game_engine._evaluate_contender_hands = MagicMock(return_value=[])
-    model._game_engine._determine_winners = MagicMock(return_value=[])
+    model._game_engine._determine_pot_winners = MagicMock(return_value=[])
 
     game = Game()
     wallet = make_wallet_mock(100)


### PR DESCRIPTION
## Summary
- split `finalize_game` into dedicated helpers that determine winners, execute payouts, send notifications, and reset the table
- rename the lower-level reset routine to `_reset_core_game_state` and rewire callers through the new orchestration helper
- update unit tests to reflect the helper renames and keep coverage of the post-hand workflow

## Testing
- pytest tests/test_game_engine_finalization.py tests/test_game_engine_helpers.py tests/test_pokerbotmodel.py

------
https://chatgpt.com/codex/tasks/task_e_68d429dfeea08328ad84136d74d01618