### PR TITLE
Use direct current_player_index access when refreshing turn deadlines

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -322,7 +322,7 @@ class GameEngine:
         if game is None:
             return
 
-        current_index = getattr(game, "current_player_index", -1)
+        current_index = game.current_player_index
         if not isinstance(current_index, int) or current_index < 0:
             if hasattr(game, "turn_deadline"):
                 game.turn_deadline = None


### PR DESCRIPTION
## Summary
- access `game.current_player_index` directly when refreshing the turn deadline so schema issues surface early

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0aae329a08328a2c738da86f28cf6