### PR TITLE
Guard message edits against stale game IDs

### DIFF
--- a/pokerapp/bootstrap.py
+++ b/pokerapp/bootstrap.py
@@ -143,6 +143,7 @@ def build_services(cfg: Config) -> ApplicationServices:
             deleted_messages_lock=deleted_messages_lock,
             last_message_hash=last_message_hash,
             last_message_hash_lock=last_message_hash_lock,
+            table_manager=table_manager,
         )
 
     def telegram_safeops_factory(*, view) -> TelegramSafeOps:

--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -1282,6 +1282,7 @@ class GameEngine:
                 operation="stop_vote_request_message",
                 request_category=RequestCategory.GENERAL,
             ),
+            current_game_id=getattr(game, "id", None),
         )
         stop_request["message_id"] = message_id
         context.chat_data[self.KEY_STOP_REQUEST] = stop_request
@@ -1465,6 +1466,7 @@ class GameEngine:
                 operation="stop_vote_resume_message",
                 request_category=RequestCategory.GENERAL,
             ),
+            current_game_id=getattr(game, "id", None),
         )
 
     async def cancel_hand(
@@ -1548,6 +1550,7 @@ class GameEngine:
                 operation="stop_vote_request_message",
                 request_category=RequestCategory.GENERAL,
             ),
+            current_game_id=getattr(game, "id", None),
         )
         stop_request["message_id"] = message_id
         context.chat_data[self.KEY_STOP_REQUEST] = stop_request
@@ -1637,6 +1640,7 @@ class GameEngine:
                 operation="stop_vote_finalize_message",
                 request_category=RequestCategory.GENERAL,
             ),
+            current_game_id=stop_request.get("game_id"),
         )
 
         context.chat_data.pop(self.KEY_STOP_REQUEST, None)

--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -936,6 +936,7 @@ class PokerBotModel:
                     text,
                     reply_markup=keyboard,
                     request_category=RequestCategory.COUNTDOWN,
+                    current_game_id=getattr(game, "id", None),
                 )
 
             anchor_message_id = game.ready_message_main_id
@@ -1064,6 +1065,7 @@ class PokerBotModel:
         parse_mode: str = ParseMode.MARKDOWN,
         log_context: Optional[str] = None,
         request_category: RequestCategory = RequestCategory.GENERAL,
+        current_game_id: Optional[str] = None,
     ) -> Optional[MessageId]:
         return await self._telegram_ops.edit_message_text(
             chat_id,
@@ -1073,6 +1075,7 @@ class PokerBotModel:
             parse_mode=parse_mode,
             log_context=log_context,
             request_category=request_category,
+            current_game_id=current_game_id,
         )
 
     async def show_table(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -1185,6 +1188,7 @@ class PokerBotModel:
                     text,
                     reply_markup=keyboard,
                     request_category=RequestCategory.COUNTDOWN,
+                    current_game_id=getattr(game, "id", None),
                 )
                 if new_id is None:
                     if message_id and message_id in game.message_ids_to_delete:

--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -4119,6 +4119,7 @@ class PokerBotViewer:
         request_category: RequestCategory = RequestCategory.GENERAL,
         *,
         suppress_exceptions: bool = True,
+        current_game_id: Optional[str] = None,
     ) -> Optional[MessageId]:
         """Edit a message using the central ``MessagingService``.
 
@@ -4149,6 +4150,7 @@ class PokerBotViewer:
                 message_id=message_id,
                 text=normalized_text,
                 reply_markup=reply_markup,
+                current_game_id=current_game_id,
                 request_category=request_category,
                 context=context,
                 parse_mode=parse_mode,

--- a/pokerapp/utils/message_updates.py
+++ b/pokerapp/utils/message_updates.py
@@ -19,6 +19,7 @@ async def safe_edit_message(
     message_id: Optional[int],
     text: Optional[str],
     reply_markup: Optional[Any] = None,
+    current_game_id: Optional[str] = None,
     **params: Any,
 ):
     """Edit a Telegram message only when the payload has changed."""
@@ -37,6 +38,7 @@ async def safe_edit_message(
             text=text,
             reply_markup=reply_markup,
             force=force,
+            current_game_id=current_game_id,
             **params,
         )
 
@@ -112,6 +114,7 @@ async def safe_edit_message(
             text=text,
             reply_markup=reply_markup,
             force=force,
+            current_game_id=current_game_id,
             **params,
         )
     except Exception:

--- a/pokerapp/utils/telegram_safeops.py
+++ b/pokerapp/utils/telegram_safeops.py
@@ -60,6 +60,7 @@ class TelegramSafeOps:
         log_context: Optional[str] = None,
         request_category: RequestCategory = RequestCategory.GENERAL,
         log_extra: Optional[Mapping[str, Any]] = None,
+        current_game_id: Optional[str] = None,
     ) -> Optional[MessageId]:
         """Safely edit a message, retrying transient failures when required."""
 
@@ -84,6 +85,7 @@ class TelegramSafeOps:
                     request_category=request_category,
                     parse_mode=parse_mode,
                     suppress_exceptions=False,
+                    current_game_id=current_game_id,
                 ),
                 log_extra=log_extra,
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,7 @@ def _inject_viewer_dependencies(monkeypatch):
                     deleted_messages_lock=deleted_messages_lock,
                     last_message_hash=last_message_hash,
                     last_message_hash_lock=last_message_hash_lock,
+                    table_manager=None,
                 )
 
             kwargs["messaging_service_factory"] = _factory

--- a/tests/test_game_engine_helpers.py
+++ b/tests/test_game_engine_helpers.py
@@ -360,6 +360,7 @@ async def test_finalize_stop_request_logs_retry_details(caplog):
             request_category,
             parse_mode,
             suppress_exceptions,
+            current_game_id=None,
         ):
             self.edit_attempts += 1
             if self.edit_attempts == 1:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -84,6 +84,7 @@ async def test_messaging_service_logs_include_context(caplog):
         _DummyBot(),
         logger_=logger,
         request_metrics=metrics,
+        table_manager=None,
     )
 
     context = {"game_id": "game-123", "stage": "TURN"}
@@ -114,6 +115,7 @@ async def test_messaging_service_logs_errors_with_context(caplog):
         _FailingBot(),
         logger_=logger,
         request_metrics=metrics,
+        table_manager=None,
     )
 
     with pytest.raises(ValueError):

--- a/tests/test_telegram_safeops.py
+++ b/tests/test_telegram_safeops.py
@@ -32,6 +32,7 @@ class _DummyView:
         request_category,
         parse_mode,
         suppress_exceptions,
+        current_game_id=None,
     ):
         self.calls.edit += 1
         if self._edit_side_effects:


### PR DESCRIPTION
## Summary
- guard Telegram edits in `MessagingService` by validating message IDs against the current TableManager game
- thread the active `game_id` through safe edit helpers, TelegramSafeOps, and game orchestration calls
- refresh factories and tests to accommodate the new dependency and parameter

## Testing
- pytest tests/test_telegram_safeops.py tests/test_game_engine_helpers.py tests/test_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68d66bc62228832880323e41ad4dcdb2