### PR TITLE
Add tracing to edit message reply markup requests

### DIFF
--- a/pokerapp/aiogram_flow.py
+++ b/pokerapp/aiogram_flow.py
@@ -490,6 +490,13 @@ class RequestManager:
                         )
                         return True
 
+                trace_telegram_api_call(
+                    "editMessageReplyMarkup",
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    reply_markup=reply_markup,
+                )
+
                 try:
                     await self._bot.edit_message_reply_markup(
                         chat_id=chat_id,


### PR DESCRIPTION
## Summary
- add the missing trace_telegram_api_call invocation to edit_message_reply_markup for consistency with other request helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd69220c0c83288dd80eff62196aef