### PR TITLE
Fix logger initialization and ready prompt persistence

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -1653,7 +1653,9 @@ class GameEngine:
         chat_id: ChatId,
         context: ContextTypes.DEFAULT_TYPE,
     ) -> None:
-        await self._player_manager.cleanup_ready_prompt(game, chat_id)
+        await self._player_manager.cleanup_ready_prompt(
+            game, chat_id, persist=False
+        )
         await self._reset_core_game_state(
             game,
             context=context,

--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -205,6 +205,7 @@ class PokerBotModel:
         self._view: PokerBotViewer = view
         self._bot: Bot = bot
         self._cfg: Config = cfg
+        self._logger = logger.getChild("model")
         self._constants = cfg.constants
         self._kv = kv
         self._redis_ops = redis_ops or RedisSafeOps(


### PR DESCRIPTION
## Summary
- initialize the PokerBotModel logger so ready handling can log without raising
- track ready prompt state changes and allow callers to skip redundant persistence
- avoid double-saving games when resetting after a stop request

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d689ac3c5483289a22789687edc218