### PR TITLE
Allow non-owner release of reentrant lock

### DIFF
--- a/pokerapp/utils/locks.py
+++ b/pokerapp/utils/locks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
+import logging
 from typing import Any, AsyncIterator, Optional
 
 
@@ -27,11 +28,28 @@ class ReentrantAsyncLock:
         self._depth = 1
 
     def release(self) -> None:
+        """Release the lock.
+
+        This implementation relaxes the strict task ownership check so that the
+        lock can be released even when the current task is not the owner. In
+        such a case a warning is logged and the underlying lock is forcibly
+        released when the reentrancy depth reaches zero. This prevents crashes
+        when a scheduled job releases the lock from a different task.
+        """
         current = asyncio.current_task()
         if current is None:
             raise RuntimeError("ReentrantAsyncLock release requires an active task")
         if self._owner is not current:
-            raise RuntimeError("Lock can only be released by the owning task")
+            logging.getLogger(__name__).warning(
+                "Non-owner task attempted to release re-entrant lock; releasing anyway"
+            )
+            if self._depth > 0:
+                self._depth -= 1
+            if self._depth <= 0:
+                self._owner = None
+                if self._lock.locked():
+                    self._lock.release()
+            return
         self._depth -= 1
         if self._depth == 0:
             self._owner = None


### PR DESCRIPTION
## Summary
- allow the re-entrant async lock to tolerate release attempts from non-owner tasks
- log a warning for diagnostic purposes and ensure the underlying lock is released when depth hits zero

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d95de8f6108328a37018fa293a9556