### PR TITLE
Add startup game recovery validation

### DIFF
--- a/pokerapp/lock_manager.py
+++ b/pokerapp/lock_manager.py
@@ -2418,4 +2418,12 @@ class LockManager:
             del frame
         return call_site, function_name
 
+    async def clear_all_locks(self) -> int:
+        """Remove all tracked locks and return how many were cleared."""
+
+        async with self._locks_guard:
+            cleared = len(self._locks)
+            self._locks.clear()
+        return cleared
+
 __all__ = ["LockManager", "LockOrderError"]

--- a/pokerapp/recovery_service.py
+++ b/pokerapp/recovery_service.py
@@ -1,0 +1,152 @@
+"""Startup recovery helpers for persisted poker games."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+
+from redis.asyncio import Redis
+
+from pokerapp.entities import ChatId
+from pokerapp.services.countdown_queue import CountdownMessageQueue
+from pokerapp.table_manager import TableManager
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from pokerapp.lock_manager import LockManager
+
+class RecoveryService:
+    """Coordinate recovery of persisted state after a restart."""
+
+    def __init__(
+        self,
+        *,
+        redis: Redis,
+        table_manager: TableManager,
+        lock_manager: Optional["LockManager"] = None,
+        countdown_queue: Optional[CountdownMessageQueue] = None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._redis = redis
+        self._table_manager = table_manager
+        self._lock_manager = lock_manager
+        self._countdown_queue = countdown_queue
+        self._logger = logger or logging.getLogger(__name__)
+
+    async def run_startup_recovery(self) -> Dict[str, Any]:
+        """Execute the startup recovery workflow and return summary stats."""
+
+        stats: Dict[str, Any] = {
+            "games_scanned": 0,
+            "games_recovered": 0,
+            "games_deleted": 0,
+            "locks_cleared": 0,
+            "countdowns_cleared": 0,
+        }
+
+        self._logger.info(
+            "Starting bot recovery sequence",
+            extra={"event_type": "startup_recovery_start"},
+        )
+
+        try:
+            game_stats = await self._recover_all_games()
+        except Exception:
+            self._logger.exception("Failed to recover games during startup")
+        else:
+            stats.update(game_stats)
+
+        try:
+            stats["locks_cleared"] = await self._clear_orphaned_locks()
+        except Exception:
+            self._logger.exception("Failed to clear orphaned locks")
+
+        try:
+            stats["countdowns_cleared"] = await self._clear_countdown_queue()
+        except Exception:
+            self._logger.exception("Failed to clear countdown queue")
+
+        stats_with_event = {**stats, "event_type": "startup_recovery_complete"}
+        self._logger.info("Startup recovery completed", extra=stats_with_event)
+        return stats
+
+    async def _recover_all_games(self) -> Dict[str, int]:
+        stats = {"games_scanned": 0, "games_recovered": 0, "games_deleted": 0}
+        pattern = self._table_manager._game_key("*")
+
+        async for raw_key in self._redis.scan_iter(match=pattern):
+            stats["games_scanned"] += 1
+            key = raw_key.decode() if isinstance(raw_key, bytes) else str(raw_key)
+            chat_id = self._extract_chat_id(key)
+            if chat_id is None:
+                continue
+
+            try:
+                game, validation = await self._table_manager.load_game(
+                    chat_id, validate=True
+                )
+            except Exception:
+                self._logger.exception(
+                    "Failed to load game during recovery", extra={"chat_id": chat_id}
+                )
+                await self._safe_delete(raw_key)
+                stats["games_deleted"] += 1
+                continue
+
+            if game is None:
+                stats["games_deleted"] += 1
+                continue
+
+            if validation and not validation.is_valid:
+                if validation.recoverable:
+                    stats["games_recovered"] += 1
+                else:
+                    stats["games_deleted"] += 1
+
+        return stats
+
+    async def _clear_orphaned_locks(self) -> int:
+        if self._lock_manager is None:
+            return 0
+
+        cleared = await self._lock_manager.clear_all_locks()
+        self._logger.info(
+            "Cleared orphaned locks",
+            extra={"locks_cleared": cleared, "event_type": "locks_cleared"},
+        )
+        return cleared
+
+    async def _clear_countdown_queue(self) -> int:
+        if self._countdown_queue is None:
+            return 0
+
+        cleared = await self._countdown_queue.clear_all()
+        self._logger.info(
+            "Cleared countdown queue",
+            extra={
+                "countdowns_cleared": cleared,
+                "event_type": "countdown_queue_cleared",
+            },
+        )
+        return cleared
+
+    def _extract_chat_id(self, key: str) -> Optional[Union[ChatId, int]]:
+        parts = key.split(":")
+        if len(parts) < 3:
+            return None
+        raw_id = parts[1]
+        try:
+            return int(raw_id)
+        except (TypeError, ValueError):
+            return raw_id
+
+    async def _safe_delete(self, key: Union[str, bytes]) -> None:
+        try:
+            await self._redis.delete(key)
+        except Exception:
+            key_value = key.decode() if isinstance(key, bytes) else str(key)
+            self._logger.exception(
+                "Failed to delete corrupted key", extra={"key": key_value}
+            )
+
+
+__all__ = ["RecoveryService"]

--- a/pokerapp/state_validator.py
+++ b/pokerapp/state_validator.py
@@ -1,0 +1,136 @@
+"""Validation and recovery helpers for persisted game state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Optional
+
+from pokerapp.cards import get_cards
+from pokerapp.entities import Game, GameState, PlayerState
+
+
+class ValidationIssue(str, Enum):
+    """Enumerates problems detected while validating a persisted game."""
+
+    CORRUPTED_JSON = "corrupted_json"
+    INVALID_STAGE = "invalid_stage"
+    ORPHANED_PLAYERS = "orphaned_players"
+    INCONSISTENT_POT = "inconsistent_pot"
+    MISSING_DEALER = "missing_dealer"
+    INVALID_DECK = "invalid_deck"
+
+
+@dataclass(slots=True)
+class ValidationResult:
+    """Outcome of validating a game snapshot."""
+
+    is_valid: bool
+    issues: List[ValidationIssue]
+    recoverable: bool
+    recovery_action: Optional[str] = None
+
+
+class GameStateValidator:
+    """Validate and recover ``Game`` instances loaded from persistence."""
+
+    _RESET_ACTION = "reset_to_waiting"
+    _DELETE_ACTION = "delete_and_recreate"
+
+    def validate_game(self, game: Game) -> ValidationResult:
+        """Inspect a game and report any validation issues."""
+
+        issues: List[ValidationIssue] = []
+
+        if not isinstance(getattr(game, "state", None), GameState):
+            issues.append(ValidationIssue.INVALID_STAGE)
+
+        state = getattr(game, "state", GameState.INITIAL)
+        players = list(getattr(game, "players", []))
+
+        if state is not GameState.INITIAL and not players:
+            issues.append(ValidationIssue.ORPHANED_PLAYERS)
+
+        if state is not GameState.INITIAL:
+            dealer_index = getattr(game, "dealer_index", None)
+            seats = getattr(game, "seats", [])
+            dealer_valid = (
+                isinstance(dealer_index, int)
+                and 0 <= dealer_index < len(seats)
+                and seats[dealer_index] is not None
+            )
+            if not dealer_valid:
+                issues.append(ValidationIssue.MISSING_DEALER)
+
+        pot = getattr(game, "pot", 0)
+        if pot is None or pot < 0:
+            issues.append(ValidationIssue.INCONSISTENT_POT)
+
+        deck = getattr(game, "remain_cards", []) or []
+        table_cards = getattr(game, "cards_table", []) or []
+        player_count = len(players)
+        if state is GameState.INITIAL:
+            expected_remaining = 52
+        else:
+            expected_remaining = max(52 - (2 * player_count) - len(table_cards), 0)
+        if len(deck) != expected_remaining:
+            issues.append(ValidationIssue.INVALID_DECK)
+
+        is_valid = not issues
+        recoverable = True
+        recovery_action: Optional[str] = None
+
+        if ValidationIssue.INVALID_STAGE in issues:
+            recoverable = False
+            recovery_action = self._DELETE_ACTION
+        elif issues:
+            recovery_action = self._RESET_ACTION
+
+        return ValidationResult(
+            is_valid=is_valid,
+            issues=issues,
+            recoverable=recoverable,
+            recovery_action=recovery_action,
+        )
+
+    def recover_game(self, game: Game, validation: ValidationResult) -> Game:
+        """Apply recovery behaviour based on validation outcome."""
+
+        if validation.is_valid or not validation.issues:
+            return game
+
+        if not validation.recoverable:
+            return Game()
+
+        return self._reset_to_waiting(game)
+
+    def _reset_to_waiting(self, game: Game) -> Game:
+        game.state = GameState.INITIAL
+        game.pot = 0
+        game.max_round_rate = 0
+        game.cards_table = []
+        game.remain_cards = get_cards()
+        game.current_player_index = -1
+        game.small_blind_index = -1
+        game.big_blind_index = -1
+        game.dealer_index = -1
+        game.last_actions = []
+
+        for player in game.players:
+            player.cards = []
+            player.round_rate = 0
+            player.total_bet = 0
+            player.has_acted = False
+            player.state = PlayerState.ACTIVE
+            player.is_dealer = False
+            player.is_small_blind = False
+            player.is_big_blind = False
+
+        return game
+
+
+__all__ = [
+    "GameStateValidator",
+    "ValidationIssue",
+    "ValidationResult",
+]

