### PR TITLE
Integrate countdown queue into game engine

### DIFF
--- a/pokerapp/services/countdown_queue.py
+++ b/pokerapp/services/countdown_queue.py
@@ -130,6 +130,22 @@ class CountdownMessageQueue:
 
         return msg
 
+    async def cancel_countdown_for_chat(self, chat_id: int) -> int:
+        """Cancel all active countdowns for a specific chat."""
+
+        cancelled_count = 0
+
+        async with self._tracking_lock:
+            keys_to_cancel = [
+                key for key in self._active_countdowns.keys() if key[0] == chat_id
+            ]
+            for key in keys_to_cancel:
+                message = self._active_countdowns[key]
+                message.cancelled = True
+                cancelled_count += 1
+
+        return cancelled_count
+
     def cancel_countdown(self, chat_id: int, message_id: int) -> bool:
         """Cancel an active countdown by marking its messages as cancelled.
 


### PR DESCRIPTION
## Summary
- initialize the countdown queue and worker inside the game engine
- provide queue-driven countdown start, completion, and cancellation helpers
- add chat-level cancellation support to the countdown queue service

## Testing
- pytest tests/test_game_engine_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68de9bb3ae3c8328ad716751b741da1f