### PR TITLE
Finalize materialized stats polish

### DIFF
--- a/scripts/rollback_003.sql
+++ b/scripts/rollback_003.sql
@@ -8,6 +8,7 @@
 BEGIN TRANSACTION;
 
 -- Drop triggers first (dependencies)
+DROP TRIGGER IF EXISTS trg_sync_username_to_stats;
 DROP TRIGGER IF EXISTS trg_update_stats_on_hand_complete;
 DROP TRIGGER IF EXISTS trg_update_stats_on_player_result;
 
@@ -22,6 +23,8 @@ DROP TABLE IF EXISTS player_stats;
 -- Verify cleanup
 SELECT 'Rollback complete. Remaining artifacts: ' || COUNT(*) AS status
 FROM sqlite_master 
-WHERE name LIKE '%player_stats%' OR name LIKE '%update_stats%';
+WHERE name LIKE '%player_stats%' 
+   OR name LIKE '%update_stats%'
+   OR name LIKE '%sync_username%';
 
 COMMIT;

--- a/scripts/verify_materialized_stats.sh
+++ b/scripts/verify_materialized_stats.sh
@@ -37,14 +37,24 @@ echo ""
 
 # Check 3: Triggers exist
 echo "✓ Check 3: Trigger verification"
-TRIGGERS=$(sqlite3 "$DB_PATH" $'SELECT name FROM sqlite_master WHERE type=\'trigger\' AND name LIKE \'%update_stats%\';')
-echo "$TRIGGERS" | sed 's/^/    ✅ /'
-TRIGGER_COUNT=$(echo "$TRIGGERS" | wc -l)
-if [ "$TRIGGER_COUNT" -ge 2 ]; then
-    echo "  ✅ All $TRIGGER_COUNT triggers created"
+TRIGGERS=$(sqlite3 "$DB_PATH" $'SELECT name FROM sqlite_master WHERE type=\'trigger\' AND name LIKE \'%stats%\' ORDER BY name;')
+if [ -n "$TRIGGERS" ]; then
+    echo "$TRIGGERS" | sed 's/^/    ✅ /'
+fi
+TRIGGER_COUNT=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sqlite_master WHERE type='trigger' AND name LIKE '%stats%';")
+if [ "$TRIGGER_COUNT" -eq 3 ]; then
+    echo "  ✅ All 3 triggers created"
 else
-    echo "  ❌ Expected 2+ triggers, found $TRIGGER_COUNT"
+    echo "  ❌ Expected 3 triggers, found $TRIGGER_COUNT"
     exit 1
+fi
+
+TRIGGER_COUNT_SYNC=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sqlite_master WHERE type='trigger' AND name='trg_sync_username_to_stats';")
+echo "    Username sync trigger: $TRIGGER_COUNT_SYNC"
+if [ "$TRIGGER_COUNT_SYNC" -eq 1 ]; then
+    echo "  ✅ Username sync trigger exists"
+else
+    echo "  ⚠️  Username sync trigger missing"
 fi
 echo ""
 


### PR DESCRIPTION
## Summary
- clarify the materialized stats migration to emphasize global scope, guard win_rate against NULL, and add a username sync trigger
- extend the verification and rollback scripts to account for the new trigger and updated trigger counts
- refresh the deployment guide with the trigger additions, revised verification expectations, and overview context

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfe766ccfc8328932aa71160f36cec