### PR TITLE
Add Telegram retry manager and Redis optimistic locking

### DIFF
--- a/pokerapp/telegram_retry_manager.py
+++ b/pokerapp/telegram_retry_manager.py
@@ -1,0 +1,140 @@
+"""
+Telegram API retry manager with exponential backoff.
+
+Provides decorators to wrap Telegram API calls with automatic retry logic,
+handling transient network errors and rate limiting.
+"""
+
+from __future__ import annotations
+
+from functools import wraps
+import asyncio
+from typing import TypeVar, Callable, Optional, Any, Awaitable
+from telegram.error import RetryAfter, TimedOut, NetworkError
+import logging
+
+T = TypeVar("T")
+
+
+class TelegramRetryManager:
+    """Manage retry logic for Telegram API calls with exponential backoff."""
+
+    def __init__(
+        self,
+        max_retries: int = 3,
+        base_delay: float = 1.0,
+        max_delay: float = 30.0,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self.max_retries = max_retries
+        self.base_delay = base_delay
+        self.max_delay = max_delay
+        self.logger = logger or logging.getLogger(__name__)
+
+    def retry_telegram_call(
+        self,
+        operation_name: str,
+        critical: bool = False,
+    ) -> Callable[[Callable[..., Awaitable[T]]], Callable[..., Awaitable[Optional[T]]]]:
+        """Decorator returning a coroutine wrapper with retry logic."""
+
+        def decorator(
+            func: Callable[..., Awaitable[T]]
+        ) -> Callable[..., Awaitable[Optional[T]]]:
+            @wraps(func)
+            async def wrapper(*args: Any, **kwargs: Any) -> Optional[T]:
+                max_attempts = self.max_retries * 2 if critical else self.max_retries
+
+                for attempt in range(1, max_attempts + 1):
+                    try:
+                        result = await func(*args, **kwargs)
+                        if attempt > 1:
+                            self.logger.info(
+                                "Telegram %s succeeded after retry", operation_name,
+                                extra={
+                                    "attempt": attempt,
+                                    "operation": operation_name,
+                                },
+                            )
+                        return result
+                    except RetryAfter as error:
+                        wait_time = float(getattr(error, "retry_after", 0)) + 1.0
+                        if attempt < max_attempts:
+                            self.logger.warning(
+                                "Telegram rate limited, retrying %s in %.1fs",
+                                operation_name,
+                                wait_time,
+                                extra={
+                                    "attempt": attempt,
+                                    "retry_after": getattr(error, "retry_after", None),
+                                    "operation": operation_name,
+                                },
+                            )
+                            await asyncio.sleep(wait_time)
+                        else:
+                            self._log_final_failure(operation_name, error, attempt, critical)
+                            if critical:
+                                raise
+                            return None
+                    except (TimedOut, NetworkError) as error:
+                        if attempt < max_attempts:
+                            delay = min(
+                                self.base_delay * (2 ** (attempt - 1)),
+                                self.max_delay,
+                            )
+                            self.logger.warning(
+                                "Telegram %s failed, retrying in %.1fs",
+                                operation_name,
+                                delay,
+                                extra={
+                                    "attempt": attempt,
+                                    "error": type(error).__name__,
+                                    "operation": operation_name,
+                                },
+                            )
+                            await asyncio.sleep(delay)
+                        else:
+                            self._log_final_failure(operation_name, error, attempt, critical)
+                            if critical:
+                                raise
+                            return None
+                    except Exception as error:  # noqa: BLE001 - propagate unexpected errors
+                        self.logger.error(
+                            "Unexpected error in %s",
+                            operation_name,
+                            extra={
+                                "error": type(error).__name__,
+                                "error_message": str(error),
+                                "operation": operation_name,
+                            },
+                            exc_info=True,
+                        )
+                        raise
+
+                return None
+
+            return wrapper
+
+        return decorator
+
+    def _log_final_failure(
+        self,
+        operation_name: str,
+        error: Exception,
+        attempts: int,
+        critical: bool,
+    ) -> None:
+        """Log the final failure after exhausting retry attempts."""
+
+        self.logger.error(
+            "Telegram %s failed after %d attempts",
+            operation_name,
+            attempts,
+            extra={
+                "operation": operation_name,
+                "error": type(error).__name__,
+                "error_message": str(error),
+                "critical": critical,
+                "total_attempts": attempts,
+            },
+        )

--- a/tests/test_task_6_1.py
+++ b/tests/test_task_6_1.py
@@ -1,0 +1,165 @@
+import asyncio
+from typing import List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from telegram.error import NetworkError, RetryAfter, TimedOut
+
+from pokerapp.entities import Game
+from pokerapp.table_manager import TableManager
+from pokerapp.telegram_retry_manager import TelegramRetryManager
+
+
+class TestTelegramRetryManager:
+    @pytest.fixture
+    def retry_manager(self) -> TelegramRetryManager:
+        return TelegramRetryManager(max_retries=3, base_delay=0.1, max_delay=1.0)
+
+    @pytest.mark.asyncio
+    async def test_retry_on_network_error(self, retry_manager: TelegramRetryManager):
+        call_count = 0
+
+        @retry_manager.retry_telegram_call("test_op", critical=False)
+        async def flaky_call() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise NetworkError("temporary outage")
+            return "success"
+
+        result = await flaky_call()
+
+        assert result == "success"
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_respect_retry_after(
+        self, retry_manager: TelegramRetryManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sleep_calls: List[float] = []
+        sleep_mock = AsyncMock(side_effect=lambda duration: sleep_calls.append(duration))
+        monkeypatch.setattr(asyncio, "sleep", sleep_mock)
+
+        call_count = 0
+
+        @retry_manager.retry_telegram_call("test_op", critical=False)
+        async def rate_limited_call() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RetryAfter(5.0)
+            return "success"
+
+        result = await rate_limited_call()
+
+        assert result == "success"
+        assert sleep_calls and sleep_calls[0] == pytest.approx(6.0, rel=1e-3)
+
+    @pytest.mark.asyncio
+    async def test_critical_raises_on_exhaustion(self, retry_manager: TelegramRetryManager) -> None:
+        @retry_manager.retry_telegram_call("test_op", critical=True)
+        async def always_fails() -> None:
+            raise NetworkError("Always fails")
+
+        with pytest.raises(NetworkError):
+            await always_fails()
+
+    @pytest.mark.asyncio
+    async def test_non_critical_returns_none(self, retry_manager: TelegramRetryManager) -> None:
+        @retry_manager.retry_telegram_call("test_op", critical=False)
+        async def always_times_out() -> None:
+            raise TimedOut("timeout")
+
+        result = await always_times_out()
+        assert result is None
+
+
+class TestOptimisticLocking:
+    @pytest.fixture
+    def redis_mock(self) -> AsyncMock:
+        mock = AsyncMock()
+        mock.get = AsyncMock(return_value=None)
+        mock.set = AsyncMock()
+        mock.pipeline = MagicMock()
+        return mock
+
+    @pytest.fixture
+    def table_manager(self, redis_mock: AsyncMock) -> TableManager:
+        redis_ops = MagicMock()
+        redis_ops.safe_get = AsyncMock()
+        redis_ops.safe_set = AsyncMock()
+        redis_ops.safe_delete = AsyncMock()
+        redis_ops.safe_mset = AsyncMock()
+        redis_ops.safe_smembers = AsyncMock(return_value=set())
+        redis_ops.safe_sadd = AsyncMock()
+        redis_ops._logger = MagicMock()
+
+        manager = TableManager(
+            redis_mock,
+            redis_ops=redis_ops,
+            wallet_redis_ops=redis_ops,
+            state_validator=None,
+        )
+        manager._redis = redis_mock
+        manager._redis_ops = redis_ops
+        manager._logger = MagicMock()
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_load_with_version_initializes(self, table_manager: TableManager, redis_mock: AsyncMock) -> None:
+        table_manager.load_game = AsyncMock(return_value=(Game(), None))
+        redis_mock.get = AsyncMock(return_value=None)
+
+        game, version = await table_manager.load_game_with_version(123)
+
+        assert isinstance(game, Game)
+        assert version == 0
+        redis_mock.set.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_save_increments_version(self, table_manager: TableManager, redis_mock: AsyncMock) -> None:
+        game = Game()
+
+        pipe_mock = AsyncMock()
+        pipe_mock.watch = AsyncMock()
+        pipe_mock.get = AsyncMock(return_value=b"5")
+        pipe_mock.unwatch = AsyncMock()
+        pipe_mock.multi = MagicMock()
+        pipe_mock.set = MagicMock()
+        pipe_mock.execute = AsyncMock()
+        pipe_mock.__aenter__.return_value = pipe_mock
+        pipe_mock.__aexit__.return_value = False
+
+        redis_mock.pipeline.return_value = pipe_mock
+        table_manager._update_player_index = AsyncMock()
+
+        success = await table_manager.save_game_with_version_check(123, game, 5)
+
+        assert success is True
+        version_key = table_manager._version_key(123)
+        assert any(
+            call.args[0] == version_key and call.args[1] == 6
+            for call in pipe_mock.set.call_args_list
+        )
+        table_manager._update_player_index.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_version_conflict_returns_false(
+        self, table_manager: TableManager, redis_mock: AsyncMock
+    ) -> None:
+        game = Game()
+
+        pipe_mock = AsyncMock()
+        pipe_mock.watch = AsyncMock()
+        pipe_mock.get = AsyncMock(return_value=b"10")
+        pipe_mock.unwatch = AsyncMock()
+        pipe_mock.__aenter__.return_value = pipe_mock
+        pipe_mock.__aexit__.return_value = False
+
+        redis_mock.pipeline.return_value = pipe_mock
+
+        success = await table_manager.save_game_with_version_check(123, game, 5)
+
+        assert success is False
+        pipe_mock.unwatch.assert_awaited_once()
+        pipe_mock.execute.assert_not_awaited()


### PR DESCRIPTION
## Summary
- add a reusable TelegramRetryManager with exponential backoff and wire it into MessagingService via the bootstrap factory
- introduce version-aware load/save helpers in TableManager to guard Redis writes with optimistic locking and document the workflow
- cover the new behaviours with dedicated unit tests for retry handling and Redis transactions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dec6e9fdac8328909a3bc777cd1d23