### PR TITLE
Enable debug dealer fallback

### DIFF
--- a/pokerapp/matchmaking_service.py
+++ b/pokerapp/matchmaking_service.py
@@ -339,6 +339,7 @@ class MatchmakingService:
             player.cards = cards
 
     def _ensure_dealer_position(self, game: Game) -> bool:
+        self._config.ALLOW_EMPTY_DEALER = True
         if not hasattr(game, "dealer_index"):
             game.dealer_index = -1
 


### PR DESCRIPTION
## Summary
- set `ALLOW_EMPTY_DEALER` to `True` at the start of `_ensure_dealer_position`
- guarantee the debug dealer fallback can run when no occupied dealer seat exists

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d79f87f77883288e385386ba9cf5fd