### PR TITLE
Remove unused Aiogram dispatcher and streamline deadline refresh

### DIFF
--- a/pokerapp/pokerbot.py
+++ b/pokerapp/pokerbot.py
@@ -86,7 +86,6 @@ class PokerBot:
         self._view: Optional[PokerBotViewer] = None
         self._model: Optional[PokerBotModel] = None
         self._controller: Optional[PokerBotCotroller] = None
-        self._aiogram_dispatcher = None
 
         self._kv_async = kv_async
         self._redis_ops = redis_ops
@@ -99,35 +98,6 @@ class PokerBot:
         self._player_report_cache = player_report_cache
         self._adaptive_player_report_cache = adaptive_player_report_cache
         self._build_application()
-        self._setup_aiogram_dispatcher()
-
-    def _setup_aiogram_dispatcher(self) -> None:
-        try:
-            from aiogram import Dispatcher  # type: ignore
-        except ImportError:  # pragma: no cover - optional dependency guard
-            self._logger.warning(
-                "Aiogram not available; skipping action router registration.",
-                extra={"event_type": "aiogram_router_skipped", "router": "action_router"},
-            )
-            self._aiogram_dispatcher = None
-            return
-
-        if self._aiogram_dispatcher is None:
-            self._aiogram_dispatcher = Dispatcher()
-
-        dispatcher = self._aiogram_dispatcher
-
-        from pokerapp.aiogram_flow import router as action_router
-
-        sub_routers = getattr(dispatcher, "sub_routers", [])
-        if any(router is action_router for router in sub_routers):
-            return
-
-        dispatcher.include_router(action_router)
-        self._logger.info(
-            "Action router registered",
-            extra={"event_type": "aiogram_router_registered", "router": "action_router"},
-        )
 
     def run(self) -> None:
         """Start the bot using the webhook listener."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,16 +3,108 @@
 import logging
 import sys
 from pathlib import Path
+from typing import Awaitable, Callable, Optional, Tuple
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+
+import fakeredis
+import fakeredis.aioredis
 import pytest
 
+from pokerapp.entities import Game
+from pokerapp.game_engine import GameEngine
+from pokerapp.lock_manager import LockManager
 from pokerapp.pokerbotview import PokerBotViewer
 from pokerapp.utils.messaging_service import MessagingService
 from pokerapp.utils.request_metrics import RequestMetrics
+
+
+class DummyTableManager:
+    def __init__(self, game: Game) -> None:
+        self._game = game
+        self.save_count = 0
+
+    async def load_game(self, chat_id: int):
+        return self._game, None
+
+    async def save_game(self, chat_id: int, game: Game) -> None:
+        self._game = game
+        self.save_count += 1
+
+
+class DummyView:
+    def __init__(self) -> None:
+        self.messages: list[tuple[int, str]] = []
+
+    async def send_message(self, chat_id: int, text: str, **kwargs) -> Optional[int]:
+        self.messages.append((chat_id, text))
+        return None
+
+
+class DummySafeOps:
+    def __init__(self, view: DummyView) -> None:
+        self._view = view
+        self.calls: list[tuple[int, str]] = []
+
+    async def send_message_safe(
+        self,
+        *,
+        call: Callable[[], Awaitable[Optional[int]]],
+        chat_id: int,
+        operation: Optional[str] = None,
+        log_extra: Optional[dict] = None,
+    ):
+        self.calls.append((chat_id, operation or "send_message"))
+        return await call()
+
+
+def _build_engine_for_game(
+    *,
+    game: Game,
+    redis_pool,
+    logger_name: str = "engine-action",
+) -> Tuple[GameEngine, DummyTableManager, DummyView]:
+    logger = logging.getLogger(logger_name)
+    lock_manager = LockManager(logger=logger, redis_pool=redis_pool)
+    table_manager = DummyTableManager(game)
+    view = DummyView()
+    safe_ops = DummySafeOps(view)
+
+    engine = GameEngine.__new__(GameEngine)
+    engine._lock_manager = lock_manager
+    engine._table_manager = table_manager
+    engine._safe_ops = safe_ops
+    engine._telegram_ops = safe_ops
+    engine._view = view
+    engine._logger = logger
+    engine._valid_player_actions = {"fold", "check", "call", "raise"}
+    engine._action_lock_ttl = 1
+    engine._action_lock_feedback_text = "⚠️ Action in progress, please wait..."
+
+    return engine, table_manager, view
+
+
+@pytest.fixture
+def redis_pool():
+    server = fakeredis.FakeServer()
+    return fakeredis.aioredis.FakeRedis(server=server)
+
+
+@pytest.fixture
+def game_engine_factory(redis_pool):
+    def _factory(
+        *,
+        game: Game,
+        logger_name: str = "test-engine",
+    ) -> Tuple[GameEngine, DummyTableManager, DummyView]:
+        return _build_engine_for_game(
+            game=game, redis_pool=redis_pool, logger_name=logger_name
+        )
+
+    return _factory
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- remove the unused Aiogram Dispatcher bootstrap from the poker bot wiring
- add a helper to consistently refresh turn deadlines when the engine may be absent
- move the test GameEngine factory into conftest for reuse across tests

## Testing
- pytest tests/test_task_6_3_2.py

------
https://chatgpt.com/codex/tasks/task_e_68dfb386eb408328980490eaccf3178d