### PR TITLE
Add Redis-backed distributed action locks

### DIFF
--- a/config/data/redis_keys.json
+++ b/config/data/redis_keys.json
@@ -2,7 +2,8 @@
   "engine": {
     "stage_lock_prefix": "stage:",
     "stop_request": "stop_request",
-    "action_lock_prefix": "action:lock:"
+    "action_lock_prefix": "action:lock:",
+    "_comment_action_lock_prefix": "Distributed action locks (Task 6.2.1)"
   },
   "player_report": {
     "cache_prefix": "pokerbot:player_report:"

--- a/pokerapp/config.py
+++ b/pokerapp/config.py
@@ -99,6 +99,7 @@ _DEFAULT_REDIS_KEYS_DATA: Dict[str, Any] = {
     "engine": {
         "stage_lock_prefix": "stage:",
         "stop_request": "stop_request",
+        "action_lock_prefix": "action:lock:",
     },
     "player_report": {
         "cache_prefix": "pokerbot:player_report:",


### PR DESCRIPTION
## Summary
- add a Redis-backed action lock implementation with a Lua release path and graceful fallbacks
- wire default Redis key prefixes through the configuration and document the distributed lock namespace
- extend task 6.2 tests to cover multi-instance behaviour, token validation, TTL expiry, and Redis failures

## Testing
- pytest tests/test_task_6_2.py

------
https://chatgpt.com/codex/tasks/task_e_68ded4921874832888976bd2e3ea83da