### PR TITLE
Refactor admin save error handling to messaging service

### DIFF
--- a/pokerapp/pokerbotcontrol.py
+++ b/pokerapp/pokerbotcontrol.py
@@ -167,7 +167,7 @@ class PokerBotCotroller:
             return
 
         args = list(getattr(context, "args", []) or [])
-        await self._model.handle_admin_command("/get_save_error", args)
+        await self._model.handle_admin_command("/get_save_error", args, admin_chat_id)
 
     async def _handle_ready(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         chat_id = None

--- a/tests/test_messaging_service_admin.py
+++ b/tests/test_messaging_service_admin.py
@@ -73,7 +73,7 @@ async def test_send_last_save_error_missing_payload():
         chat_id=12,
         text="No save error found for chat 55",
         request_category=RequestCategory.GENERAL,
-        context={"chat_id": 55, "detailed": False},
+        context={"admin_chat_id": 12, "chat_id": 55, "detailed": False},
     )
     safe_get.assert_awaited_once_with(
         "chat:55:last_save_error",


### PR DESCRIPTION
## Summary
- update PokerBotModel to resolve the admin chat id upstream and delegate `/get_save_error` handling to the messaging service
- enhance MessagingService save-error reporting to emit friendlier messages and preserve raw payload data when needed
- refresh the admin command and messaging service unit tests for the new control flow and contexts

## Testing
- pytest tests/test_admin_commands.py tests/test_messaging_service_admin.py

------
https://chatgpt.com/codex/tasks/task_e_68d7c6c0cca88328b84a2580466c5d70