### PR TITLE
Migrate betting flow to snapshot progress stage API

### DIFF
--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -1744,7 +1744,7 @@ class PokerBotModel:
         return True
 
     async def _process_playing(
-        self, chat_id: ChatId, game: Game, context: CallbackContext
+        self, chat_id: ChatId, game: Game
     ) -> Optional[Player]:
         """
         مغز متفکر و کنترل‌کننده اصلی جریان بازی.
@@ -1765,23 +1765,19 @@ class PokerBotModel:
         contenders = game.players_by(states=(PlayerState.ACTIVE, PlayerState.ALL_IN))
         if len(contenders) <= 1:
             should_continue = await self._game_engine.progress_stage(
-                context=context,
                 chat_id=chat_id,
-                game=game,
             )
             if should_continue:
-                return await self._process_playing(chat_id, game, context)
+                return await self._process_playing(chat_id, game)
             return None
 
         # شرط ۲: آیا دور شرط‌بندی فعلی به پایان رسیده است؟
         if self._is_betting_round_over(game):
             should_continue = await self._game_engine.progress_stage(
-                context=context,
                 chat_id=chat_id,
-                game=game,
             )
             if should_continue:
-                return await self._process_playing(chat_id, game, context)
+                return await self._process_playing(chat_id, game)
             return None
 
         # شرط ۳: بازی ادامه دارد، نوبت را به بازیکن بعدی منتقل کن
@@ -1797,12 +1793,10 @@ class PokerBotModel:
 
         # اگر هیچ بازیکن فعالی برای حرکت بعدی وجود ندارد (مثلاً همه All-in هستند)
         should_continue = await self._game_engine.progress_stage(
-            context=context,
             chat_id=chat_id,
-            game=game,
         )
         if should_continue:
-            return await self._process_playing(chat_id, game, context)
+            return await self._process_playing(chat_id, game)
         return None
 
     async def _send_turn_message(
@@ -2054,7 +2048,7 @@ class PokerBotModel:
 
                 try:
                     next_player = await self._process_playing(
-                        chat_id, current_game, context
+                        chat_id, current_game
                     )
                 except Exception:
                     logger.exception(

--- a/tests/handlers/test_betting_handlers.py
+++ b/tests/handlers/test_betting_handlers.py
@@ -1,0 +1,82 @@
+"""Regression tests for betting flow handlers.
+
+These tests exercise the poker model's betting flow helper to ensure it
+no longer relies on the deprecated ``GameEngine.progress_stage``
+signature that accepted ``context`` and ``game`` arguments.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pokerapp.pokerbotmodel import PokerBotModel
+
+
+@pytest.mark.asyncio
+async def test_progress_stage_called_with_chat_id_only_single_contender():
+    model = object.__new__(PokerBotModel)
+    progress_stage = AsyncMock(return_value=False)
+    model._game_engine = SimpleNamespace(progress_stage=progress_stage)
+    model._round_rate = SimpleNamespace(
+        _find_next_active_player_index=MagicMock(return_value=-1)
+    )
+    model._is_betting_round_over = MagicMock(return_value=False)
+
+    game = SimpleNamespace(
+        turn_message_id=None,
+        players_by=lambda states: [object()],
+        current_player_index=0,
+    )
+
+    result = await PokerBotModel._process_playing(model, chat_id=42, game=game)
+
+    assert result is None
+    progress_stage.assert_awaited_once_with(chat_id=42)
+
+
+@pytest.mark.asyncio
+async def test_progress_stage_called_with_chat_id_only_when_round_over():
+    model = object.__new__(PokerBotModel)
+    progress_stage = AsyncMock(return_value=False)
+    model._game_engine = SimpleNamespace(progress_stage=progress_stage)
+    model._round_rate = SimpleNamespace(
+        _find_next_active_player_index=MagicMock(return_value=-1)
+    )
+    model._is_betting_round_over = MagicMock(return_value=True)
+
+    game = SimpleNamespace(
+        turn_message_id=None,
+        players_by=lambda states: [object(), object()],
+        current_player_index=0,
+    )
+
+    result = await PokerBotModel._process_playing(model, chat_id=-101, game=game)
+
+    assert result is None
+    progress_stage.assert_awaited_once_with(chat_id=-101)
+
+
+@pytest.mark.asyncio
+async def test_progress_stage_called_with_chat_id_only_when_all_in():
+    model = object.__new__(PokerBotModel)
+    progress_stage = AsyncMock(return_value=False)
+    model._game_engine = SimpleNamespace(progress_stage=progress_stage)
+    model._round_rate = SimpleNamespace(
+        _find_next_active_player_index=MagicMock(return_value=-1)
+    )
+    model._is_betting_round_over = MagicMock(return_value=False)
+
+    # Two contenders so the first branch is skipped, but betting round is not
+    # over and the search for the next active player returns -1, forcing the
+    # final progress_stage call.
+    game = SimpleNamespace(
+        turn_message_id=None,
+        players_by=lambda states: [object(), object()],
+        current_player_index=0,
+    )
+
+    result = await PokerBotModel._process_playing(model, chat_id=7, game=game)
+
+    assert result is None
+    progress_stage.assert_awaited_once_with(chat_id=7)


### PR DESCRIPTION
## Summary
- update the betting flow helper to drop legacy `progress_stage` keyword arguments and rely on the snapshot signature
- remove the unused `context` parameter from `_process_playing` recursion and clean up the call site
- add regression tests that assert `progress_stage` is awaited with only the `chat_id`

## Testing
- pytest tests/handlers/test_betting_handlers.py -W error::DeprecationWarning

------
https://chatgpt.com/codex/tasks/task_e_68e14327b0148328826d6ca05c07b9e4