### PR TITLE
Add lock tracing to chat and turn message guards

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -919,6 +919,7 @@ class GameEngine:
         stage_label: str,
         timeout_seconds: Optional[float],
         context: Optional[Mapping[str, Any]] = None,
+        **guard_kwargs: Any,
     ) -> AsyncIterator[None]:
         loop = asyncio.get_running_loop()
         start_time = loop.time()
@@ -954,6 +955,7 @@ class GameEngine:
                 lock_key,
                 timeout=timeout_seconds,
                 context=context,
+                **guard_kwargs,
             ):
                 entered = True
                 yield


### PR DESCRIPTION
## Summary
- allow `_trace_lock_guard` to forward additional lock manager arguments so non-stage locks can participate in tracing
- switch the chat guard and turn message stage updates in `PokerBotModel` to reuse `_trace_lock_guard` for consistent lock diagnostics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d80daa932483288061f7d5163a58eb