### PR TITLE
Fix flake8 lint error in pokerbot model

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -1078,8 +1078,7 @@ class PokerBotModel:
 
                         await self._view.start_prestart_countdown(
                             chat_id=chat_id,
-                            game_id=
-                            str(game_identifier) if game_identifier is not None else None,
+                            game_id=str(game_identifier) if game_identifier is not None else None,
                             anchor_message_id=anchor_message_id,
                             seconds=countdown_value,
                             payload_fn=_countdown_payload,


### PR DESCRIPTION
## Summary
- update the prestart countdown call so the game_id keyword argument is on a single line
- ensure flake8 E251 no longer triggers for pokerbotmodel.py

## Testing
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68d6b135d9908328b1b3f6f516d2231e