### PR TITLE
Ensure lock snapshot logs include context

### DIFF
--- a/pokerapp/lock_manager.py
+++ b/pokerapp/lock_manager.py
@@ -837,20 +837,20 @@ class LockManager:
         level: int = logging.WARNING,
         extra: Optional[Mapping[str, Any]] = None,
     ) -> None:
+        payload: Dict[str, Any] = {
+            "stage": stage,
+            "event_type": "lock_snapshot",
+        }
+        if extra:
+            payload.update(extra)
+
         try:
             snapshot = self.detect_deadlock()
         except Exception:  # pragma: no cover - defensive logging path
             self._logger.exception(
-                "Failed to capture lock snapshot", extra={"stage": stage, "event_type": "lock_snapshot"}
+                "Failed to capture lock snapshot during %s", stage, extra=payload
             )
             return
-
-        payload: Dict[str, Any] = {"event_type": "lock_snapshot", "stage": stage}
-        if extra:
-            for key, value in extra.items():
-                if key == "event_type":
-                    continue
-                payload[key] = value
 
         effective_level = level if level >= logging.WARNING else logging.WARNING
         self._logger.log(


### PR DESCRIPTION
## Summary
- ensure lock snapshot logging always includes stage and event type context
- guarantee lock snapshot logs are emitted at warning level or higher and handle capture failures gracefully

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6c9f400088328900c7c93c2a97ae3