### PR TITLE
Handle deleted countdown anchors gracefully

### DIFF
--- a/tests/test_countdown_worker.py
+++ b/tests/test_countdown_worker.py
@@ -8,7 +8,7 @@ from typing import List
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from telegram.error import TelegramError
+from aiogram.exceptions import TelegramAPIError
 
 from pokerapp.services.countdown_queue import CountdownMessageQueue
 from pokerapp.services.countdown_worker import CountdownWorker
@@ -198,7 +198,7 @@ async def test_on_complete_callback() -> None:
 async def test_telegram_error_handling() -> None:
     queue = CountdownMessageQueue()
     safe_ops = MagicMock()
-    safe_ops.edit_message_text = AsyncMock(side_effect=TelegramError("failure"))
+    safe_ops.edit_message_text = AsyncMock(side_effect=TelegramAPIError(MagicMock(), "failure"))
 
     worker = CountdownWorker(queue, safe_ops, edit_interval=0.1)
     await worker.start()


### PR DESCRIPTION
## Summary
- add granular Telegram error handling in the countdown worker with anchor cleanup and no-op detection
- extend the countdown queue with anchor-aware removal helpers used by the worker
- document countdown error handling semantics and align unit tests with aiogram exceptions

## Testing
- pytest tests/test_countdown_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68deb118187c8328bcb136468ce90773