### PR TITLE
Add admin command for retrieving last save error details

### DIFF
--- a/pokerapp/pokerbotcontrol.py
+++ b/pokerapp/pokerbotcontrol.py
@@ -35,6 +35,7 @@ class PokerBotCotroller:
         application.add_handler(CommandHandler('stop', self._handle_stop))
         application.add_handler(CommandHandler('money', self._handle_money))
         application.add_handler(CommandHandler('ban', self._handle_ban))
+        application.add_handler(CommandHandler('get_save_error', self._handle_get_save_error))
 
         # game management command
         application.add_handler(CommandHandler('newgame', self._handle_create_game))
@@ -156,6 +157,17 @@ class PokerBotCotroller:
         elif normalized == "ریور":
             game, chat_id = await self._model._get_game(update, context)
             await self._model.add_cards_to_table(0, game, chat_id, "🃏 ریور")
+
+    async def _handle_get_save_error(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        chat = update.effective_chat
+        admin_chat_id = getattr(self._view, "_admin_chat_id", None)
+        if admin_chat_id is None or chat is None or chat.id != admin_chat_id:
+            return
+
+        args = list(getattr(context, "args", []) or [])
+        await self._model.handle_admin_command("/get_save_error", args)
 
     async def _handle_ready(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         chat_id = None

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -1,0 +1,132 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pokerapp.pokerbotmodel import PokerBotModel
+
+
+def _make_model(admin_chat_id=123):
+    view = SimpleNamespace(_admin_chat_id=admin_chat_id)
+    view.send_message = AsyncMock()
+    safe_get = AsyncMock()
+    redis_ops = SimpleNamespace(safe_get=safe_get)
+    table_manager = SimpleNamespace(_redis_ops=redis_ops)
+
+    model = object.__new__(PokerBotModel)
+    model._view = view
+    model._table_manager = table_manager
+    model._logger = MagicMock()
+    return model, view.send_message, safe_get
+
+
+@pytest.mark.asyncio
+async def test_handle_admin_command_ignored_without_admin_chat():
+    model, send_message, safe_get = _make_model(admin_chat_id=None)
+
+    await model.handle_admin_command("/get_save_error", [])
+
+    send_message.assert_not_awaited()
+    safe_get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_admin_command_usage_message():
+    model, send_message, safe_get = _make_model()
+
+    await model.handle_admin_command("/get_save_error", [])
+
+    send_message.assert_awaited_once()
+    args, _ = send_message.await_args
+    assert args[0] == 123
+    assert args[1] == "Usage: /get_save_error <chat_id> [detailed]"
+    safe_get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_admin_command_invalid_chat_id():
+    model, send_message, safe_get = _make_model()
+
+    await model.handle_admin_command("/get_save_error", ["abc"])
+
+    send_message.assert_awaited_once()
+    args, _ = send_message.await_args
+    assert args[1] == "Invalid chat_id: abc"
+    safe_get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_admin_command_unknown_command():
+    model, send_message, safe_get = _make_model()
+
+    await model.handle_admin_command("/unknown", ["1"])
+
+    send_message.assert_not_awaited()
+    safe_get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_admin_command_no_payload():
+    model, send_message, safe_get = _make_model()
+    safe_get.return_value = None
+
+    await model.handle_admin_command("/get_save_error", ["101"])
+
+    safe_get.assert_awaited_once_with(
+        "chat:101:last_save_error", log_extra={"chat_id": 101}
+    )
+    args, _ = send_message.await_args
+    assert args[1] == "No save error found for chat 101"
+
+
+@pytest.mark.asyncio
+async def test_handle_admin_command_basic_payload():
+    model, send_message, safe_get = _make_model()
+    safe_get.return_value = json.dumps(
+        {"error": "boom", "timestamp": "2024-01-01T00:00:00Z"}
+    )
+
+    await model.handle_admin_command("/get_save_error", ["77"])
+
+    safe_get.assert_awaited_once_with(
+        "chat:77:last_save_error", log_extra={"chat_id": 77}
+    )
+    args, _ = send_message.await_args
+    assert args[1] == "Error: boom\nTime: 2024-01-01T00:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_handle_admin_command_detailed_payload():
+    model, send_message, safe_get = _make_model()
+    safe_get.return_value = json.dumps(
+        {
+            "chat_id": 77,
+            "timestamp": "2024",
+            "game_state": "WAITING",
+            "exception": "boom",
+            "player_count": 1,
+            "players": [{"user_id": 1, "seat_index": 2, "role": "dealer"}],
+        }
+    )
+
+    await model.handle_admin_command("/get_save_error", ["77", "detailed"])
+
+    safe_get.assert_awaited_once_with(
+        "chat:77:last_save_error_detailed", log_extra={"chat_id": 77}
+    )
+    args, _ = send_message.await_args
+    assert "Players (1):" in args[1]
+    assert " - 1 seat 2 role dealer" in args[1]
+
+
+@pytest.mark.asyncio
+async def test_handle_admin_command_fallback_raw_payload():
+    model, send_message, safe_get = _make_model()
+    safe_get.return_value = b"not-json"
+
+    await model.handle_admin_command("/get_save_error", ["55"])
+
+    args, _ = send_message.await_args
+    assert "Raw: not-json" in args[1]
+


### PR DESCRIPTION
## Summary
- add an admin-only `/get_save_error` command and route it through the controller
- fetch last save error payloads from Redis with basic and detailed formatting for admins
- cover the new command handling logic with targeted async unit tests

## Testing
- pytest tests/test_admin_commands.py

------
https://chatgpt.com/codex/tasks/task_e_68d7c162c7d883289d157871ccc6f774