### PR TITLE
Ensure delete_message diagnostics include game context

### DIFF
--- a/pokerapp/pokerbotview.py
+++ b/pokerapp/pokerbotview.py
@@ -2391,6 +2391,7 @@ class PokerBotViewer:
                                             message_id=normalized_existing_message,
                                             allow_anchor_deletion=True,
                                             anchor_reason="anchor_refresh",
+                                            game=game,
                                         )
                                     except Exception:
                                         logger.warning(
@@ -2406,6 +2407,7 @@ class PokerBotViewer:
                                     await self.delete_message(
                                         chat_id=chat_id,
                                         message_id=normalized_existing_message,
+                                        game=game,
                                     )
                                 except Exception:
                                     logger.warning(


### PR DESCRIPTION
## Summary
- pass the game context to delete_message when removing replaced role anchors so Telegram API diagnostics record the correct lock information

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dabe9f29d08328af7f498e9aebd356