### PR TITLE
Improve lock diagnostics and reduce chat lock contention

### DIFF
--- a/pokerapp/config.py
+++ b/pokerapp/config.py
@@ -77,7 +77,7 @@ _DEFAULT_GAME_CONSTANTS_DATA: Dict[str, Any] = {
     "locks": {
         "category_timeouts_seconds": {
             "engine_stage": 25.0,
-            "chat": 15.0,
+            "chat": 8.0,
             "player_report": 5.0,
             "wallet": 5.0,
         }


### PR DESCRIPTION
## Summary
- add lock owner diagnostics to timeout and failure logs by leveraging detect_deadlock snapshots
- shorten stage lock lifetimes when refreshing turn messages to keep network calls outside of guarded sections
- reduce the chat lock timeout configuration to 8 seconds to trigger fallbacks sooner

## Testing
- pytest tests/test_lock_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ae9d713883289854e3752281386c