### PR TITLE
Fix action lock tests and initialize turn deadlines

### DIFF
--- a/pokerapp/entities.py
+++ b/pokerapp/entities.py
@@ -180,6 +180,7 @@ class Game:
 
         # 🆕 اضافه شده: پیام نوبت فعلی
         self.turn_message_id: Optional[MessageId] = None
+        self.turn_deadline: Optional[float] = None
 
         # 🆕 اضافه شده: پیام تصویر میز
         self.board_message_id: Optional[MessageId] = None
@@ -199,6 +200,7 @@ class Game:
         self.pot = 0
         self.max_round_rate = 0
         self.current_player_index = -1
+        self.turn_deadline = None
         self.small_blind_index = -1
         self.big_blind_index = -1
         for player in self.players:

--- a/pokerapp/lock_manager.py
+++ b/pokerapp/lock_manager.py
@@ -2942,11 +2942,12 @@ class LockManager:
         self,
         chat_id: int,
         user_id: int,
-        token_or_action: str,
+        token_or_action: Optional[str] = None,
         token: Optional[str] = None,
         *,
         action_type: Optional[str] = None,
         action_data: Optional[str] = None,
+        lock_token: Optional[str] = None,
     ) -> bool:
         """Release an action lock using token validation.
 
@@ -2955,14 +2956,26 @@ class LockManager:
         signature.
         """
 
-        resolved_token: str
+        if lock_token is not None and token is None:
+            token = lock_token
+
+        resolved_token: Optional[str]
         resolved_action_type: Optional[str] = action_type
-        if token is None:
+        if token is None and token_or_action is not None:
             resolved_token = token_or_action
         else:
             resolved_token = token
-            if resolved_action_type is None:
+            if (
+                resolved_action_type is None
+                and token_or_action is not None
+                and isinstance(token_or_action, str)
+            ):
                 resolved_action_type = token_or_action.strip().lower()
+
+        if resolved_token is None:
+            raise ValueError(
+                "Token must be provided when releasing an action lock."
+            )
 
         action_identifier: Optional[str]
         if resolved_action_type:

--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -1715,6 +1715,11 @@ class PokerBotModel:
 
         if next_player_index != -1:
             game.current_player_index = next_player_index
+            engine = getattr(self, "_game_engine", None)
+            if engine is not None:
+                engine.refresh_turn_deadline(game)
+            else:
+                game.turn_deadline = GameEngine.compute_turn_deadline()
             return game.players[next_player_index]
 
         # اگر هیچ بازیکن فعالی برای حرکت بعدی وجود ندارد (مثلاً همه All-in هستند)
@@ -2261,6 +2266,11 @@ class RoundRateModel:
         game.max_round_rate = SMALL_BLIND * 2
         game.current_player_index = first_action_index
         game.trading_end_user_id = big_blind_player.user_id
+
+        if self._model is not None and getattr(self._model, "_game_engine", None) is not None:
+            self._model._game_engine.refresh_turn_deadline(game)
+        else:
+            game.turn_deadline = GameEngine.compute_turn_deadline()
 
         player_turn = game.get_player_by_seat(game.current_player_index)
         return player_turn

--- a/tests/test_task_6_3_2.py
+++ b/tests/test_task_6_3_2.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Optional
+from typing import Optional, Tuple
 
 import fakeredis
 import fakeredis.aioredis
@@ -60,86 +60,16 @@ class DummySafeOps:
         return await call()
 
 
