### PR TITLE
Align stage lock guard call structure

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -966,15 +966,17 @@ class GameEngine:
         lock_key = self._stage_lock_key(chat_id)
         stage_label = "stage_lock:start_game"
         event_stage_label = "start_game"
+        retry_stage_label: Optional[str] = None
         try:
             async with self._trace_lock_guard(
                 lock_key=lock_key,
                 chat_id=chat_id,
                 game=game,
                 stage_label=stage_label,
-                timeout=self._stage_lock_timeout,
                 event_stage_label=event_stage_label,
+                timeout=self._stage_lock_timeout,
                 retry_without_timeout=False,
+                retry_stage_label=retry_stage_label,
             ):
                 await self._matchmaking_service.start_game(
                     context=context,
@@ -1030,15 +1032,17 @@ class GameEngine:
         lock_key = self._stage_lock_key(chat_id)
         stage_label = "stage_lock:add_cards_to_table"
         event_stage_label = "add_cards_to_table"
+        retry_stage_label: Optional[str] = None
         try:
             async with self._trace_lock_guard(
                 lock_key=lock_key,
                 chat_id=chat_id,
                 game=game,
                 stage_label=stage_label,
-                timeout=self._stage_lock_timeout,
                 event_stage_label=event_stage_label,
+                timeout=self._stage_lock_timeout,
                 retry_without_timeout=False,
+                retry_stage_label=retry_stage_label,
             ):
                 await self._matchmaking_service.add_cards_to_table(
                     count=count,
@@ -1071,22 +1075,25 @@ class GameEngine:
             )
 
         lock_key = self._stage_lock_key(chat_id)
+        stage_label = "stage_lock:progress_stage"
+        event_stage_label = "stage_progress"
+        retry_stage_label = "chat_guard_timeout:progress_stage"
         try:
             async with self._trace_lock_guard(
                 lock_key=lock_key,
                 chat_id=chat_id,
                 game=game,
-                stage_label="stage_lock:progress_stage",
+                stage_label=stage_label,
+                event_stage_label=event_stage_label,
                 timeout=self._stage_lock_timeout,
-                event_stage_label="stage_progress",
                 retry_without_timeout=True,
-                retry_stage_label="chat_guard_timeout:progress_stage",
+                retry_stage_label=retry_stage_label,
             ):
                 return await _run_locked()
         except TimeoutError:
             self._log_engine_event_lock_failure(
                 lock_key=lock_key,
-                event_stage_label="stage_progress",
+                event_stage_label=event_stage_label,
                 chat_id=chat_id,
                 game=game,
             )
@@ -1157,16 +1164,17 @@ class GameEngine:
         lock_key = self._stage_lock_key(chat_id)
         stage_label = "stage_lock:finalize_game"
         event_stage_label = "finalize_game"
+        retry_stage_label = "chat_guard_timeout:finalize_game"
         try:
             async with self._trace_lock_guard(
                 lock_key=lock_key,
                 chat_id=chat_id,
                 game=game,
                 stage_label=stage_label,
-                timeout=self._stage_lock_timeout,
                 event_stage_label=event_stage_label,
+                timeout=self._stage_lock_timeout,
                 retry_without_timeout=True,
-                retry_stage_label="chat_guard_timeout:finalize_game",
+                retry_stage_label=retry_stage_label,
             ):
                 (
                     message_cleanup_ids,
@@ -1880,15 +1888,17 @@ class GameEngine:
         lock_key = self._stage_lock_key(chat_id)
         stage_label = "stage_lock:confirm_stop_vote"
         event_stage_label = "confirm_stop_vote"
+        retry_stage_label: Optional[str] = None
         try:
             async with self._trace_lock_guard(
                 lock_key=lock_key,
                 chat_id=chat_id,
                 game=game,
                 stage_label=stage_label,
-                timeout=self._stage_lock_timeout,
                 event_stage_label=event_stage_label,
+                timeout=self._stage_lock_timeout,
                 retry_without_timeout=False,
+                retry_stage_label=retry_stage_label,
             ):
                 stop_request = self._validate_stop_request(context=context, game=game)
 
@@ -1936,15 +1946,17 @@ class GameEngine:
         lock_key = self._stage_lock_key(chat_id)
         stage_label = "stage_lock:resume_stop_vote"
         event_stage_label = "resume_stop_vote"
+        retry_stage_label: Optional[str] = None
         try:
             async with self._trace_lock_guard(
                 lock_key=lock_key,
                 chat_id=chat_id,
                 game=game,
                 stage_label=stage_label,
-                timeout=self._stage_lock_timeout,
                 event_stage_label=event_stage_label,
+                timeout=self._stage_lock_timeout,
                 retry_without_timeout=False,
+                retry_stage_label=retry_stage_label,
             ):
                 stop_request = context.chat_data.get(self.KEY_STOP_REQUEST)
                 if not stop_request or stop_request.get("game_id") != game.id:
@@ -1989,15 +2001,17 @@ class GameEngine:
         lock_key = self._stage_lock_key(chat_id)
         stage_label = "stage_lock:cancel_hand"
         event_stage_label = "cancel_hand"
+        retry_stage_label: Optional[str] = None
         try:
             async with self._trace_lock_guard(
                 lock_key=lock_key,
                 chat_id=chat_id,
                 game=game,
                 stage_label=stage_label,
-                timeout=self._stage_lock_timeout,
                 event_stage_label=event_stage_label,
+                timeout=self._stage_lock_timeout,
                 retry_without_timeout=False,
+                retry_stage_label=retry_stage_label,
             ):
                 original_game_id = game.id
                 players_snapshot = list(game.seated_players())
@@ -2158,15 +2172,17 @@ class GameEngine:
         lock_key = self._stage_lock_key(chat_id)
         stage_label = "stage_lock:finalize_stop_request"
         event_stage_label = "finalize_stop_request"
+        retry_stage_label: Optional[str] = None
         try:
             async with self._trace_lock_guard(
                 lock_key=lock_key,
                 chat_id=chat_id,
                 game=game,
                 stage_label=stage_label,
-                timeout=self._stage_lock_timeout,
                 event_stage_label=event_stage_label,
+                timeout=self._stage_lock_timeout,
                 retry_without_timeout=False,
+                retry_stage_label=retry_stage_label,
             ):
                 message_text = self._build_stop_cancellation_message(stop_request)
 
@@ -2207,15 +2223,17 @@ class GameEngine:
         lock_key = self._stage_lock_key(chat_id)
         stage_label = "stage_lock:reset_game_state_after_stop"
         event_stage_label = "reset_game_state_after_stop"
+        retry_stage_label: Optional[str] = None
         try:
             async with self._trace_lock_guard(
                 lock_key=lock_key,
                 chat_id=chat_id,
                 game=game,
                 stage_label=stage_label,
-                timeout=self._stage_lock_timeout,
                 event_stage_label=event_stage_label,
+                timeout=self._stage_lock_timeout,
                 retry_without_timeout=False,
+                retry_stage_label=retry_stage_label,
             ):
                 await self._player_manager.cleanup_ready_prompt(
                     game, chat_id, persist=False


### PR DESCRIPTION
## Summary
- normalize stage lock usages in game_engine to follow the trace guard template
- add explicit retry stage label variables so every call passes timeout and retry metadata consistently

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d82731a1a48328a062569e3ae0a27f