### PR TITLE
Add table-locked fold handler

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -1122,6 +1122,116 @@ class GameEngine:
 
         return result
 
+    async def handle_fold(self, chat_id: int, user_id: int) -> bool:
+        """Handle a player's fold with table-level locking and version retries."""
+
+        async def _process_once() -> Optional[bool]:
+            try:
+                game_data, version = await self._table_manager.load_game_with_version(
+                    chat_id
+                )
+            except Exception:
+                self._logger.exception(
+                    "Failed loading game for fold",
+                    extra={
+                        "event_type": "engine_fold_load_failed",
+                        "chat_id": chat_id,
+                        "user_id": user_id,
+                    },
+                )
+                return False
+
+            current_game: Optional[Game]
+            if isinstance(game_data, tuple):
+                current_game = game_data[0]
+            else:
+                current_game = game_data
+
+            if current_game is None:
+                self._logger.warning(
+                    "No active game for fold",
+                    extra={
+                        "event_type": "engine_fold_no_game",
+                        "chat_id": chat_id,
+                        "user_id": user_id,
+                    },
+                )
+                return False
+
+            player = self._find_player_by_user_id(current_game, user_id)
+            if player is None:
+                self._logger.warning(
+                    "Player not found in game during fold",
+                    extra={
+                        "event_type": "engine_fold_no_player",
+                        "chat_id": chat_id,
+                        "user_id": user_id,
+                        "game_id": getattr(current_game, "id", None),
+                    },
+                )
+                return False
+
+            try:
+                success = await self._execute_player_action(
+                    game=current_game,
+                    player=player,
+                    action="fold",
+                    amount=0,
+                )
+            except Exception:
+                self._logger.exception(
+                    "Unexpected error executing fold",
+                    extra={
+                        "event_type": "engine_fold_execute_error",
+                        "chat_id": chat_id,
+                        "user_id": user_id,
+                        "game_id": getattr(current_game, "id", None),
+                    },
+                )
+                return False
+
+            if not success:
+                return False
+
+            self.refresh_turn_deadline(current_game)
+
+            try:
+                save_success = await self._table_manager.save_game_with_version_check(
+                    chat_id,
+                    current_game,
+                    version,
+                )
+            except Exception:
+                self._logger.exception(
+                    "Failed saving game after fold",
+                    extra={
+                        "event_type": "engine_fold_save_failed",
+                        "chat_id": chat_id,
+                        "user_id": user_id,
+                        "game_id": getattr(current_game, "id", None),
+                    },
+                )
+                return False
+
+            if not save_success:
+                return None
+
+            return True
+
+        lock_manager = self._lock_manager
+
+        while True:
+            if lock_manager is None:
+                result = await _process_once()
+            else:
+                async with lock_manager.table_write_lock(chat_id):
+                    result = await _process_once()
+
+            if result is None:
+                continue
+
+            return bool(result)
+
     async def process_bet(self, chat_id: int, user_id: int, amount: int) -> bool:
         """Process a betting request with table-level locking and retries."""
 


### PR DESCRIPTION
## Summary
- add a `handle_fold` helper that performs fold handling under the table write lock
- load and save games with version tracking and retry on version conflicts during fold processing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e00f441380832885751ed17cce1a84