### PR TITLE
Ensure stop command cleans ready prompt

### DIFF
--- a/pokerapp/pokerbotcontrol.py
+++ b/pokerapp/pokerbotcontrol.py
@@ -177,6 +177,7 @@ class PokerBotCotroller:
             }
             if message_text in cleanup_messages:
                 game = await self._model._table_manager.get_game(chat_id)
+                await self._model._player_manager.cleanup_ready_prompt(game, chat_id)
                 clear_all_message_ids(game)
                 logger.info(
                     "Cleared all message IDs after stop",


### PR DESCRIPTION
## Summary
- ensure the /stop command cleanup path deletes the ready prompt before clearing cached IDs

## Testing
- pytest tests/test_game_engine_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68d68068cc988328bcb5cb79c8d18c4c