### PR TITLE
Implement timezone utilities for localized formatting

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -733,7 +733,7 @@ class PokerBotModel:
                 anchor = anchor.replace(tzinfo=datetime.timezone.utc)
             target_time = anchor + datetime.timedelta(seconds=countdown)
             localized = format_local(
-                target_time, "%H:%M:%S", tz_name=self._timezone_name
+                target_time, self._timezone_name, fmt="%H:%M:%S"
             )
             lines.append(f"🕒 زمان تقریبی شروع: {localized}")
             lines.append("🚀 برای شروع سریع‌تر بازی /start را بزنید یا صبر کنید.")

--- a/pokerapp/stats/service.py
+++ b/pokerapp/stats/service.py
@@ -1009,12 +1009,12 @@ class StatsService(BaseStatsService):
             lines.append(f"📐 بازده سرمایه (ROI): {roi:.1f}%")
         if stats.last_game_at:
             last_game = format_local(
-                stats.last_game_at, "%Y-%m-%d %H:%M %Z", tz_name=self._timezone_name
+                stats.last_game_at, self._timezone_name, fmt="%Y-%m-%d %H:%M %Z"
             )
             lines.append(f"🕰️ آخرین بازی: {last_game}")
         if stats.last_bonus_at:
             last_bonus = format_local(
-                stats.last_bonus_at, "%Y-%m-%d %H:%M %Z", tz_name=self._timezone_name
+                stats.last_bonus_at, self._timezone_name, fmt="%Y-%m-%d %H:%M %Z"
             )
             lines.append(f"🎯 آخرین بونوس: {last_bonus}")
 
@@ -1037,7 +1037,7 @@ class StatsService(BaseStatsService):
                     prefix = "🤝 مساوی"
                 if game.finished_at:
                     timestamp = format_local(
-                        game.finished_at, "%Y-%m-%d %H:%M", tz_name=self._timezone_name
+                        game.finished_at, self._timezone_name, fmt="%Y-%m-%d %H:%M"
                     )
                 else:
                     timestamp = "-"

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -21,26 +21,26 @@ def test_to_local_applies_tehran_offset():
     assert local.utcoffset() == timedelta(hours=3, minutes=30)
 
 
-def test_to_local_handles_dst_transition():
+def test_to_local_handles_tehran_dst_transition():
     before = to_local(
-        datetime(2024, 3, 10, 6, 30, tzinfo=ZoneInfo("UTC")), tz_name="America/New_York"
+        datetime(2022, 3, 21, 20, 0, tzinfo=ZoneInfo("UTC")), tz_name="Asia/Tehran"
     )
     after = to_local(
-        datetime(2024, 3, 10, 7, 30, tzinfo=ZoneInfo("UTC")), tz_name="America/New_York"
+        datetime(2022, 3, 21, 21, 0, tzinfo=ZoneInfo("UTC")), tz_name="Asia/Tehran"
     )
 
-    assert before.hour == 1
-    assert before.utcoffset() == timedelta(hours=-5)
+    assert before.hour == 23
+    assert before.utcoffset() == timedelta(hours=3, minutes=30)
 
-    assert after.hour == 3
-    assert after.utcoffset() == timedelta(hours=-4)
+    assert after.hour == 1
+    assert after.utcoffset() == timedelta(hours=4, minutes=30)
 
 
 def test_format_local_uses_configured_timezone():
     cfg = Config()
     base = datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo("UTC"))
 
-    formatted = format_local(base, "%Y-%m-%d %H:%M", tz_name=cfg.TIMEZONE_NAME)
+    formatted = format_local(base, cfg.TIMEZONE_NAME, fmt="%Y-%m-%d %H:%M")
     expected = to_local(base, tz_name=cfg.TIMEZONE_NAME).strftime("%Y-%m-%d %H:%M")
 
     assert formatted == expected


### PR DESCRIPTION
## Summary
- replace the timezone helpers with a simple UTC-based implementation and formatting utility
- update pokerbot and stats services to use the new formatting helper with the configured timezone
- expand tests to cover Asia/Tehran daylight transition handling

## Testing
- pytest tests/test_time_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d43044b00c8328928f4ad421a8663e