### PR TITLE
Guard add_cards_to_table with stage lock logging

### DIFF
--- a/pokerapp/matchmaking_service.py
+++ b/pokerapp/matchmaking_service.py
@@ -312,16 +312,13 @@ class MatchmakingService:
         street_name: str,
         send_message: bool,
     ) -> None:
-        async with self._lock_manager.guard(
-            self._stage_lock_key(chat_id), timeout=self._stage_lock_timeout
-        ):
-            await self._add_cards_to_table(
-                count=count,
-                game=game,
-                chat_id=chat_id,
-                street_name=street_name,
-                send_message=send_message,
-            )
+        await self._add_cards_to_table(
+            count=count,
+            game=game,
+            chat_id=chat_id,
+            street_name=street_name,
+            send_message=send_message,
+        )
 
     # ------------------------------------------------------------------
     # Internal helpers


### PR DESCRIPTION
## Summary
- guard the stage lock acquisition in `GameEngine.add_cards_to_table` so lock timeouts are logged via the engine failure helper
- delegate `MatchmakingService.add_cards_to_table` directly to its helper to avoid double-locking after moving the guard to the engine

## Testing
- pytest tests/test_pokerbotmodel.py::test_add_cards_to_table_does_not_send_stage_message tests/test_pokerbotmodel.py::test_add_cards_to_table_removes_existing_stage_message

------
https://chatgpt.com/codex/tasks/task_e_68d6f4ea9c4c8328883be8ac14c58dc9