### PR TITLE
Fix ready roster persistence and chat guard timeouts

### DIFF
--- a/pokerapp/lock_manager.py
+++ b/pokerapp/lock_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -589,6 +590,10 @@ class LockManager:
         self, key: str, override: Optional[float]
     ) -> Optional[float]:
         if override is not None:
+            if isinstance(override, (int, float)) and (
+                override < 0 or math.isinf(override)
+            ):
+                return None
             return override
         category = self._resolve_lock_category(key)
         category_timeout = None

--- a/pokerapp/player_manager.py
+++ b/pokerapp/player_manager.py
@@ -168,6 +168,17 @@ class PlayerManager:
             for player in players:
                 player.ready_message_id = None
 
+            if getattr(game, "ready_users", None):
+                game.ready_users.clear()
+            remover = getattr(game, "remove_player_by_user", None)
+            if callable(remover):
+                for player in players:
+                    if player is None:
+                        continue
+                    user_id = getattr(player, "user_id", None)
+                    if user_id is not None:
+                        remover(user_id)
+
             game.ready_message_main_id = None
             game.ready_message_main_text = ""
             game.ready_message_game_id = None


### PR DESCRIPTION
## Summary
- disable category timeouts when the chat guard retries without a timeout so the lock can be acquired successfully
- clear stale ready rosters when recreating the ready prompt and prune seats based on the current ready message metadata
- build the ready message from the current ready players and base auto-start scheduling on their count

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d68cac1ac8832891a14dd936b3fb41