### PR TITLE
Fix countdown timing and start deadlock

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -231,6 +231,14 @@ class GameEngine:
         "key_start_countdown_context",
         "start_countdown_context",
     )
+    KEY_START_COUNTDOWN_ANCHOR = _ENGINE_CONSTANTS.get(
+        "key_start_countdown_anchor",
+        "start_countdown_anchor",
+    )
+    KEY_START_COUNTDOWN_INITIAL_SECONDS = _ENGINE_CONSTANTS.get(
+        "key_start_countdown_initial_seconds",
+        "start_countdown_initial_seconds",
+    )
     STAGE_LOCK_PREFIX = _ENGINE_REDIS_KEYS.get("stage_lock_prefix", "stage:")
     KEY_STOP_REQUEST = _ENGINE_REDIS_KEYS.get(
         "stop_request",


### PR DESCRIPTION
## Summary
- store countdown anchor metadata so the approximate start time remains stable while the timer counts down
- skip re-acquiring the chat guard during auto-start to avoid deadlocks when the countdown hits zero
- extend countdown unit tests to cover the new metadata and stable start-time behaviour

## Testing
- pytest tests/test_pokerbotmodel.py

------
https://chatgpt.com/codex/tasks/task_e_68d69122e16c83288da3fee2a8e5effd