### PR TITLE
Improve chip update error logging

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -729,9 +729,9 @@ class GameEngine:
             player = game.seats[seat_index]
             if player is None or not hasattr(player, "wallet"):
                 logger.error(
-                    "Player missing wallet attribute",
+                    "Player object invalid or missing wallet attribute",
                     extra={
-                        "event_type": "chip_update_no_wallet",
+                        "event_type": "chip_update_player_invalid",
                         "chat_id": chat_id,
                         "user_id": user_id,
                     },
@@ -741,9 +741,9 @@ class GameEngine:
             wallet = getattr(player, "wallet", None)
             if wallet is None or not hasattr(wallet, "chips"):
                 logger.error(
-                    "Player missing wallet attribute",
+                    "Wallet object invalid or missing chips attribute",
                     extra={
-                        "event_type": "chip_update_no_wallet",
+                        "event_type": "chip_update_wallet_invalid",
                         "chat_id": chat_id,
                         "user_id": user_id,
                     },


### PR DESCRIPTION
## Summary
- differentiate chip update logging for invalid player objects versus wallets to improve diagnostics

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e019bf6c6083288be3ec5ce1a0e095