### PR TITLE
Allow ascending lock acquisitions

### DIFF
--- a/pokerapp/lock_manager.py
+++ b/pokerapp/lock_manager.py
@@ -990,10 +990,10 @@ class LockManager:
         violation_type: Optional[str] = None
         if level < highest_level:
             violation_type = "descending"
-        elif level > lowest_level:
-            violation_type = "ascending"
-        else:
+        elif level >= highest_level:
             return
+        else:
+            violation_type = "ascending"
         held_contexts = [f"{item.key}(level={item.level})" for item in acquisitions]
         lock_identity = self._format_lock_identity(key, level, context)
         message = (


### PR DESCRIPTION
## Summary
- allow the lock manager to permit acquiring higher-level locks while guarding against descending lock order violations
- update the lock manager tests to cover the relaxed ordering rules

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d98a3b92d48328971ecf3486dd1e15