--- a/tests/test_state_validator.py
+++ b/tests/test_state_validator.py
@@ -1,0 +1,123 @@
+import fakeredis
+import fakeredis.aioredis
+import pytest
+
+from pokerapp.entities import Game, GameState, Player, PlayerState, Wallet
+from pokerapp.state_validator import GameStateValidator, ValidationIssue
+from pokerapp.table_manager import TableManager
+
+
+class DummyWallet(Wallet):
+    @staticmethod
+    def _prefix(id: int, suffix: str = ""):
+        return f"{id}{suffix}"
+
+    async def add_daily(self, amount: int) -> int:
+        return amount
+
+    async def has_daily_bonus(self) -> bool:
+        return False
+
+    async def inc(self, amount: int = 0) -> int:
+        return amount
+
+    async def inc_authorized_money(self, game_id: str, amount: int) -> None:
+        return None
+
+    async def authorized_money(self, game_id: str) -> int:
+        return 0
+
+    async def authorize(self, game_id: str, amount: int) -> None:
+        return None
+
+    async def authorize_all(self, game_id: str) -> int:
+        return 0
+
+    async def value(self) -> int:
+        return 0
+
+    async def approve(self, game_id: str) -> None:
+        return None
+
+    async def cancel(self, game_id: str) -> None:
+        return None
+
+
+@pytest.fixture
+def validator() -> GameStateValidator:
+    return GameStateValidator()
+
+
+def _make_player(user_id: str = "1") -> Player:
+    return Player(
+        user_id=user_id,
+        mention_markdown=f"@player{user_id}",
+        wallet=DummyWallet(),
+        ready_message_id="ready",
+    )
+
+
+def test_validate_valid_waiting_game(validator: GameStateValidator) -> None:
+    game = Game()
+
+    result = validator.validate_game(game)
+
+    assert result.is_valid is True
+    assert result.issues == []
+
+
+def test_validate_missing_dealer(validator: GameStateValidator) -> None:
+    game = Game()
+    player = _make_player()
+    game.add_player(player, seat_index=0)
+    game.state = GameState.ROUND_PRE_FLOP
+    game.dealer_index = -1
+    game.remain_cards = game.remain_cards[:50]
+
+    result = validator.validate_game(game)
+
+    assert ValidationIssue.MISSING_DEALER in result.issues
+    assert result.recovery_action == "reset_to_waiting"
+
+
+def test_recover_to_waiting(validator: GameStateValidator) -> None:
+    game = Game()
+    player = _make_player()
+    game.add_player(player, seat_index=0)
+    game.state = GameState.ROUND_PRE_FLOP
+    game.dealer_index = -1
+    game.remain_cards = game.remain_cards[:50]
+    player.cards = ["AS", "KD"]
+    player.total_bet = 100
+    player.has_acted = True
+    player.state = PlayerState.FOLD
+
+    result = validator.validate_game(game)
+    recovered = validator.recover_game(game, result)
+
+    assert recovered.state is GameState.INITIAL
+    assert recovered.pot == 0
+    assert recovered.cards_table == []
+    assert len(recovered.remain_cards) == 52
+    assert recovered.dealer_index == -1
+    assert player.cards == []
+    assert player.total_bet == 0
+    assert player.has_acted is False
+    assert player.state is PlayerState.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_corrupted_json_handling() -> None:
+    server = fakeredis.FakeServer()
+    redis_async = fakeredis.aioredis.FakeRedis(server=server)
+    validator = GameStateValidator()
+    table_manager = TableManager(redis_async, state_validator=validator)
+
+    await redis_async.set("chat:123:game", b"{invalid json")
+
+    game, result = await table_manager.load_game(123, validate=True)
+
+    assert game is None
+    assert result is not None
+    assert ValidationIssue.CORRUPTED_JSON in result.issues
+    assert await redis_async.get("chat:123:game") is None


### PR DESCRIPTION
## Summary
- add a GameStateValidator to check persisted poker tables and reset invalid state during load
- integrate a RecoveryService into bootstrap to scan Redis, clear orphaned locks, and wipe countdown tasks on startup
- document the recovery flow and add targeted tests for validator behaviour

## Testing
- pytest tests/test_state_validator.py tests/test_table_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68deb52d0fac8328b27303d23331c2da