### PR TITLE
Allow debug fallback dealer assignment

### DIFF
--- a/pokerapp/config.py
+++ b/pokerapp/config.py
@@ -640,6 +640,13 @@ class Config:
         self.ALLOWED_UPDATES: Optional[List[str]] = self._parse_allowed_updates(
             allowed_updates_raw
         )
+        allow_empty_dealer_raw = os.getenv("POKERBOT_ALLOW_EMPTY_DEALER")
+        allow_empty_dealer = False
+        if allow_empty_dealer_raw is not None:
+            allow_empty_dealer = (
+                allow_empty_dealer_raw.strip().lower() in {"1", "true", "yes", "on"}
+            )
+        self.ALLOW_EMPTY_DEALER: bool = self.DEBUG or allow_empty_dealer
         max_connections_raw, max_connections_source = self._get_first_nonempty_env(
             "POKERBOT_WEBHOOK_MAX_CONNECTIONS",
             "POKERBOT_MAX_CONNECTIONS",

--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -274,6 +274,7 @@ class PokerBotModel:
             safe_int=self._safe_int,
             old_players_key=KEY_OLD_PLAYERS,
             logger=logger.getChild("matchmaking"),
+            config=cfg,
         )
         self._telegram_ops = telegram_safe_ops or TelegramSafeOps(
             self._view,


### PR DESCRIPTION
## Summary
- add Config flag `ALLOW_EMPTY_DEALER` derived from POKERBOT_DEBUG or new POKERBOT_ALLOW_EMPTY_DEALER env var
- allow MatchmakingService to inject Config and create a debug dealer fallback when enabled
- cover the fallback behaviour with a unit test and pass the Config through PokerBotModel

## Testing
- pytest tests/test_matchmaking_service_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68d43d1f45d0832897732155f504fa14