### PR TITLE
Add warnings and tests for legacy game engine signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 - `_InMemoryActionLockBackend.keys()` added for pattern-based key scanning.
 - Queue estimation enabled by default (`enable_queue_estimation: true`).
 - Refactored callback answering in `protect_against_races` with dual-path fallback.
+- `GameEngine.progress_stage()` and `GameEngine.finalize_game()` emit
+  `DeprecationWarning` when legacy `context`/`game` parameters are used
+  and both methods route through snapshot-based helpers. The
+  `finalize_game` coroutine now always returns `None`.
 
 ### Technical Details
 - Queue estimation uses `_estimate_queue_position()` helper method.
@@ -33,6 +37,8 @@
 - Action-level locking for player actions to prevent duplicate callbacks (Task 6.3.2)
 - CLI flag `--skip-stats-buffer` to disable deferred statistics persistence during debugging sessions
 - Stats batch buffer metric for monitoring the average flush batch size
+- Backward compatibility regression tests and migration guide for the
+  snapshot-based game engine entry points.
 
 ### Known Issues
 - SQLite deployments only run the bootstrap migration (`001_create_statistics_tables.sql`).

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -1,0 +1,93 @@
+# Migration Guide: Legacy Context Calls to Snapshot Workflows
+
+## Overview
+
+`GameEngine.progress_stage` and `GameEngine.finalize_game` now expose
+snapshot-based execution paths. The legacy signatures that accept
+`context` and `game` objects are still available for backwards
+compatibility, but they emit `DeprecationWarning` messages and will be
+removed in a future major release.
+
+Migrating to the new entry points keeps the critical section small,
+moves all Telegram I/O outside the stage lock, and dramatically reduces
+lock contention when several hands finish in parallel.
+
+## What Changed?
+
+### Deprecated Signatures
+
+```python
+# Legacy usage (deprecated)
+await game_engine.progress_stage(
+    context=context,
+    chat_id=chat_id,
+    game=game,
+)
+
+await game_engine.finalize_game(
+    context=context,
+    game=game,
+    chat_id=chat_id,
+)
+```
+
+### Preferred Snapshot Signatures
+
+```python
+# Snapshot usage (preferred)
+await game_engine.progress_stage(chat_id=chat_id)
+
+await game_engine.finalize_game(chat_id=chat_id)
+```
+
+## Why Switch?
+
+- **Shorter lock holds** – winner evaluation, messaging, and statistics
+  happen after the lock is released.
+- **Type safety** – dependencies are accessed through dedicated
+  protocols instead of dynamic attribute lookups.
+- **Cleaner integrations** – there is a single code path to exercise in
+  tests and during production incidents.
+
+## Migration Checklist
+
+1. **Locate legacy calls**
+
+   ```bash
+   rg "progress_stage(.*context" -g"*.py"
+   rg "finalize_game(.*context" -g"*.py"
+   ```
+
+2. **Remove `context` and `game` arguments**
+
+   ```python
+   # Before
+   await game_engine.progress_stage(context=context, chat_id=chat_id, game=game)
+
+   # After
+   await game_engine.progress_stage(chat_id=chat_id)
+   ```
+
+3. **Trim unused variables** – eliminate `context` or `game`
+   parameters that were only forwarded to the engine.
+
+4. **Run the compatibility tests**
+
+   ```bash
+   pytest tests/test_game_engine_backward_compat.py -v
+   ```
+
+## Deprecation Timeline
+
+| Version | Status            | Action Required                         |
+|---------|-------------------|-----------------------------------------|
+| 1.x     | Deprecated        | Switch to snapshot signatures           |
+| 2.0     | Removal planned   | Legacy keyword arguments will error out |
+
+## Additional Notes
+
+- The new path always requires `chat_id`.
+- `finalize_game` now returns `None`; callers should await it only for
+  side effects.
+- Legacy usage will continue to work during the deprecation window but
+  logs a warning to simplify auditing.

