### PR TITLE
Document betting round timeout configuration

### DIFF
--- a/config/system_constants.json
+++ b/config/system_constants.json
@@ -6,6 +6,10 @@
   "default_rate_limit_per_minute": 20,
   "default_timezone_name": "Asia/Tehran",
   "locks": {
+    "category_timeouts_seconds": {
+      "engine_stage": 25.0,
+      "engine_stage_betting": 15.0
+    },
     "action": {
       "ttl": 10,
       "valid_types": ["fold", "check", "call", "raise"]


### PR DESCRIPTION
## Summary
- document the engine_stage_betting timeout in system_constants.json so operators can tune betting rounds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0fb6fd3808328b328c60f41102938