### PR TITLE
Add trace_guard helper for stage lock tracing

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -750,7 +750,7 @@ class GameEngine:
             self._lock_manager._resolve_lock_category(lock_key) or "unknown"
         )
         event_stage = event_stage_label or stage_label
-        guard_context_manager = self._lock_manager.guard
+        guard_context_manager = self._lock_manager.trace_guard
 
         def _resolve_chat_and_game_ids() -> Tuple[Optional[int], Optional[int]]:
             resolved_chat: Optional[int] = None

--- a/pokerapp/lock_manager.py
+++ b/pokerapp/lock_manager.py
@@ -630,6 +630,29 @@ class LockManager:
         finally:
             self.release(key, context=combined_context)
 
+    def trace_guard(
+        self,
+        key: str,
+        *,
+        timeout: Optional[float] = None,
+        context: Optional[Mapping[str, Any]] = None,
+        context_extra: Optional[Mapping[str, Any]] = None,
+        level: Optional[int] = None,
+        timeout_log_level: Optional[int] = logging.WARNING,
+        failure_log_level: Optional[int] = logging.ERROR,
+    ) -> AsyncIterator[None]:
+        """Alias for :meth:`guard` used by traced lock helpers."""
+
+        return self.guard(
+            key,
+            timeout=timeout,
+            context=context,
+            context_extra=context_extra,
+            level=level,
+            timeout_log_level=timeout_log_level,
+            failure_log_level=failure_log_level,
+        )
+
     def release(
         self, key: str, context: Optional[Mapping[str, Any]] = None
     ) -> None:


### PR DESCRIPTION
## Summary
- update the game engine to obtain critical-section locks via `LockManager.trace_guard`
- introduce a `LockManager.trace_guard` helper that delegates to the existing `guard` context manager

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d82c5a252483289eaee6d3a150addf