### PR TITLE
Fix table lock key operations and tests

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -474,7 +474,11 @@ class GameEngine:
             )
             return True
         finally:
-            await self._lock_manager.release_table_lock(chat_id, lock_token)
+            await self._lock_manager.release_table_lock(
+                chat_id=chat_id,
+                token=lock_token,
+                operation="join",
+            )
 
     async def leave_game(
         self,
@@ -574,7 +578,11 @@ class GameEngine:
             )
             return True
         finally:
-            await self._lock_manager.release_table_lock(chat_id, lock_token)
+            await self._lock_manager.release_table_lock(
+                chat_id=chat_id,
+                token=lock_token,
+                operation="leave",
+            )
 
     async def _create_joining_player(
         self, user_id: int, user_name: str
@@ -1562,7 +1570,7 @@ class GameEngine:
                                 "error": str(exc),
                                 "error_type": type(exc).__name__,
                             },
-            )
+                        )
 
             self._logger.debug(
                 "All relevant locks released for chat",


### PR DESCRIPTION
## Summary
- include the operation name in table-level lock keys and in the release path so join/leave locks remain independent
- update game engine cleanup calls to release the appropriate join/leave table lock tokens
- refresh task 6.3.1 tests to cover independent operations and align table manager mocks

## Testing
- flake8 pokerapp/lock_manager.py pokerapp/game_engine.py tests/test_task_6_3_1.py
- mypy pokerapp/lock_manager.py pokerapp/game_engine.py *(fails: existing repository typing errors)*
- pytest tests/test_task_6_3_1.py -v --tb=short


------
https://chatgpt.com/codex/tasks/task_e_68dfa6c7b5448328b8f5885e9da43075