### PR TITLE
Log lock caller functions for acquire/release

### DIFF
--- a/tests/test_lock_manager.py
+++ b/tests/test_lock_manager.py
@@ -124,6 +124,17 @@ async def test_lock_manager_context_logging() -> None:
         for message in messages
     )
 
+    assert any(
+        record.__dict__.get("event_type") == "lock_acquired"
+        and record.__dict__.get("call_site_function") not in {None, "unknown"}
+        for record in handler.records
+    )
+    assert any(
+        record.__dict__.get("event_type") == "lock_released"
+        and record.__dict__.get("release_function") not in {None, "unknown"}
+        for record in handler.records
+    )
+
     logger.removeHandler(handler)
 
 


### PR DESCRIPTION
## Summary
- enrich lock acquisition logs with the originating call-site function alongside existing metadata
- capture release call-site details for diagnostics, including long-hold and error paths
- update lock manager tests to assert the new function-level logging fields

## Testing
- pytest tests/test_lock_manager.py *(fails: ModuleNotFoundError: No module named 'telegram')*

------
https://chatgpt.com/codex/tasks/task_e_68d974a003dc8328a0e0ec9c967bc6df