### PR TITLE
Add safe edit helpers with markup canonicalisation

### DIFF
--- a/pokerapp/utils/cache.py
+++ b/pokerapp/utils/cache.py
@@ -119,6 +119,13 @@ class MessageStateCache:
                 ),
             )
 
+    async def get(self, chat_id: int, message_id: int) -> Optional[MessagePayload]:
+        """Return the cached payload for ``(chat_id, message_id)`` if available."""
+
+        key = self._key(chat_id, message_id)
+        async with self._lock:
+            return self._cache.get(key)
+
     async def forget(self, chat_id: int, message_id: int) -> None:
         """Remove a cached entry when the message is deleted."""
 

--- a/pokerapp/utils/message_updates.py
+++ b/pokerapp/utils/message_updates.py
@@ -26,7 +26,19 @@ async def safe_edit_message(
     if message_id is None:
         return None
 
+    params = dict(params)
     force = bool(params.pop("force", False))
+
+    safe_method = getattr(messaging_service, "safe_edit_message", None)
+    if callable(safe_method):
+        return await safe_method(
+            chat_id=chat_id,
+            message_id=message_id,
+            text=text,
+            reply_markup=reply_markup,
+            force=force,
+            **params,
+        )
 
     cache = getattr(messaging_service, "message_state_cache", None)
     service_logger: logging.Logger = getattr(


### PR DESCRIPTION
## Summary
- add `MessagingService.safe_edit_message` and `safe_edit_reply_markup` to reuse `MessageStateCache` for combined text/markup deduplication
- canonicalise inline markup serialization and expose `MessageStateCache.get` for retrieving cached payloads
- let the shared `safe_edit_message` helper delegate to the service-level implementation when available

## Testing
- pytest tests/test_logging.py tests/test_pokerbotmodel.py *(fails: countdown tests expect start_prestart_countdown to be awaited)*

------
https://chatgpt.com/codex/tasks/task_e_68d5999e89c08328961e20f4d81a08d0