### PR TITLE
Document emergency reset lock guard

### DIFF
--- a/docs/lock_contention_analysis.md
+++ b/docs/lock_contention_analysis.md
@@ -26,7 +26,12 @@ Because all of these were awaited while the `stage:<chat>` lock was held, parall
 
 ## Unprotected Mutations
 
-The audit identified a critical window in `_execute_player_action` where awaited wallet authorisations could run concurrently with other player requests, leading to interleaved updates of `game.pot` and betting metadata.  The Phase 2A-4 fix promotes this routine into the `stage:<chat>` guard so the betting pipeline is fully serialized while the wallet round-trips complete.
+The audit identified critical windows where concurrent operations could corrupt game state:
+
+1. **`_execute_player_action`**: Awaited wallet authorisations allowed interleaved updates of `game.pot` and betting metadata.
+2. **`emergency_reset`**: Multiple admin reset commands could execute concurrently, leading to partial cleanup or inconsistent state.
+
+The Phase 2A-4 fixes serialize both operations within the `stage:<chat>` guard so state mutations remain atomic during async I/O.
 
 ## Reset Path Races
 

--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -2602,11 +2602,13 @@ class GameEngine:
 
     async def emergency_reset(self, chat_id: int) -> None:
         """
-        Forcefully unwind timers and locks after a critical failure.
+        Force-reset game state during crash recovery or deadlock scenarios.
 
-        The post-audit implementation acquires the stage lock around the
-        crash-recovery path to avoid interleaving state resets with other
-        operations that may still be retrying.
+        Phase 2A-4 Lock Audit Fix (CRITICAL-2): acquires ``stage_lock`` to
+        prevent concurrent state mutations during emergency cleanup, ensuring
+        atomic reset even when multiple admin commands are issued simultaneously.
+
+        Ref: docs/lock_contention_analysis.md, Section "Unprotected Mutations".
         """
 
         normalized_chat = self._safe_int(chat_id)


### PR DESCRIPTION
## Summary
- expand the lock contention report to cover the emergency_reset race remediation
- document the emergency_reset stage lock acquisition inline with the other Phase 2A fixes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0f5386208832897569fe057447f5e