-@pytest.fixture
-def redis_pool():
-    server = fakeredis.FakeServer()
-    return fakeredis.aioredis.FakeRedis(server=server)
-
-
-@pytest.mark.asyncio
-async def test_action_lock_prevents_duplicate(redis_pool) -> None:
-    manager = LockManager(logger=logging.getLogger("lock-prevent"), redis_pool=redis_pool)
-    chat_id, user_id = 123, 456
-
-    token1 = await manager.acquire_action_lock(chat_id, user_id, "fold")
-    token2 = await manager.acquire_action_lock(chat_id, user_id, "fold")
-
-    assert token1 is not None
-    assert token2 is None
-
-    await manager.release_action_lock(chat_id, user_id, "fold", token1)
-
-
-@pytest.mark.asyncio
-async def test_action_lock_allows_different_users(redis_pool) -> None:
-    manager = LockManager(logger=logging.getLogger("lock-multi"), redis_pool=redis_pool)
-    chat_id = 987
-
-    token_alice = await manager.acquire_action_lock(chat_id, 100, "fold")
-    token_bob = await manager.acquire_action_lock(chat_id, 200, "call")
-
-    assert token_alice is not None
-    assert token_bob is not None
-
-    await manager.release_action_lock(chat_id, 100, "fold", token_alice)
-    await manager.release_action_lock(chat_id, 200, "call", token_bob)
-
-
-@pytest.mark.asyncio
-async def test_action_lock_expires_after_ttl(redis_pool) -> None:
-    manager = LockManager(logger=logging.getLogger("lock-ttl"), redis_pool=redis_pool)
-    chat_id, user_id = 222, 333
-
-    await manager.acquire_action_lock(chat_id, user_id, "raise", ttl=1)
-    await asyncio.sleep(1.1)
-    token2 = await manager.acquire_action_lock(chat_id, user_id, "raise")
-
-    assert token2 is not None
-
-    await manager.release_action_lock(chat_id, user_id, "raise", token2)
-
-
-@pytest.mark.asyncio
-async def test_action_lock_release_validation(redis_pool) -> None:
-    manager = LockManager(logger=logging.getLogger("lock-release"), redis_pool=redis_pool)
-    chat_id, user_id = 111, 222
-
-    token = await manager.acquire_action_lock(chat_id, user_id, "check")
-    assert token is not None
-
-    released_wrong = await manager.release_action_lock(chat_id, user_id, "check", token="wrong")
-    released_correct = await manager.release_action_lock(chat_id, user_id, "check", token)
-
-    assert released_wrong is False
-    assert released_correct is True
-
-
-@pytest.mark.asyncio
-async def test_game_engine_rejects_duplicate_action(redis_pool) -> None:
+def _build_engine_for_game(
+    *,
+    game: Game,
+    redis_pool,
+    logger_name: str = "engine-action",
+) -> Tuple["GameEngine", DummyTableManager, DummyView]:
     from pokerapp.game_engine import GameEngine
 
-    logger = logging.getLogger("engine-action")
+    logger = logging.getLogger(logger_name)
     lock_manager = LockManager(logger=logger, redis_pool=redis_pool)
-
-    game = Game()
-    chat_id, user_id = 777, 888
-    game.chat_id = chat_id
-    wallet = DummyWallet()
-    player = Player(user_id, "Player", wallet, "ready")
-    game.add_player(player, seat_index=0)
-    game.current_player_index = 0
-    game.turn_deadline = asyncio.get_running_loop().time() + 5
-
     table_manager = DummyTableManager(game)
     view = DummyView()
     safe_ops = DummySafeOps(view)
@@ -155,6 +85,113 @@ async def test_game_engine_rejects_duplicate_action(redis_pool) -> None:
     engine._action_lock_ttl = 1
     engine._action_lock_feedback_text = "⚠️ Action in progress, please wait..."
 
