### PR TITLE
Add stats buffer toggle and document SQLite migration limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## [Unreleased]
 ### Added
 - Action-level locking for player actions to prevent duplicate callbacks (Task 6.3.2)
+- CLI flag `--skip-stats-buffer` to disable deferred statistics persistence during debugging sessions
+- Stats batch buffer metric for monitoring the average flush batch size
+
+### Known Issues
+- SQLite deployments only run the bootstrap migration (`001_create_statistics_tables.sql`).
+  Additional SQL migration files are skipped to avoid unsupported statements, so
+  use PostgreSQL or MySQL for the materialised statistics tables.
 
 ### Fixed
 - Countdown timer stability (eliminated time jumps, freezing, resumption)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ The winner is determinated by various combinations of Poker hands rank from five
   frequently rate limited or raise it if you need to burst above the default
   throughput.
 
+#### Debugging flags
+
+- Pass `--skip-stats-buffer` to `python main.py` to bypass the asynchronous
+  statistics batching buffer. This is useful when diagnosing migration issues or
+  when you want writes to hit the database immediately at the cost of higher
+  load.
+
 ### Statistics & database setup
 
 The bot ships with a production-ready statistics engine that keeps track of

--- a/main.py
+++ b/main.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
+import argparse
 import asyncio
 import os
 import sys
-from typing import Iterable, Mapping, Sequence
+from typing import Iterable, Mapping, Optional, Sequence
 
 from dotenv import load_dotenv
 
@@ -41,10 +42,21 @@ def _startup_log_extra(
     return extra
 
 
-def main() -> None:
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the Poker Telegram bot")
+    parser.add_argument(
+        "--skip-stats-buffer",
+        action="store_true",
+        help="Disable the asynchronous stats batching buffer (debugging only).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    args = parse_args(argv)
     load_dotenv()
     cfg: Config = Config()
-    services = build_services(cfg)
+    services = build_services(cfg, skip_stats_buffer=args.skip_stats_buffer)
     logger = services.logger.getChild(__name__)
 
     logger.info(

--- a/pokerapp/stats/buffer.py
+++ b/pokerapp/stats/buffer.py
@@ -68,6 +68,7 @@ class StatsBatchBuffer:
             "total_flushes": 0,
             "failed_flushes": 0,
             "avg_batch_size": 0.0,
+            "average_batch_size": 0.0,
             "max_buffer_size_reached": 0,
             "last_flush_timestamp": None,
             "last_flush_duration_ms": 0.0,
@@ -180,9 +181,11 @@ class StatsBatchBuffer:
             self.metrics["last_flush_duration_ms"] = duration_ms
             total_flushes = self.metrics["total_flushes"]
             if total_flushes:
-                self.metrics["avg_batch_size"] = (
-                    self.metrics["total_records_flushed"] / total_flushes
-                )
+                average = self.metrics["total_records_flushed"] / total_flushes
+            else:
+                average = 0.0
+            self.metrics["avg_batch_size"] = average
+            self.metrics["average_batch_size"] = average
 
         logger.info(
             "Flushed %s statistics records in %.2f ms", len(records_to_flush), duration_ms
@@ -242,6 +245,8 @@ class StatsBatchBuffer:
             total_flushed = self.metrics["total_records_flushed"]
             total_flushes = self.metrics["total_flushes"] or 1
             avg_batch = total_flushed / total_flushes
+            self.metrics["avg_batch_size"] = avg_batch
+            self.metrics["average_batch_size"] = avg_batch
         else:
             total_flushed = 0
             avg_batch = 0.0


### PR DESCRIPTION
## Summary
- add a CLI flag to skip attaching the statistics batch buffer and document the option in the README
- expose an average batch size metric from the stats buffer and log the value during shutdown
- document the SQLite migration limitation in the changelog

## Testing
- pytest tests/test_statistics_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68dff4495fa08328b03cd40f6c8d7b77