### PR TITLE
Implement countdown worker and supporting tests

### DIFF
--- a/pokerapp/services/countdown_worker.py
+++ b/pokerapp/services/countdown_worker.py
@@ -1,0 +1,196 @@
+"""Countdown worker responsible for processing countdown messages."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Optional
+
+from telegram.error import TelegramError
+
+from pokerapp.services.countdown_queue import CountdownMessage, CountdownMessageQueue
+from pokerapp.utils.telegram_safeops import TelegramSafeOps
+
+
+class CountdownWorker:
+    """Background worker that updates countdown messages in Telegram."""
+
+    def __init__(
+        self,
+        queue: CountdownMessageQueue,
+        safe_ops: TelegramSafeOps,
+        edit_interval: float = 1.0,
+    ) -> None:
+        self._queue = queue
+        self._safe_ops = safe_ops
+        self._edit_interval = max(edit_interval, 0.0)
+        self._worker_task: Optional[asyncio.Task[None]] = None
+        self._shutdown_event = asyncio.Event()
+        self._logger = logging.getLogger(__name__)
+
+    async def start(self) -> None:
+        """Start the countdown processing worker."""
+
+        if self._worker_task and not self._worker_task.done():
+            return
+
+        if self._shutdown_event.is_set():
+            self._shutdown_event = asyncio.Event()
+
+        loop = asyncio.get_running_loop()
+        self._worker_task = loop.create_task(self._worker_loop(), name="countdown-worker")
+        self._logger.info("Countdown worker started")
+
+    async def stop(self) -> None:
+        """Stop the countdown worker gracefully."""
+
+        self._shutdown_event.set()
+
+        if self._worker_task is None:
+            return
+
+        task = self._worker_task
+        if not task.done():
+            task.cancel()
+            try:
+                await asyncio.wait_for(task, timeout=5.0)
+            except asyncio.TimeoutError:
+                self._logger.warning("Countdown worker stop timed out")
+            except asyncio.CancelledError:
+                pass
+            except Exception:  # pragma: no cover - defensive
+                self._logger.exception("Error while stopping countdown worker")
+        self._worker_task = None
+        self._logger.info("Countdown worker stopped")
+
+    async def _worker_loop(self) -> None:
+        """Continuously consume messages from the queue until shutdown."""
+
+        try:
+            while not self._shutdown_event.is_set():
+                try:
+                    msg = await asyncio.wait_for(self._queue.dequeue(), timeout=0.1)
+                except asyncio.TimeoutError:
+                    continue
+                if msg is None:
+                    continue
+                try:
+                    await self._process_countdown(msg)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    self._logger.exception(
+                        "Unexpected error processing countdown",
+                        extra={
+                            "chat_id": getattr(msg, "chat_id", None),
+                            "message_id": getattr(msg, "message_id", None),
+                        },
+                    )
+        except asyncio.CancelledError:
+            self._logger.debug("Countdown worker loop cancelled")
+            raise
+
+    async def _process_countdown(self, msg: CountdownMessage) -> None:
+        """Process a single countdown message."""
+
+        if msg.cancelled:
+            self._logger.debug(
+                "Countdown message cancelled before processing",
+                extra={"chat_id": msg.chat_id, "message_id": msg.message_id},
+            )
+            return
+
+        remaining = float(getattr(msg, "duration_seconds", 0.0))
+        if remaining <= 0:
+            await self._invoke_completion(msg)
+            self._logger.debug(
+                "Countdown completed instantly",
+                extra={"chat_id": msg.chat_id, "message_id": msg.message_id},
+            )
+            return
+
+        loop = asyncio.get_running_loop()
+        end_time = loop.time() + remaining
+        last_edit = 0.0
+
+        self._logger.debug(
+            "Starting countdown",
+            extra={"chat_id": msg.chat_id, "message_id": msg.message_id, "remaining": remaining},
+        )
+
+        while not msg.cancelled and not self._shutdown_event.is_set():
+            now = loop.time()
+            remaining = max(0.0, end_time - now)
+            if remaining <= 0:
+                break
+
+            if now - last_edit >= self._edit_interval:
+                try:
+                    await self._safe_ops.edit_message_text(
+                        chat_id=msg.chat_id,
+                        message_id=msg.message_id,
+                        text=self._format_message_text(msg, remaining),
+                        from_countdown=True,
+                    )
+                except TelegramError:
+                    self._logger.exception(
+                        "TelegramError while editing countdown message",
+                        extra={"chat_id": msg.chat_id, "message_id": msg.message_id},
+                    )
+                    return
+                last_edit = now
+            sleep_for = min(0.1, remaining)
+            try:
+                await asyncio.sleep(sleep_for)
+            except asyncio.CancelledError:
+                raise
+
+        if msg.cancelled:
+            self._logger.debug(
+                "Countdown cancelled",
+                extra={"chat_id": msg.chat_id, "message_id": msg.message_id},
+            )
+            return
+
+        if self._shutdown_event.is_set():
+            self._logger.debug(
+                "Countdown interrupted by shutdown",
+                extra={"chat_id": msg.chat_id, "message_id": msg.message_id},
+            )
+            return
+
+        await self._invoke_completion(msg)
+        self._logger.debug(
+            "Countdown completed",
+            extra={"chat_id": msg.chat_id, "message_id": msg.message_id},
+        )
+
+    async def _invoke_completion(self, msg: CountdownMessage) -> None:
+        """Invoke the ``on_complete`` callback if present."""
+
+        callback = getattr(msg, "on_complete", None)
+        if not callable(callback):
+            return
+        try:
+            result: Any = callback()
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception:  # pragma: no cover - defensive
+            self._logger.exception(
+                "Error running countdown completion callback",
+                extra={"chat_id": msg.chat_id, "message_id": msg.message_id},
+            )
+
+    def _format_message_text(self, msg: CountdownMessage, remaining: float) -> str:
+        formatter = getattr(msg, "format_text", None)
+        if callable(formatter):
+            try:
+                return formatter(remaining)
+            except Exception:  # pragma: no cover - defensive
+                self._logger.exception(
+                    "Error formatting countdown text",
+                    extra={"chat_id": msg.chat_id, "message_id": msg.message_id},
+                )
+        return getattr(msg, "text", str(int(remaining)))
+
+__all__ = ["CountdownWorker"]

--- a/tests/test_countdown_worker.py
+++ b/tests/test_countdown_worker.py
@@ -1,0 +1,248 @@
+"""Tests for the countdown worker implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+from typing import List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from telegram.error import TelegramError
+
+from pokerapp.services.countdown_queue import CountdownMessageQueue
+from pokerapp.services.countdown_worker import CountdownWorker
+
+
+@pytest.mark.asyncio
+async def test_worker_lifecycle() -> None:
+    queue = CountdownMessageQueue()
+    safe_ops = MagicMock()
+    safe_ops.edit_message_text = AsyncMock()
+    worker = CountdownWorker(queue, safe_ops, edit_interval=0.05)
+
+    await worker.start()
+    assert worker._worker_task is not None  # type: ignore[attr-defined]
+    assert not worker._shutdown_event.is_set()  # type: ignore[attr-defined]
+
+    await worker.stop()
+    assert worker._worker_task is None  # type: ignore[attr-defined]
+    assert worker._shutdown_event.is_set()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_process_single_countdown() -> None:
+    queue = CountdownMessageQueue()
+    safe_ops = MagicMock()
+    safe_ops.edit_message_text = AsyncMock()
+
+    worker = CountdownWorker(queue, safe_ops, edit_interval=0.15)
+    await worker.start()
+
+    await queue.enqueue(
+        chat_id=1,
+        message_id=100,
+        text="⏳",
+        duration_seconds=0.9,
+        formatter=lambda remaining: f"⏳ {math.ceil(remaining)}",
+    )
+
+    await asyncio.sleep(1.2)
+    await worker.stop()
+
+    calls = safe_ops.edit_message_text.await_args_list
+    assert len(calls) >= 3
+    last_text = calls[-1].kwargs["text"]
+    assert "0" in last_text or "⏳" in last_text
+
+
+@pytest.mark.asyncio
+async def test_cancellation_honored() -> None:
+    queue = CountdownMessageQueue()
+    safe_ops = MagicMock()
+    safe_ops.edit_message_text = AsyncMock()
+
+    on_complete = AsyncMock()
+    worker = CountdownWorker(queue, safe_ops, edit_interval=0.1)
+    await worker.start()
+
+    msg = await queue.enqueue(
+        chat_id=2,
+        message_id=200,
+        text="Countdown",
+        duration_seconds=1.5,
+        formatter=lambda remaining: f"{int(remaining)}",
+        on_complete=on_complete,
+    )
+
+    async def cancel_after_delay() -> None:
+        await asyncio.sleep(0.4)
+        msg.cancelled = True
+
+    asyncio.create_task(cancel_after_delay())
+    await asyncio.sleep(0.9)
+    await worker.stop()
+
+    assert msg.cancelled is True
+    on_complete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rate_limiting() -> None:
+    queue = CountdownMessageQueue()
+    safe_ops = MagicMock()
+    timestamps: List[float] = []
+
+    async def record_time(**kwargs: object) -> None:
+        timestamps.append(asyncio.get_running_loop().time())
+
+    safe_ops.edit_message_text = AsyncMock(side_effect=record_time)
+    worker = CountdownWorker(queue, safe_ops, edit_interval=0.3)
+    await worker.start()
+
+    await queue.enqueue(
+        chat_id=3,
+        message_id=300,
+        text="RL",
+        duration_seconds=1.2,
+        formatter=lambda remaining: str(int(math.ceil(remaining))),
+    )
+
+    await asyncio.sleep(1.6)
+    await worker.stop()
+
+    assert len(timestamps) >= 3
+    deltas = [b - a for a, b in zip(timestamps, timestamps[1:])]
+    assert all(delta >= 0.29 for delta in deltas)
+
+
+@pytest.mark.asyncio
+async def test_multiple_countdowns_sequential() -> None:
+    queue = CountdownMessageQueue()
+    safe_ops = MagicMock()
+    safe_ops.edit_message_text = AsyncMock()
+
+    completions: List[int] = []
+
+    def make_callback(identifier: int):
+        async def _callback() -> None:
+            completions.append(identifier)
+        return _callback
+
+    worker = CountdownWorker(queue, safe_ops, edit_interval=0.1)
+    await worker.start()
+
+    for idx in range(3):
+        await queue.enqueue(
+            chat_id=idx,
+            message_id=idx,
+            text="Seq",
+            duration_seconds=0.4,
+            formatter=lambda remaining, idx=idx: f"{idx}:{int(math.ceil(remaining))}",
+            on_complete=make_callback(idx),
+        )
+
+    await asyncio.sleep(2)
+    await worker.stop()
+
+    assert completions == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_on_complete_callback() -> None:
+    queue = CountdownMessageQueue()
+    safe_ops = MagicMock()
+    safe_ops.edit_message_text = AsyncMock()
+
+    on_complete = AsyncMock()
+    worker = CountdownWorker(queue, safe_ops, edit_interval=0.1)
+    await worker.start()
+
+    await queue.enqueue(
+        chat_id=10,
+        message_id=10,
+        text="Done",
+        duration_seconds=0.3,
+        formatter=lambda remaining: f"{int(math.ceil(remaining))}",
+        on_complete=on_complete,
+    )
+
+    await asyncio.sleep(0.6)
+    await worker.stop()
+
+    on_complete.assert_awaited()
+
+    safe_ops.edit_message_text.reset_mock()
+    on_complete.reset_mock()
+    await worker.start()
+
+    msg = await queue.enqueue(
+        chat_id=11,
+        message_id=11,
+        text="Cancel",
+        duration_seconds=1.0,
+        formatter=lambda remaining: f"{int(math.ceil(remaining))}",
+        on_complete=on_complete,
+    )
+
+    await asyncio.sleep(0.3)
+    msg.cancelled = True
+    await asyncio.sleep(0.5)
+    await worker.stop()
+
+    assert msg.cancelled is True
+    on_complete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_telegram_error_handling() -> None:
+    queue = CountdownMessageQueue()
+    safe_ops = MagicMock()
+    safe_ops.edit_message_text = AsyncMock(side_effect=TelegramError("failure"))
+
+    worker = CountdownWorker(queue, safe_ops, edit_interval=0.1)
+    await worker.start()
+
+    await queue.enqueue(
+        chat_id=12,
+        message_id=12,
+        text="Error",
+        duration_seconds=0.4,
+        formatter=lambda remaining: f"{int(math.ceil(remaining))}",
+    )
+
+    await asyncio.sleep(0.5)
+    await worker.stop()
+
+    assert safe_ops.edit_message_text.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_shutdown_during_countdown() -> None:
+    queue = CountdownMessageQueue()
+    safe_ops = MagicMock()
+    timestamps: List[float] = []
+
+    async def record_time(**kwargs: object) -> None:
+        timestamps.append(asyncio.get_running_loop().time())
+
+    safe_ops.edit_message_text = AsyncMock(side_effect=record_time)
+    worker = CountdownWorker(queue, safe_ops, edit_interval=0.2)
+    await worker.start()
+
+    on_complete = AsyncMock()
+    msg = await queue.enqueue(
+        chat_id=13,
+        message_id=13,
+        text="Shutdown",
+        duration_seconds=2.0,
+        formatter=lambda remaining: f"{int(math.ceil(remaining))}",
+        on_complete=on_complete,
+    )
+
+    await asyncio.sleep(0.4)
+    await worker.stop()
+
+    assert len(timestamps) >= 1
+    on_complete.assert_not_called()
+    assert msg.cancelled is False


### PR DESCRIPTION
## Summary
- add a countdown worker that processes queued countdown messages with rate limiting, cancellation handling, and Telegram error resilience
- extend the countdown queue message data to carry duration, formatting, and completion callbacks for countdown updates
- cover the new worker with unit tests exercising lifecycle, cancellation, rate limiting, and shutdown scenarios

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68de9897c98c8328a0a2d8aa03994e85