### PR TITLE
Reduce lock timeout error severity for guard retries

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -388,7 +388,10 @@ class PokerBotModel:
         timeout_seconds = self._chat_guard_timeout_seconds
         try:
             async with self._lock_manager.guard(
-                key, timeout=timeout_seconds, level=0
+                key,
+                timeout=timeout_seconds,
+                level=0,
+                failure_log_level=logging.WARNING,
             ):
                 yield
                 return
@@ -398,6 +401,7 @@ class PokerBotModel:
                 event_stage_label=event_stage_label,
                 chat_id=chat_id,
                 game=game,
+                log_level=logging.WARNING,
             )
             logger.warning(
                 "Chat guard timed out after %.1fs for chat %s; retrying without timeout",


### PR DESCRIPTION
## Summary
- allow the lock manager to customize timeout and failure log levels when acquiring locks
- downgrade chat and stage guard retries to log lock contention at warning instead of error

## Testing
- pytest tests/test_lock_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d7020097dc8328b6f6495a7cc4ac26