### PR TITLE
Ensure stop command clears ready prompts

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -1652,6 +1652,7 @@ class GameEngine:
         chat_id: ChatId,
         context: ContextTypes.DEFAULT_TYPE,
     ) -> None:
+        await self._player_manager.cleanup_ready_prompt(game, chat_id)
         await self._reset_core_game_state(
             game,
             context=context,


### PR DESCRIPTION
## Summary
- clear any ready prompt message IDs when a game is stopped to prevent stale edits

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6741d04848328ba3c612cdfb67564