### PR TITLE
Add regression test guarding stage lock usage in game engine

### DIFF
--- a/tests/test_lock_guard_usage.py
+++ b/tests/test_lock_guard_usage.py
@@ -1,0 +1,9 @@
+import pathlib
+
+
+def test_game_engine_uses_trace_lock_guard_only() -> None:
+    game_engine_path = pathlib.Path(__file__).resolve().parents[1] / "pokerapp" / "game_engine.py"
+    content = game_engine_path.read_text(encoding="utf-8")
+    assert "_lock_manager.acquire(" not in content, (
+        "game_engine.py should use _trace_lock_guard instead of calling _lock_manager.acquire directly"
+    )


### PR DESCRIPTION
## Summary
- add a regression test that scans game_engine.py for legacy _lock_manager.acquire usage to ensure _trace_lock_guard remains standard

## Testing
- pytest tests/test_lock_guard_usage.py

------
https://chatgpt.com/codex/tasks/task_e_68d9612d14f883288bd64a02a710fee6