### PR TITLE
Improve stage lock reset trace guard instrumentation

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -1397,6 +1397,7 @@ class GameEngine:
         event_stage_label = "reset_game_state_after_round"
 
         try:
+            # Migrated to _trace_lock_guard for audited stage lock acquisition with retries
             async with self._trace_lock_guard(
                 lock_key=lock_key,
                 chat_id=chat_id,


### PR DESCRIPTION
## Summary
- document the migration of the stage lock reset path to the unified `_trace_lock_guard`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d954e63e8883288168c4f871775be7