### PR TITLE
Ensure `/stop` clears ready prompt metadata

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -1207,6 +1207,7 @@ class GameEngine:
         """Validate and submit a stop request for the active hand."""
 
         if game.state == GameState.INITIAL:
+            await self._player_manager.cleanup_ready_prompt(game, chat_id)
             clear_all_message_ids(game)
             await self._table_manager.save_game(chat_id, game)
             raise UserException(self.ERROR_NO_ACTIVE_GAME)

--- a/tests/test_game_engine_helpers.py
+++ b/tests/test_game_engine_helpers.py
@@ -31,6 +31,7 @@ def game_engine_setup():
 
     player_manager = MagicMock()
     player_manager.clear_player_anchors = AsyncMock()
+    player_manager.cleanup_ready_prompt = AsyncMock()
 
     async def _passthrough_send_message_safe(*, call, **_kwargs):
         return await call()


### PR DESCRIPTION
## Summary
- call the player manager's ready prompt cleanup when `/stop` is triggered for an inactive game so stale IDs are cleared and persisted
- extend the game engine helper test fixture to mock the async ready prompt cleanup helper

## Testing
- pytest tests/test_game_engine_helpers.py::test_stop_game_initial_state_clears_messages

------
https://chatgpt.com/codex/tasks/task_e_68d67b3d389c8328a2a1e2552dbea2e7