### PR TITLE
Adjust start game stage lock retry handling

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -974,7 +974,8 @@ class GameEngine:
                 stage_label=stage_label,
                 event_stage_label=event_stage_label,
                 timeout=self._stage_lock_timeout,
-                retry_without_timeout=False,
+                retry_without_timeout=True,
+                retry_stage_label="chat_guard_timeout:start_game",
             ):
                 await self._matchmaking_service.start_game(
                     context=context,


### PR DESCRIPTION
## Summary
- ensure start_game uses the tracing stage lock helper with retry semantics to avoid premature timeouts during game startup

## Testing
- pytest tests/test_game_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d8360e89d8832884dad2a97970a164