### PR TITLE
Optimize statistics batching and add indexes

### DIFF
--- a/migrations/002_add_performance_indexes.sql
+++ b/migrations/002_add_performance_indexes.sql
@@ -1,0 +1,26 @@
+-- Migration: Add performance indexes for statistics workloads
+-- Generated on: 2025-10-03
+
+BEGIN;
+
+-- Improve retrieval of recent hands per chat
+CREATE INDEX IF NOT EXISTS idx_player_hand_history_chat_finished
+    ON player_hand_history (chat_id, finished_at DESC);
+
+-- Accelerate player-specific history lookups
+CREATE INDEX IF NOT EXISTS idx_player_hand_history_user_finished
+    ON player_hand_history (user_id, finished_at DESC);
+
+-- Optimise leaderboard queries based on games played
+CREATE INDEX IF NOT EXISTS idx_player_stats_total_games
+    ON player_stats (total_games DESC);
+
+-- Optimise leaderboard queries for winners
+CREATE INDEX IF NOT EXISTS idx_player_stats_total_wins
+    ON player_stats (total_wins DESC);
+
+-- Support filtering by chat and player when analysing hands
+CREATE INDEX IF NOT EXISTS idx_player_hand_history_chat_user
+    ON player_hand_history (chat_id, user_id);
+
+COMMIT;

--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -685,7 +685,12 @@ class PokerBotModel:
         pot_total = sum(result.payout for result in results)
 
         if self._stats_enabled():
-            await self._stats.finish_hand(match_id, chat_id, results, pot_total)
+            await self._stats.record_hand_finished_batch(
+                hand_id=match_id,
+                chat_id=chat_id,
+                results=results,
+                pot_total=pot_total,
+            )
             self._player_report_cache.invalidate_on_event(
                 (self._safe_int(player.user_id) for player in game.players),
                 event_type="hand_finished",

--- a/pokerapp/stats_reporter.py
+++ b/pokerapp/stats_reporter.py
@@ -78,7 +78,7 @@ class StatsReporter:
             results = self._build_hand_results(
                 game=game, payouts=payouts, hand_labels=hand_labels
             )
-            await self._stats.finish_hand(
+            await self._stats.record_hand_finished_batch(
                 hand_id=game.id,
                 chat_id=self._safe_int(chat_id),
                 results=results,

--- a/tests/test_game_engine_finalization.py
+++ b/tests/test_game_engine_finalization.py
@@ -66,6 +66,7 @@ def _build_stats_service() -> MagicMock:
     stats = MagicMock(spec=BaseStatsService)
     stats.register_player_profile = AsyncMock()
     stats.start_hand = AsyncMock()
+    stats.record_hand_finished_batch = AsyncMock()
     stats.finish_hand = AsyncMock()
     stats.record_daily_bonus = AsyncMock()
     stats.build_player_report = AsyncMock()
@@ -820,8 +821,8 @@ async def test_finalize_game_single_winner_distributes_pot_and_updates_stats():
     assert winners_by_pot and winners_by_pot[0]["amount"] == 100
     assert winners_by_pot[0]["winners"][0]["player"] is winner
 
-    stats.finish_hand.assert_awaited_once()
-    _, stats_kwargs = stats.finish_hand.await_args
+    stats.record_hand_finished_batch.assert_awaited_once()
+    _, stats_kwargs = stats.record_hand_finished_batch.await_args
     results = list(stats_kwargs["results"])
     assert any(res.user_id == winner.user_id and res.payout == 100 for res in results)
     assert any(res.user_id == loser.user_id and res.result == "loss" for res in results)
@@ -899,7 +900,7 @@ async def test_finalize_game_split_pot_between_tied_winners():
     assert pot_summary and pot_summary[0]["amount"] == 100
     assert {winner_info["player"] for winner_info in pot_summary[0]["winners"]} == {player_a, player_b}
 
-    _, stats_kwargs = stats.finish_hand.await_args
+    _, stats_kwargs = stats.record_hand_finished_batch.await_args
     results = list(stats_kwargs["results"])
     for result in results:
         assert result.result == "push"

--- a/tests/test_private_matchmaking.py
+++ b/tests/test_private_matchmaking.py
@@ -53,6 +53,7 @@ async def _build_model():
     table_manager = TableManager(kv)
     stats = MagicMock(spec=BaseStatsService)
     stats.start_hand = AsyncMock()
+    stats.record_hand_finished_batch = AsyncMock()
     stats.finish_hand = AsyncMock()
     stats.register_player_profile = AsyncMock()
     stats.build_player_report = AsyncMock()
@@ -169,12 +170,12 @@ async def test_private_matchmaking_reports_results_updates_stats():
     match_id = stats.start_hand.await_args.args[0]
     await model.report_private_match_result(match_id, 505)
 
-    assert stats.finish_hand.await_count == 1
-    finish_call = stats.finish_hand.await_args
-    assert finish_call.args[0] == match_id
-    results = finish_call.args[2]
+    assert stats.record_hand_finished_batch.await_count == 1
+    finish_call = stats.record_hand_finished_batch.await_args
+    assert finish_call.kwargs["hand_id"] == match_id
+    results = finish_call.kwargs["results"]
     expected_pot_total = sum(result.payout for result in results)
-    assert finish_call.args[3] == expected_pot_total == 1
+    assert finish_call.kwargs["pot_total"] == expected_pot_total == 1
     messages = [call.args[1] for call in view.send_message.await_args_list]
     assert any("برنده" in message for message in messages)
 


### PR DESCRIPTION
## Summary
- add a batched hand-finish API on the stats service and implement bulk persistence for history rows
- route reporters and private match flows through the batched writer to keep stage locks short
- add hand/stat indexes and tests that validate the batching behaviour

## Testing
- pytest tests/test_statistics_integration.py::test_finish_hand_batches_history_inserts
- pytest tests/test_private_matchmaking.py::test_private_matchmaking_reports_results_updates_stats
- pytest tests/test_game_engine_finalization.py::test_finalize_game_split_pot_between_tied_winners

------
https://chatgpt.com/codex/tasks/task_e_68dfb89a860c83289f7f72de5c3fcc6e