### PR TITLE
Validate ready prompt message context

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -168,7 +168,10 @@ class Game:
         self.ready_message_main_id: Optional[MessageId] = None
         # متن آخرین پیام آماده‌باش برای جلوگیری از ویرایش‌های تکراری
         self.ready_message_main_text: str = ""
-    
+        # Metadata to ensure prompt edits apply to the right game context
+        self.ready_message_game_id: Optional[str] = None
+        self.ready_message_stage: Optional[GameState] = None
+
         # 🆕 اضافه شده: آرایه پیام‌هایی که باید پاک شوند
         self.message_ids_to_delete: List[MessageId] = []
 
@@ -304,6 +307,10 @@ class Game:
         # persisted state.
         if "board_message_id" not in state:
             self.board_message_id = None
+        if "ready_message_game_id" not in state:
+            self.ready_message_game_id = None
+        if "ready_message_stage" not in state:
+            self.ready_message_stage = None
 
     def __repr__(self):
         return "{}({!r})".format(self.__class__.__name__, self.__dict__)

--- a/pokerapp/player_manager.py
+++ b/pokerapp/player_manager.py
@@ -162,6 +162,8 @@ class PlayerManager:
         if message_id:
             game.ready_message_main_id = message_id
             game.ready_message_main_text = "برای نشستن سر میز دکمه را بزن"
+            game.ready_message_game_id = getattr(game, "id", None)
+            game.ready_message_stage = game.state
             if self._table_manager is not None:
                 await self._table_manager.save_game(chat_id, game)
 
@@ -184,6 +186,8 @@ class PlayerManager:
             )
         else:
             game.ready_message_main_id = None
+        game.ready_message_game_id = None
+        game.ready_message_stage = None
         game.ready_message_main_text = ""
 
         for player in getattr(game, "players", []):

--- a/tests/test_pokerbotmodel.py
+++ b/tests/test_pokerbotmodel.py
@@ -630,8 +630,10 @@ async def test_auto_start_tick_starts_prestart_countdown_and_updates_state():
     kv = MagicMock()
     table_manager = MagicMock()
     game = Game()
-    game.ready_message_main_id = 111
     game.id = "game-42"
+    game.ready_message_main_id = 111
+    game.ready_message_game_id = game.id
+    game.ready_message_stage = game.state
     game.ready_message_main_text = "prompt"
     table_manager.get_game = AsyncMock(return_value=game)
     table_manager.save_game = AsyncMock()
@@ -688,8 +690,10 @@ async def test_auto_start_tick_does_not_restart_on_regular_tick():
     kv = MagicMock()
     table_manager = MagicMock()
     game = Game()
-    game.ready_message_main_id = 321
     game.id = "game-43"
+    game.ready_message_main_id = 321
+    game.ready_message_game_id = game.id
+    game.ready_message_stage = game.state
     table_manager.get_game = AsyncMock(return_value=game)
     table_manager.save_game = AsyncMock()
 
@@ -732,8 +736,10 @@ async def test_auto_start_tick_restarts_when_countdown_increases():
     kv = MagicMock()
     table_manager = MagicMock()
     game = Game()
-    game.ready_message_main_id = 555
     game.id = "game-44"
+    game.ready_message_main_id = 555
+    game.ready_message_game_id = game.id
+    game.ready_message_stage = game.state
     table_manager.get_game = AsyncMock(return_value=game)
     table_manager.save_game = AsyncMock()
 
@@ -1056,6 +1062,8 @@ async def test_start_game_assigns_blinds_to_occupied_seats():
     game = Game()
     ready_message_id = 444
     game.ready_message_main_id = ready_message_id
+    game.ready_message_game_id = game.id
+    game.ready_message_stage = game.state
     game.ready_message_main_text = "prompt"
     game.dealer_index = 0
 
@@ -1133,6 +1141,8 @@ async def test_start_game_keeps_ready_message_id_when_deletion_fails():
     game = Game()
     ready_message_id = 321
     game.ready_message_main_id = ready_message_id
+    game.ready_message_game_id = game.id
+    game.ready_message_stage = game.state
     game.ready_message_main_text = "prompt"
     game.dealer_index = -1
 


### PR DESCRIPTION
## Summary
- add metadata to games and cleanup routines to track which game generated a ready prompt
- guard ready prompt edits to ensure the cached message belongs to the active game and fall back to sending a new prompt when stale
- refine countdown handling to start the prestart timer only once per hand, expose dynamic countdown text, and update tests to cover the new bookkeeping

## Testing
- pytest tests/test_pokerbotmodel.py


------
https://chatgpt.com/codex/tasks/task_e_68d660edfea48328aa559d612427a5e4