### PR TITLE
Remove defensive getattr defaults for pot accesses

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -995,7 +995,7 @@ class GameEngine:
             extra.update(
                 {
                     "debug_stage": getattr(getattr(game, "state", None), "name", None),
-                    "debug_pot": getattr(game, "pot", None),
+                    "debug_pot": game.pot,
                     "debug_player_snapshot": snapshot,
                 }
             )
@@ -1855,7 +1855,7 @@ class GameEngine:
                         return False
                 player.round_rate = int(getattr(player, "round_rate", 0)) + call_amount
                 player.total_bet = int(getattr(player, "total_bet", 0)) + call_amount
-                game.pot = int(getattr(game, "pot", 0)) + call_amount
+                game.pot = game.pot + call_amount
             if hasattr(player, "has_acted"):
                 player.has_acted = True
             if call_amount > 0:
@@ -1890,7 +1890,7 @@ class GameEngine:
                     return False
             player.round_rate = int(getattr(player, "round_rate", 0)) + total_amount
             player.total_bet = int(getattr(player, "total_bet", 0)) + total_amount
-            game.pot = int(getattr(game, "pot", 0)) + total_amount
+            game.pot = game.pot + total_amount
             game.max_round_rate = max(
                 int(getattr(game, "max_round_rate", 0)),
                 player.round_rate,


### PR DESCRIPTION
## Summary
- replace defensive getattr defaults for the game pot with direct attribute access to surface schema issues earlier

## Testing
- mypy pokerapp/game_engine.py --strict
- flake8 pokerapp/game_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68e0aeba8f0483289dbf635fd80f4d4b