### PR TITLE
Refine finalize_game stage lock guard

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -1104,7 +1104,7 @@ class GameEngine:
         game: Game,
         chat_id: ChatId,
     ) -> None:
-        async def _run_locked() -> Tuple[
+        async def _finalize_locked() -> Tuple[
             Set[MessageId],
             List[Dict[str, Any]],
             Optional[Dict[str, Any]],
@@ -1179,7 +1179,7 @@ class GameEngine:
                     announcements,
                     record_kwargs,
                     reset_notifications,
-                ) = await _run_locked()
+                ) = await _finalize_locked()
         except TimeoutError:
             self._log_engine_event_lock_failure(
                 lock_key=lock_key,


### PR DESCRIPTION
## Summary
- rename the finalize_game stage lock helper to `_finalize_locked`
- ensure the trace lock guard invokes the updated helper when finalizing a game

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d958cf58888328a9946f420a78de0c