### PR TITLE
Reduce noisy chat lock timeout warnings

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -382,7 +382,10 @@ class PokerBotModel:
         timeout_seconds = self._chat_guard_timeout_seconds
         try:
             async with self._lock_manager.guard(
-                key, timeout=timeout_seconds, level=0
+                key,
+                timeout=timeout_seconds,
+                level=0,
+                suppress_timeout_logs=True,
             ):
                 yield
                 return
@@ -392,9 +395,13 @@ class PokerBotModel:
                 timeout_seconds,
                 self._safe_int(chat_id),
             )
+            self._log_lock_snapshot("chat_guard_timeout", level=logging.WARNING)
 
         async with self._lock_manager.guard(
-            key, timeout=math.inf, level=0
+            key,
+            timeout=math.inf,
+            level=0,
+            suppress_timeout_logs=True,
         ):
             yield
 


### PR DESCRIPTION
## Summary
- add a suppress_timeout_logs option to the lock manager so callers can manage timeout reporting themselves
- update the chat guard to use the new flag, capture a lock snapshot, and retry without spamming warnings

## Testing
- pytest tests/test_lock_manager.py
- pytest tests/test_pokerbotmodel.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a8f214888328b76a04f66fe50f86