### PR TITLE
Route admin notifications through TelegramSafeOps

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -962,14 +962,25 @@ class GameEngine:
                     "error_type": "PotMismatch",
                 },
             )
+            notify_payload = {
+                "event": "pot_mismatch",
+                "game_pot": game.pot,
+                "calculated": calculated_pot_total,
+            }
+            log_extra = self._build_telegram_log_extra(
+                chat_id=chat_identifier,
+                message_id=None,
+                game_id=getattr(game, "id", None),
+                operation="notify_admin_pot_mismatch",
+                request_category=RequestCategory.GENERAL,
+            )
             try:
                 asyncio.create_task(
-                    self._view.notify_admin(
-                        {
-                            "event": "pot_mismatch",
-                            "game_pot": game.pot,
-                            "calculated": calculated_pot_total,
-                        }
+                    self._telegram_ops.send_message_safe(
+                        call=lambda data=notify_payload: self._view.notify_admin(data),
+                        chat_id=chat_identifier,
+                        operation="notify_admin_pot_mismatch",
+                        log_extra=log_extra,
                     )
                 )
             except Exception:  # pragma: no cover - notify best effort


### PR DESCRIPTION
## Summary
- wrap pot mismatch admin notifications with TelegramSafeOps to reuse centralized retry/backoff behaviour
- add structured logging context when notifying admins about pot mismatches

## Testing
- pytest tests/test_telegram_safeops.py

------
https://chatgpt.com/codex/tasks/task_e_68d42da37840832881f97a135e19fff9