### PR TITLE
Handle missing remove_anchor without exception

### DIFF
--- a/pokerapp/services/countdown_worker.py
+++ b/pokerapp/services/countdown_worker.py
@@ -72,7 +72,11 @@ class CountdownWorker:
         try:
             remove_anchor = getattr(self._queue, "remove_anchor", None)
             if remove_anchor is None:
-                raise AttributeError("Countdown queue lacks remove_anchor")
+                self._logger.debug(
+                    "Countdown queue lacks remove_anchor; skipping cancel",
+                    extra={"anchor_key": anchor_key},
+                )
+                return
             await remove_anchor(anchor_key)
             self._logger.debug(
                 "Cancelled countdown updates for anchor",


### PR DESCRIPTION
## Summary
- log and exit early when the countdown queue lacks a remove_anchor method during cancellation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deb39ef01c8328b2ad628c5cab9274