### PR TITLE
Normalize post-round reset with traced stage lock guard

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -185,6 +185,30 @@ class Game:
         self.seat_announcement_message_id: Optional[MessageId] = None
 
     # --- Seats / players helpers ----------------------------------------
+    def reset_bets(self) -> None:
+        """Clear betting state for all seated players and reset pot tracking."""
+
+        self.pot = 0
+        self.max_round_rate = 0
+        self.current_player_index = -1
+        self.small_blind_index = -1
+        self.big_blind_index = -1
+        for player in self.players:
+            player.total_bet = 0
+            player.round_rate = 0
+            player.has_acted = False
+            player.state = PlayerState.ACTIVE
+
+    def rotate_dealer(self) -> int:
+        """Advance the dealer button and refresh dealer flags."""
+
+        new_dealer_index = self.advance_dealer()
+        for idx, seat_player in enumerate(self.seats):
+            if seat_player is None:
+                continue
+            seat_player.is_dealer = idx == new_dealer_index
+        return new_dealer_index
+
     @property
     def players(self) -> List[Player]:
         """Return a compact list of players currently seated (order is seat ascending)."""

--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -1378,6 +1378,9 @@ class GameEngine:
 
         async def _run_locked() -> None:
             clear_all_message_ids(game)
+            game.reset_bets()
+            game.rotate_dealer()
+            await self._player_manager.reseat_players(game)
             self._logger.info(
                 "Game state reset after round",
                 extra=self._log_extra(


### PR DESCRIPTION
## Summary
- add Game helpers to reset betting state and refresh the dealer button between rounds
- implement PlayerManager.reseat_players to normalize seat assignments and persist them
- update GameEngine._reset_game_state_after_round to use the traced stage lock guard while reusing the retry label

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d832b748e083289da9f0c80dea60f6