--- a/tests/test_game_engine_backward_compat.py
+++ b/tests/test_game_engine_backward_compat.py
@@ -1,0 +1,153 @@
+"""Backward compatibility tests for the snapshot-based game engine paths."""
+
+import warnings
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pokerapp.entities import ChatId, Game
+from pokerapp.game_engine import GameEngine
+
+
+@pytest.fixture
+def engine_dependencies() -> Dict[str, Any]:
+    async def clear_game_messages(game: Game, chat_id: ChatId, **_: Any) -> None:
+        return None
+
+    def build_identity_from_player(player: Any) -> Any:
+        return player
+
+    def safe_int(value: Any) -> int:
+        return int(value)
+
+    view = MagicMock()
+    view.send_message = AsyncMock(return_value=None)
+    view.delete_message = AsyncMock(return_value=None)
+
+    deps: Dict[str, Any] = {
+        "table_manager": MagicMock(),
+        "view": view,
+        "winner_determination": MagicMock(),
+        "request_metrics": MagicMock(),
+        "round_rate": MagicMock(),
+        "player_manager": MagicMock(),
+        "matchmaking_service": MagicMock(),
+        "stats_reporter": MagicMock(),
+        "clear_game_messages": clear_game_messages,
+        "build_identity_from_player": build_identity_from_player,
+        "safe_int": safe_int,
+        "old_players_key": "test:old_players",
+        "telegram_safe_ops": MagicMock(),
+        "lock_manager": MagicMock(),
+        "logger": MagicMock(),
+        "constants": None,
+        "adaptive_player_report_cache": None,
+        "player_factory": None,
+    }
+    return deps
+
+
+@pytest.fixture
+def game_engine(engine_dependencies: Dict[str, Any]) -> GameEngine:
+    return GameEngine(**engine_dependencies)
+
+
+@pytest.mark.asyncio
+async def test_progress_stage_legacy_path_warns(game_engine: GameEngine) -> None:
+    legacy = AsyncMock(return_value=True)
+    game_engine._progress_stage_legacy = legacy  # type: ignore[attr-defined]
+
+    context = MagicMock()
+    game = Game()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = await game_engine.progress_stage(
+            context=context,
+            chat_id=ChatId(1234),
+            game=game,
+        )
+
+    legacy.assert_awaited_once_with(
+        context=context,
+        chat_id=ChatId(1234),
+        game=game,
+    )
+    assert result is True
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, DeprecationWarning)
+
+
+@pytest.mark.asyncio
+async def test_progress_stage_requires_chat_id(game_engine: GameEngine) -> None:
+    with pytest.raises(ValueError):
+        await game_engine.progress_stage()
+
+
+@pytest.mark.asyncio
+async def test_progress_stage_snapshot_path_no_warning(game_engine: GameEngine) -> None:
+    snapshot = AsyncMock(return_value=True)
+    game_engine._progress_stage_snapshot = snapshot  # type: ignore[attr-defined]
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = await game_engine.progress_stage(chat_id=ChatId(4321))
+
+    snapshot.assert_awaited_once_with(ChatId(4321))
+    assert result is True
+    assert caught == []
+
+
+@pytest.mark.asyncio
+async def test_finalize_game_returns_none(game_engine: GameEngine) -> None:
+    finalize_snapshot = AsyncMock(return_value=True)
+    game_engine._finalize_game_snapshot = finalize_snapshot  # type: ignore[attr-defined]
+
+    result = await game_engine.finalize_game(chat_id=ChatId(999))
+
+    finalize_snapshot.assert_awaited_once_with(ChatId(999))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_finalize_game_legacy_warns(game_engine: GameEngine) -> None:
+    finalize_legacy = AsyncMock(return_value=None)
+    game_engine._finalize_game_legacy = finalize_legacy  # type: ignore[attr-defined]
+
+    context = MagicMock()
+    game = Game()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = await game_engine.finalize_game(
+            context=context,
+            game=game,
+            chat_id=ChatId(555),
+        )
+
+    finalize_legacy.assert_awaited_once_with(
+        context=context,
+        game=game,
+        chat_id=ChatId(555),
+    )
+    assert result is None
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, DeprecationWarning)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_winner_prefers_determination_service(
+    game_engine: GameEngine,
+) -> None:
+    winner = MagicMock()
+    determination = MagicMock()
+    determination.determine_winner.return_value = winner
+    game_engine._winner_selector = None  # type: ignore[attr-defined]
+    game_engine._winner_determination = determination  # type: ignore[assignment]
+
+    game = Game()
+    result = game_engine._evaluate_winner_snapshot(game)  # type: ignore[attr-defined]
+
+    determination.determine_winner.assert_called_once_with(game)
+    assert result is winner


### PR DESCRIPTION
## Summary
- add deprecation warnings and protocol-backed messaging calls to the snapshot game engine paths
- ensure `finalize_game` returns `None` and improve deferred task logging
- document the migration and cover the legacy path behaviour with regression tests

## Testing
- pytest tests/test_game_engine_backward_compat.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e13ae2022083289f7820e7a349a62d