### PR TITLE
Add safe edit helper for orchestrated message updates

### DIFF
--- a/tests/test_aiogram_flow.py
+++ b/tests/test_aiogram_flow.py
@@ -151,7 +151,7 @@ async def test_voting_flow_updates_message():
     assert "✔️ Ali" in bot.edit_message_text.await_args.kwargs["text"]
 
     await orchestrator.vote_join("Sara")
-    last_markup = bot.edit_message_reply_markup.await_args.kwargs["reply_markup"]
+    last_markup = bot.edit_message_text.await_args_list[-1].kwargs["reply_markup"]
     assert any(
         button.callback_data == "seat:join"
         for row in last_markup.inline_keyboard


### PR DESCRIPTION
## Summary
- add a safe_edit_message helper to RequestManager to coalesce text and markup edits with cache checks
- switch orchestrator updates to use the new helper when refreshing turn, anchor, and voting messages
- update aiogram flow tests to assert markup expectations via edit_message_text after the refactor

## Testing
- pytest tests/test_aiogram_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68d5a963a7e88328a35e98f55e3a2dcd