### PR TITLE
Increase betting round timeout configuration

### DIFF
--- a/config/system_constants.json
+++ b/config/system_constants.json
@@ -6,6 +6,10 @@
   "default_rate_limit_per_minute": 20,
   "default_timezone_name": "Asia/Tehran",
   "locks": {
+    "category_timeouts_seconds": {
+      "engine_stage": 25.0,
+      "engine_stage_betting": 30.0
+    },
     "action": {
       "ttl": 10,
       "valid_types": ["fold", "check", "call", "raise"]


### PR DESCRIPTION
## Summary
- increase the documented `engine_stage_betting` timeout to 30 seconds so the configuration extends betting rounds by 5 seconds compared to the default stage timeout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0fb6fd3808328b328c60f41102938