### PR TITLE
Add chat-aware scoping to adaptive cache

### DIFF
--- a/pokerapp/matchmaking_service.py
+++ b/pokerapp/matchmaking_service.py
@@ -430,7 +430,9 @@ class MatchmakingService:
     ) -> Optional[Player]:
         current_player = await self._round_rate.set_blinds(game, chat_id)
         self._player_manager.assign_role_labels(game)
-        await self._stats_reporter.invalidate_players(game.players)
+        await self._stats_reporter.invalidate_players(
+            game.players, chat_id=self._safe_int(chat_id)
+        )
         return current_player
 
     async def _handle_post_start_notifications(

--- a/pokerapp/player_identity_manager.py
+++ b/pokerapp/player_identity_manager.py
@@ -122,6 +122,7 @@ class PlayerIdentityManager:
         report = await self._player_report_cache.get_with_context(
             user_id_int,
             _load_report,
+            chat_id=chat.id,
         )
         if report is None or (
             report.stats.total_games <= 0 and not report.recent_games

--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -694,6 +694,7 @@ class PokerBotModel:
             self._player_report_cache.invalidate_on_event(
                 (self._safe_int(player.user_id) for player in game.players),
                 event_type="hand_finished",
+                chat_id=self._safe_int(chat_id),
             )
 
         game.state = GameState.FINISHED

--- a/pokerapp/stats/service.py
+++ b/pokerapp/stats/service.py
@@ -868,7 +868,9 @@ class StatsService(BaseStatsService):
             and self._player_report_cache is not None
         ):
             self._player_report_cache.invalidate_on_event(
-                players_for_invalidation, event_type="hand_finished"
+                players_for_invalidation,
+                event_type="hand_finished",
+                chat_id=coerced_chat_id,
             )
 
     async def finish_hand(
@@ -914,7 +916,8 @@ class StatsService(BaseStatsService):
 
         if self._player_report_cache is not None:
             self._player_report_cache.invalidate_on_event(
-                [self._coerce_int(user_id)], event_type="bonus_claimed"
+                [self._coerce_int(user_id)],
+                event_type="bonus_claimed",
             )
 
     async def build_player_report(self, user_id: int) -> Optional[PlayerStatisticsReport]:

--- a/tests/test_game_engine_finalization.py
+++ b/tests/test_game_engine_finalization.py
@@ -590,7 +590,7 @@ async def test_record_hand_results_updates_cache_and_stats():
     engine._invalidate_adaptive_report_cache.assert_called_once()
     cache_args, cache_kwargs = engine._invalidate_adaptive_report_cache.call_args
     assert cache_args[0] == players_snapshot
-    assert cache_kwargs == {"event_type": "hand_finished"}
+    assert cache_kwargs == {"event_type": "hand_finished", "chat_id": -99}
 
     engine._stats_reporter.hand_finished_deferred.assert_awaited_once()
     _, stats_kwargs = engine._stats_reporter.hand_finished_deferred.await_args
@@ -968,7 +968,7 @@ async def test_finalize_game_single_winner_distributes_pot_and_updates_stats():
 
 
     adaptive_cache_mock.invalidate_on_event.assert_called_once_with(
-        {1, 2}, "hand_finished"
+        {1, 2}, "hand_finished", chat_id=chat_id
     )
     winner_wallet.inc.assert_awaited_once_with(100)
     loser_wallet.inc.assert_not_awaited()
@@ -1049,7 +1049,7 @@ async def test_finalize_game_split_pot_between_tied_winners():
 
 
     adaptive_cache_mock.invalidate_on_event.assert_called_once_with(
-        {10, 20}, "hand_finished"
+        {10, 20}, "hand_finished", chat_id=chat_id
     )
     wallet_a.inc.assert_awaited_once_with(50)
     wallet_b.inc.assert_awaited_once_with(50)

--- a/tests/test_game_engine_helpers.py
+++ b/tests/test_game_engine_helpers.py
@@ -99,10 +99,10 @@ async def test_refund_players_cancels_wallets_and_invalidates(game_engine_setup)
     wallet_a.cancel.assert_awaited_once_with("game-123")
     wallet_b.cancel.assert_awaited_once_with("game-123")
     game_engine_setup.adaptive_cache.invalidate_on_event.assert_called_once_with(
-        {1, 2}, "hand_finished"
+        {1, 2}, "hand_finished", chat_id=None
     )
     game_engine_setup.stats_reporter.invalidate_players.assert_awaited_once_with(
-        [player_a, player_b], event_type="hand_finished"
+        [player_a, player_b], chat_id=None, event_type="hand_finished"
     )
 
 

--- a/tests/test_matchmaking_service_helpers.py
+++ b/tests/test_matchmaking_service_helpers.py
@@ -182,7 +182,7 @@ async def test_post_blinds_assigns_roles_and_invalidates(matchmaking_setup):
     assert current is player
     matchmaking_setup.player_manager.assign_role_labels.assert_called_once_with(game)
     matchmaking_setup.stats_reporter.invalidate_players.assert_awaited_once_with(
-        game.players
+        game.players, chat_id=-300
     )
 
 


### PR DESCRIPTION
## Summary
- scope AdaptivePlayerReportCache entries by chat ID to isolate multi-chat stat lookups and persistence keys
- propagate chat context through game engine, matchmaking, stats reporter, and identity flows when invalidating caches
- expand cache tests to cover chat-specific storage and update expectations for internal bookkeeping

## Testing
- pytest tests/test_player_report_cache.py tests/test_game_engine_helpers.py tests/test_game_engine_finalization.py tests/test_matchmaking_service_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68dfc4bc5b3c8328a4827e6fc4725dbf