+    return engine, table_manager, view
+
+
+@pytest.fixture
+def redis_pool():
+    server = fakeredis.FakeServer()
+    return fakeredis.aioredis.FakeRedis(server=server)
+
+
+@pytest.mark.asyncio
+async def test_action_lock_prevents_duplicate(redis_pool) -> None:
+    """Test that acquiring the same lock twice blocks the second attempt."""
+
+    manager = LockManager(logger=logging.getLogger("lock-prevent"), redis_pool=redis_pool)
+    chat_id, user_id = 123, 456
+
+    token1 = await manager.acquire_action_lock(chat_id, user_id, "fold")
+    assert token1 is not None
+
+    token2 = await manager.acquire_action_lock(chat_id, user_id, "fold")
+    assert token2 is None
+
+    released = await manager.release_action_lock(chat_id, user_id, "fold", token1)
+    assert released is True
+
+    token3 = await manager.acquire_action_lock(chat_id, user_id, "fold")
+    assert token3 is not None
+    await manager.release_action_lock(chat_id, user_id, "fold", token3)
+
+
+@pytest.mark.asyncio
+async def test_action_lock_allows_different_users(redis_pool) -> None:
+    """Test that different users can acquire locks simultaneously."""
+
+    manager = LockManager(logger=logging.getLogger("lock-multi"), redis_pool=redis_pool)
+    chat_id = 987
+
+    token_alice = await manager.acquire_action_lock(chat_id, 100, "fold")
+    token_bob = await manager.acquire_action_lock(chat_id, 200, "call")
+
+    assert token_alice is not None
+    assert token_bob is not None
+
+    released_alice = await manager.release_action_lock(chat_id, 100, "fold", token_alice)
+    released_bob = await manager.release_action_lock(chat_id, 200, "call", token_bob)
+
+    assert released_alice is True
+    assert released_bob is True
+
+
+@pytest.mark.asyncio
+async def test_action_lock_expires_after_ttl(redis_pool) -> None:
+    """Test that lock auto-expires and can be reacquired."""
+
+    manager = LockManager(logger=logging.getLogger("lock-ttl"), redis_pool=redis_pool)
+    chat_id, user_id = 222, 333
+
+    token1 = await manager.acquire_action_lock(chat_id, user_id, "raise", ttl=1)
+    assert token1 is not None
+
+    await asyncio.sleep(1.1)
+
+    token2 = await manager.acquire_action_lock(chat_id, user_id, "raise")
+    assert token2 is not None
+
+    await manager.release_action_lock(chat_id, user_id, "raise", token2)
+
+
+@pytest.mark.asyncio
+async def test_action_lock_release_validation(redis_pool) -> None:
+    """Test that lock release validates the token."""
+
+    manager = LockManager(logger=logging.getLogger("lock-release"), redis_pool=redis_pool)
+    chat_id, user_id = 111, 222
+
+    token = await manager.acquire_action_lock(chat_id, user_id, "check")
+    assert token is not None
+
+    released_wrong = await manager.release_action_lock(
+        chat_id, user_id, "check", "wrong-token-12345"
+    )
+    assert released_wrong is False
+
+    released_correct = await manager.release_action_lock(chat_id, user_id, "check", token)
+    assert released_correct is True
+
+    released_again = await manager.release_action_lock(chat_id, user_id, "check", token)
+    assert released_again is False
+
+
+@pytest.mark.asyncio
+async def test_game_engine_rejects_duplicate_action(redis_pool) -> None:
+    logger = logging.getLogger("engine-action")
+
+    game = Game()
+    chat_id, user_id = 777, 888
+    game.chat_id = chat_id
+    wallet = DummyWallet()
+    player = Player(user_id, "Player", wallet, "ready")
+    game.add_player(player, seat_index=0)
+    game.current_player_index = 0
+    game.turn_deadline = asyncio.get_running_loop().time() + 5
+
+    engine, table_manager, view = _build_engine_for_game(
+        game=game, redis_pool=redis_pool, logger_name="engine-action"
+    )
+
     task1 = asyncio.create_task(engine.process_action(chat_id, user_id, "fold"))
     task2 = asyncio.create_task(engine.process_action(chat_id, user_id, "fold"))
 
@@ -164,3 +201,26 @@ async def test_game_engine_rejects_duplicate_action(redis_pool) -> None:
     assert results.count(False) == 1
     assert table_manager.save_count == 1
     assert any(chat == user_id for chat, _ in view.messages)
+
+
+@pytest.mark.asyncio
+async def test_turn_deadline_enforcement(redis_pool) -> None:
+    game = Game()
+    chat_id, user_id = 123, 456
+    game.chat_id = chat_id
+    wallet = DummyWallet()
+    player = Player(user_id, "Player", wallet, "ready")
+    game.add_player(player, seat_index=0)
+    game.current_player_index = 0
+
+    engine, table_manager, _ = _build_engine_for_game(
+        game=game, redis_pool=redis_pool, logger_name="engine-deadline"
+    )
+
+    loop = asyncio.get_running_loop()
+    game.turn_deadline = loop.time() - 10
+
+    success = await engine.process_action(chat_id, user_id, "fold")
+
+    assert success is False
+    assert table_manager.save_count == 0


### PR DESCRIPTION
## Summary
- restore and extend the task 6.3.2 test suite with additional action lock coverage and a turn deadline enforcement scenario
- define and refresh game turn deadlines via new GameEngine helpers, integrating with PokerBotModel turn selection and blinds setup
- accept `lock_token` when releasing action locks and register the aiogram action router during PokerBot initialisation

## Testing
- pytest tests/test_task_6_3_2.py -v --tb=short
- python -c "from pokerapp.game_engine import GameEngine; print('✅ Imports OK')"
- python - <<'PY'
from unittest.mock import MagicMock

from pokerapp.pokerbot import PokerBot

bot = PokerBot.__new__(PokerBot)
bot._logger = MagicMock()
bot._aiogram_dispatcher = None

bot._setup_aiogram_dispatcher()

print(type(bot._aiogram_dispatcher).__name__)
print(bot._logger.info.call_args)
PY
- pytest tests/ -v --tb=short -k "not slow"

------
https://chatgpt.com/codex/tasks/task_e_68dfaf8808b08328983b982f981ca579