### PR TITLE
Defer statistics reporting outside finalize_game stage lock

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,7 @@ makes the poker logic easy to test and reason about.
 | Service | Responsibility |
 | ------- | -------------- |
 | **TableManager** | Persists `Game` snapshots in Redis, rehydrates games after bot restarts, and enforces per-chat storage isolation. |
-| **StatsService / StatsReporter** | Streams `hand_started` and `hand_finished` events into the relational database or a no-op backend, depending on configuration. |
+| **StatsService / StatsReporter** | Streams `hand_started` and `hand_finished_deferred` events into the relational database or a no-op backend, depending on configuration. |
 | **PlayerReportCache** | Provides cached leaderboard and player statistics for `/stats` requests so users see instant responses. |
 | **AdaptivePlayerReportCache** | Learns which players query stats most often and invalidates their cache entries immediately after each hand or stop vote. |
 | **PrivateMatchService** | Manages private matches, old-player reminders, and other orchestration that spans multiple hands. |
@@ -167,7 +167,7 @@ constructor arguments are:
 - `MatchmakingService` — drives stage transitions (`start_game`, `progress_stage`,
   and dealing helpers) while holding the `LockManager` stage lock.
 - `PlayerManager` — manages seating, ready prompts, and stop votes.
-- `StatsReporter` — records `hand_started`/`hand_finished` events and invalidates
+- `StatsReporter` — records `hand_started`/`hand_finished_deferred` events and invalidates
   caches for player reports.
 - `RequestMetrics` — tracks per-stage timing and request categories for logging.
 - `TelegramSafeOps` — ensures Telegram API calls are retried safely with rich

--- a/docs/diagrams/architecture_data_flow.mmd
+++ b/docs/diagrams/architecture_data_flow.mmd
@@ -29,7 +29,7 @@ flowchart LR
     ENGINE --> PM : seat/role updates
     PM --> VIEW : join prompt & anchors
     ENGINE --> VIEW : table snapshots
-    ENGINE --> STATS : hand_started / hand_finished
+    ENGINE --> STATS : hand_started / hand_finished_deferred
     STATS --> DB
     ENGINE --> METRIC : cycle tracking
     METRIC --> REDIS : counters

--- a/docs/diagrams/game_flow_sequence.mmd
+++ b/docs/diagrams/game_flow_sequence.mmd
@@ -40,6 +40,6 @@ sequenceDiagram
     Note over GE,SS: finalize_game()
     GE->>GE: finalize_game(context, game, chat)
     GE->>TG: send_showdown_results()
-    GE->>SS: hand_finished(payouts, hand_labels)
+    GE->>SS: hand_finished_deferred(payouts, hand_labels)
     GE->>TM: reset+save_game(chat_id, game)
     GE->>PM: send_join_prompt() → back to WAITING

--- a/docs/diagrams/game_flow_swimlane.puml
+++ b/docs/diagrams/game_flow_swimlane.puml
@@ -30,7 +30,7 @@ start
 |GameEngine|
 :finalize_game();
 |StatsService|
-:hand_finished(payouts);
+:hand_finished_deferred(payouts);
 |TableManager|
 :reset & save game;
 |PlayerManager|

--- a/pokerapp/stats_reporter.py
+++ b/pokerapp/stats_reporter.py
@@ -63,7 +63,7 @@ class StatsReporter:
             )
         await self.invalidate_players(game.seated_players())
 
-    async def hand_finished(
+    async def hand_finished_deferred(
         self,
         game: Game,
         chat_id: ChatId,
@@ -72,7 +72,7 @@ class StatsReporter:
         hand_labels: Dict[int, Optional[str]],
         pot_total: int,
     ) -> None:
-        """Report final hand statistics and invalidate cached player reports."""
+        """Report hand statistics outside of the stage lock."""
 
         if self._stats_enabled():
             results = self._build_hand_results(


### PR DESCRIPTION
## Summary
- capture a stats snapshot during finalize_game with the new `_prepare_hand_statistics` helper and persist it after the stage lock
- rename the StatsReporter entrypoint to `hand_finished_deferred` and harden `_record_hand_results` against reporting errors
- add regression tests for deferred writes and update documentation/diagrams to reflect the new stats flow

## Testing
- pytest tests/test_game_engine_finalization.py

------
https://chatgpt.com/codex/tasks/task_e_68dfbc3840b08328a509fad5ba610c66