### PR TITLE
Fix cache equality check race condition

### DIFF
--- a/pokerapp/utils/telegram_safeops.py
+++ b/pokerapp/utils/telegram_safeops.py
@@ -81,17 +81,17 @@ class TelegramSafeOps:
         if cache_key is not None:
             async with self._cache_lock:
                 cached_text = self._last_edit_cache.get(cache_key)
-            if cached_text == text:
-                self._logger.debug(
-                    "Skipping edit_message_text because content unchanged",
-                    extra=self._build_extra(
-                        chat_id=chat_id,
-                        message_id=message_id,
-                        operation="edit_message_text",
-                        extra=log_extra,
-                    ),
-                )
-                return message_id
+                if cached_text == text:
+                    self._logger.debug(
+                        "Skipping edit_message_text because content unchanged",
+                        extra=self._build_extra(
+                            chat_id=chat_id,
+                            message_id=message_id,
+                            operation="edit_message_text",
+                            extra=log_extra,
+                        ),
+                    )
+                    return message_id
 
         try:
             result = await self._execute(


### PR DESCRIPTION
## Summary
- keep the cached text equality check inside the cache lock to avoid TOCTOU races

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de6f0448ec83289a1f383569b8e005