### PR TITLE
Clean message references when aborting games

### DIFF
--- a/tests/test_pokerbotmodel.py
+++ b/tests/test_pokerbotmodel.py
@@ -489,6 +489,9 @@ async def test_cancel_hand_refunds_wallets_and_announces():
     )
     game.add_player(player_b, seat_index=1)
     game.pot = 300
+    game.board_message_id = 404
+    game.message_ids_to_delete.extend([77, 88])
+    game.anchor_message_id = 909
 
     stop_request = {
         "game_id": game.id,
@@ -512,6 +515,11 @@ async def test_cancel_hand_refunds_wallets_and_announces():
     assert view.send_message.await_count == 1
     table_manager.save_game.assert_awaited_once_with(chat_id, game)
     assert game.state == GameState.INITIAL
+    assert player_a.ready_message_id is None
+    assert player_b.ready_message_id is None
+    assert getattr(game, "anchor_message_id", None) is None
+    assert game.board_message_id is None
+    assert game.message_ids_to_delete == []
 
 
 


### PR DESCRIPTION
## Summary
- add a reusable helper to reset cached message identifiers on stop and abort flows
- ensure /stop without an active game clears residual IDs before notifying players
- extend stop-related tests to cover the new cleanup behaviour

## Testing
- `pytest tests/test_game_engine_helpers.py tests/test_pokerbotmodel.py::test_cancel_hand_refunds_wallets_and_announces`


------
https://chatgpt.com/codex/tasks/task_e_68d65e63f214832898d6e043e23595f1