### PR TITLE
Add rollout health endpoint integration and telemetry

### DIFF
--- a/main.py
+++ b/main.py
@@ -185,6 +185,8 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         private_match_service=services.private_match_service,
         messaging_service_factory=services.messaging_service_factory,
         telegram_safeops_factory=services.telegram_safeops_factory,
+        feature_flags=services.feature_flags,
+        rollout_monitor=services.rollout_monitor,
     )
     try:
         if use_polling:

--- a/migrations/004_create_system_config_table.sql
+++ b/migrations/004_create_system_config_table.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS system_config (
+    key TEXT PRIMARY KEY,
+    value JSONB NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO system_config (key, value)
+SELECT 'system_constants', to_jsonb(value)
+FROM (
+    SELECT jsonb_build_object(
+        'lock_manager', jsonb_build_object(
+            'enable_fine_grained_locks', false,
+            'rollout_percentage', 0
+        )
+    ) AS value
+) AS initial
+ON CONFLICT (key) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION update_system_config_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER system_config_timestamp
+BEFORE UPDATE ON system_config
+FOR EACH ROW
+EXECUTE FUNCTION update_system_config_timestamp();

--- a/pokerapp/config.py
+++ b/pokerapp/config.py
@@ -751,7 +751,10 @@ class Config:
     def reload_system_constants(self) -> None:
         """Reload cached system constants from disk."""
 
-        self.system_constants = deepcopy(_load_system_constants())
+        global _SYSTEM_CONSTANTS
+
+        _SYSTEM_CONSTANTS = _load_system_constants()
+        self.system_constants = deepcopy(_SYSTEM_CONSTANTS)
 
     @staticmethod
     def _normalize_webhook_path(path: str) -> str:

--- a/pokerapp/feature_flags.py
+++ b/pokerapp/feature_flags.py
@@ -7,6 +7,7 @@ import hashlib
 import logging
 
 from pokerapp.config import Config
+from pokerapp.utils.request_metrics import set_rollout_percentage
 
 
 class FeatureFlagManager:
@@ -25,6 +26,11 @@ class FeatureFlagManager:
         lock_config = self._config.system_constants.get("lock_manager", {})
         self._enabled = lock_config.get("enable_fine_grained_locks", False)
         self._rollout_percentage = lock_config.get("rollout_percentage", 0)
+
+        if self._enabled:
+            set_rollout_percentage(float(self._rollout_percentage))
+        else:
+            set_rollout_percentage(0.0)
 
         self._logger.info(
             "Feature flags loaded",
@@ -77,6 +83,11 @@ class FeatureFlagManager:
                     "new_percentage": self._rollout_percentage,
                 },
             )
+
+        if self._enabled:
+            set_rollout_percentage(float(self._rollout_percentage))
+        else:
+            set_rollout_percentage(0.0)
 
 
 __all__ = ["FeatureFlagManager"]

--- a/pokerapp/utils/rollout_metrics.py
+++ b/pokerapp/utils/rollout_metrics.py
@@ -9,7 +9,10 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
-from psycopg_pool import AsyncConnectionPool
+try:  # pragma: no cover - optional dependency
+    from psycopg_pool import AsyncConnectionPool
+except Exception:  # pragma: no cover - optional dependency missing
+    AsyncConnectionPool = None  # type: ignore[assignment]
 
 from pokerapp.feature_flags import FeatureFlagManager
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ fakeredis==2.19.0
 cachetools>=5.3
 pytest-asyncio>=1.2
 PyYAML>=6.0
+prometheus-client>=0.17.0


### PR DESCRIPTION
## Summary
- wire FeatureFlagManager and a rollout monitor through the bootstrap layer so the bot can register health checks and react to database-backed rollbacks
- expose the fine-grained locks health endpoint from the webhook application and ensure configuration reloads refresh the global system constants cache
- export Prometheus gauges/counters for rollout, lock metrics, and action telemetry while updating the lock manager to feed both Prometheus and the rollout monitor
- add the system_config migration along with the prometheus-client dependency expected by the monitoring stack

## Testing
- pytest *(fails: tests/test_lock_manager.py::test_lock_manager_context_logging, tests/test_lock_manager.py::test_lock_manager_detects_reverse_lock_order, tests/test_lock_manager_fixes.py::test_fast_path_validation_rollback, tests/test_player_report_cache.py::test_default_ttl_hit_and_miss, tests/test_player_report_cache.py::test_bonus_event_applies_shorter_ttl, tests/test_player_report_cache.py::test_invalidate_on_event_records_event_specific_ttls, tests/test_player_report_cache.py::test_invalidate_on_event_triggers_loader_again, tests/test_player_report_cache.py::test_persistent_store_roundtrip, tests/test_player_report_cache.py::test_concurrent_get_uses_single_loader_call, tests/test_player_report_cache.py::test_hand_finished_event_sets_post_hand_ttl, tests/test_player_report_cache.py::test_cache_entry_expires_from_memory_and_persistent_store, tests/test_player_report_cache.py::test_unknown_event_type_falls_back_to_default_ttl, tests/test_statistics_integration.py::test_statistics_command_formats_report, tests/test_statistics_integration.py::test_statistics_command_without_history)*

------
https://chatgpt.com/codex/tasks/task_e_68e12fbd1e908328a1acca1cc690a54d