### PR TITLE
Add stats batching infrastructure and graceful shutdown flush

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -2525,6 +2525,7 @@ class GameEngine:
         if not isinstance(stats_kwargs, dict):
             return
 
+        game_snapshot = stats_kwargs.get("game")
         try:
             await self._stats_reporter.hand_finished_deferred(**stats_kwargs)
         except Exception:
@@ -2537,7 +2538,6 @@ class GameEngine:
                         resolved_chat = int(stats_kwargs["chat_id"])  # type: ignore[arg-type]
                     except Exception:  # pragma: no cover - fallback to None
                         resolved_chat = None
-            game_snapshot = stats_kwargs.get("game")
             log_extra = {
                 "chat_id": resolved_chat,
                 "game_id": getattr(game_snapshot, "id", None),
@@ -2547,6 +2547,13 @@ class GameEngine:
                 extra=log_extra,
                 exc_info=True,
             )
+        else:
+            if self._logger.isEnabledFor(logging.DEBUG):
+                self._logger.debug(
+                    "Queued hand statistics for chat_id=%s hand_id=%s",
+                    chat_scope,
+                    getattr(game_snapshot, "id", None),
+                )
 
     async def _reset_game_state(
         self,


### PR DESCRIPTION
## Summary
- integrate StatsBatchBuffer into the stats service to buffer hand completions, add SQLite-safe migration handling, and flush batches asynchronously
- bootstrap the buffer during service construction and add debug logging when hands are queued for statistics processing
- ensure the main shutdown path always closes the stats service so buffered records flush before exit

## Testing
- pytest tests/test_statistics_integration.py
- pytest tests/test_game_engine_finalization.py

------
https://chatgpt.com/codex/tasks/task_e_68dfef91d2748328a58a95bd75fc2351