### PR TITLE
Document countdown concurrency guarantees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## [Unreleased]
+### Fixed
+- Countdown timer stability (eliminated time jumps, freezing, resumption)
+- Telegram API rate limiting (1 req/sec throttling per message)
+- Race conditions in concurrent countdown start/cancel
+- Deadlock risk in task cancellation flow


### PR DESCRIPTION
## Summary
- document the countdown lock hierarchy and monotonic timing safeguards in the view
- describe the countdown concurrency guarantees and lock ordering in the architecture docs
- add a changelog entry capturing the countdown stability fixes

## Testing
- not run (verification only)


------
https://chatgpt.com/codex/tasks/task_e_68de77b812b4832899873452bfcdb241