### PR TITLE
Implement two-phase commit betting flow

### DIFF
--- a/docs/TWO_PHASE_COMMIT_DESIGN.md
+++ b/docs/TWO_PHASE_COMMIT_DESIGN.md
@@ -1,82 +1,138 @@
-# Two-Phase Commit Protocol for Atomic Betting
+# Two-Phase Commit Betting Architecture
 
-## Overview
-This document describes the Two-Phase Commit (2PC) protocol implemented for atomic betting operations in the poker bot.
+## System Overview
 
-## Problem Statement
-**Race Condition**: Previous implementation deducted chips from wallet *before* acquiring the table lock, causing:
-- **Money loss** if game state disappeared between deduction and save
-- **Incomplete rollbacks** if compensation credits failed
-- **No audit trail** for failed transactions
+```
+┌───────────────────────────────┐        ┌──────────────────────┐
+│ Telegram Client               │        │ Wallet Repository    │
+│  (Player action)             │        │  (PostgreSQL/Redis)  │
+└──────────────┬────────────────┘        └──────────┬───────────┘
+               │                                    │
+               │ 1️⃣ Action request                 │
+               ▼                                    │
+┌───────────────────────────────┐        ┌──────────▼───────────┐
+│ BettingHandler                │        │ WalletService        │
+│  - Validate action           │        │  (Phase 1 & Phase 2) │
+│  - Coordinate locks          │        └──────────┬───────────┘
+└──────────────┬────────────────┘                   │
+               │ 2️⃣ Reserve (Phase 1)              │ 3️⃣ Debit wallet
+               ▼                                    │  Store reservation
+┌───────────────────────────────┐                   │
+│ LockManager                   │                   │
+│  - Acquire table write lock   │                   │
+└──────────────┬────────────────┘                   │
+               │ 4️⃣ Load/Validate state            │
+               ▼                                    │
+┌───────────────────────────────┐                   │
+│ GameEngine + Redis            │                   │
+│  - Load state + version       │                   │
+│  - Apply action               │◄──────────────────┘
+│  - Save with Lua CAS          │
+└──────────────┬────────────────┘
+               │ 5️⃣ Commit (Phase 2)
+               ▼
+┌───────────────────────────────┐
+│ WalletService                 │
+│  - Commit / rollback          │
+│  - DLQ on refund failure      │
+└───────────────────────────────┘
+```
 
-## Solution Architecture
+## Phase Responsibilities
 
-### Phase 1: Reserve (Outside Table Lock)
-1. Check user balance
-2. Atomically deduct chips from wallet
-3. Create reservation record
-4. Persist to Redis (durability)
-5. Schedule auto-expiry (5 min default)
+### Phase 1 – Reservation (outside lock)
+1. Validate intent using the latest snapshot.
+2. Atomically debit the wallet via the repository.
+3. Persist reservation hash in Redis with a 5-minute TTL and 30-second grace.
+4. Schedule watchdog to auto-rollback on timeout.
 
-### Phase 2: Commit (Inside Table Lock)
-1. Acquire table lock
-2. Load game state + version
-3. Validate player turn
-4. Commit reservation (mark as finalised)
-5. Apply action to game state
-6. Save with version check
-7. Release lock
+### Phase 2 – Commit (inside lock)
+1. Acquire table write lock (30s timeout).
+2. Reload game state with optimistic locking version.
+3. Confirm player turn and action legality.
+4. Commit the reservation (idempotent status flip).
+5. Apply action to state and persist via Lua compare-and-set.
 
-### Abort: Rollback
-1. Return chips to wallet
-2. Mark reservation as rolled back
-3. If refund fails → send to DLQ
+### Abort & Compensation
+- **Rollback pending reservation** – return chips and mark as `rolled_back`.
+- **Compensate committed reservation** – credit funds and mark as `rolled_back` when state persistence fails.
+- **Refund failure** – push to `wallet:dlq` with full context for manual remediation.
 
-## Guarantees
-- ✅ **Atomicity** – Chips are deducted and committed in a single atomic operation per phase; version checks prevent lost updates
-- ✅ **Durability** – Reservations persisted to Redis; DLQ ensures no money is permanently lost
-- ✅ **Isolation** – Table lock prevents concurrent modifications; optimistic locking detects conflicts
+## Error Decision Tree
 
-## Error Scenarios
-
-| Scenario | Handling |
-| --- | --- |
-| Insufficient funds | Reserve fails, no deduction |
-| Game ends before commit | Auto-rollback (5 min expiry) |
-| Version conflict during save | Compensating transaction (refund) |
-| Refund fails | DLQ entry + alert |
-| Lock timeout | Reservation auto-expires |
+```
+Start → Reserve chips?
+  ├─ No (insufficient funds) → Fail fast
+  └─ Yes → Acquire table lock → Load state?
+       ├─ No → Rollback (game_not_found)
+       └─ Yes → Player turn?
+            ├─ No → Rollback (not_players_turn)
+            └─ Yes → Commit reservation
+                 → Apply + Save state (CAS)
+                      ├─ Success → ACK
+                      └─ Conflict/Failure?
+                           ├─ Optimistic conflict → Compensating refund
+                           └─ Wallet refund failure → DLQ + alert
+```
 
 ## Performance Characteristics
-- Reserve Phase: ~50ms (DB + Redis write)
-- Commit Phase: ~200ms (inside table lock)
-- Total Lock Hold Time: ~200ms (95% reduction from 4s baseline)
 
-## Monitoring Metrics
+| Operation              | Target P95 | Notes                                      |
+|-----------------------|------------|---------------------------------------------|
+| Phase 1 Reservation   | 50 ms      | DB debit + Redis write                      |
+| Lock Hold (Phase 2)   | <200 ms    | Includes state load, validation, and save   |
+| Compensation Workflow | <300 ms    | Debit already completed, credit on failure  |
+
+Lock duration is dominated by the game state update; wallet mutation is executed outside the critical section.
+
+## Monitoring & Observability
+
+Prometheus metrics exposed via `pokerapp.metrics`:
+
 - `poker_wallet_reserve_total{status="success|insufficient_funds|error"}`
 - `poker_wallet_commit_total{status="success|not_found|error"}`
 - `poker_wallet_rollback_total{status="success|not_found|error"}`
 - `poker_wallet_dlq_total`
 - `poker_wallet_operation_duration_seconds{operation="reserve|commit|rollback"}`
+- `poker_action_duration_seconds{action="fold|check|call|raise|all_in"}`
 
-## Dead Letter Queue (DLQ)
-Failed refunds are sent to the DLQ with:
-- Reservation details
-- Error message
-- Timestamp
+### Sample Grafana Queries
 
-Manual resolution is required – ops should monitor `poker_wallet_dlq_total`.
+- **Reservation Failure Rate**
+  ```promql
+  sum(rate(poker_wallet_reserve_total{status!="success"}[5m]))
+    / sum(rate(poker_wallet_reserve_total[5m]))
+  ```
+- **Average Lock Hold Time**
+  ```promql
+  histogram_quantile(
+    0.95,
+    sum(rate(poker_wallet_operation_duration_seconds_bucket{operation="commit"}[5m]))
+      by (le)
+  )
+  ```
+- **DLQ Alert**
+  ```promql
+  increase(poker_wallet_dlq_total[1h]) > 0
+  ```
 
-## Migration Path
-1. Deploy `WalletService` + `BettingHandler`
-2. Monitor metrics for 24 hours
-3. Verify DLQ processing
-4. Roll out to all tables
+## Migration Plan
 
-## Testing Strategy
-See `tests/test_two_phase_commit.py` for:
-- Happy path (reserve → commit)
-- Insufficient funds (reserve fails)
-- Version conflict (compensating transaction)
-- Auto-expiry (rollback after timeout)
-- DLQ handling (refund failure)
+1. **Deploy Two-Phase components** – roll out `WalletService`, `BettingHandler`, and `GameEngine` enhancements behind a feature flag.
+2. **Shadow traffic** – mirror betting requests to the new handler while continuing to use legacy flow.
+3. **Cutover** – enable feature flag per table once metrics remain within SLOs for 24 hours.
+4. **Monitor** – ensure DLQ remains empty and wallet balances reconcile with historical baselines.
+
+## Rollback Strategy
+
+- Disable feature flag to revert to legacy single-phase handler.
+- Flush reservation keys via `wallet:reservation:*` to prevent orphaned records.
+- Drain DLQ entries – each record includes `reservation_id`, `user_id`, `amount`, `reason`, and timestamp to support manual reimbursement.
+
+## Operational Notes
+
+- All wallet and Redis interactions honour a 5-second timeout to prevent cascading stalls.
+- Reservation watchdog tasks self-cancel once committed or rolled back.
+- DLQ pushes log at `ERROR` level and increment `poker_wallet_dlq_total` for on-call visibility.
+- Optimistic locking ensures no lost updates even under concurrent raises or all-in actions.
+

--- a/pokerapp/metrics.py
+++ b/pokerapp/metrics.py
@@ -1,0 +1,66 @@
+"""Centralised Prometheus metric definitions for the poker application.
+
+This module intentionally performs the ``prometheus_client`` imports lazily in
+order to avoid hard dependencies during testing.  All counters and histograms
+are safe no-op stand-ins when ``prometheus_client`` is not installed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:  # pragma: no cover - Optional dependency in some execution environments
+    from prometheus_client import Counter, Histogram
+except Exception:  # pragma: no cover - provide lightweight fallbacks for tests
+
+    class _Metric:  # type: ignore[override]
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def labels(self, *_args: Any, **_kwargs: Any) -> "_Metric":
+            return self
+
+        def inc(self, *_args: Any, **_kwargs: Any) -> None:
+            return None
+
+        def observe(self, *_args: Any, **_kwargs: Any) -> None:
+            return None
+
+    Counter = Histogram = _Metric  # type: ignore[misc, assignment]
+
+
+WALLET_RESERVE_COUNTER = Counter(
+    "poker_wallet_reserve_total",
+    "Total number of wallet reservations initiated",
+    labelnames=["status"],
+)
+
+WALLET_COMMIT_COUNTER = Counter(
+    "poker_wallet_commit_total",
+    "Total number of wallet reservation commits",
+    labelnames=["status"],
+)
+
+WALLET_ROLLBACK_COUNTER = Counter(
+    "poker_wallet_rollback_total",
+    "Total number of wallet reservation rollbacks",
+    labelnames=["status"],
+)
+
+WALLET_DLQ_COUNTER = Counter(
+    "poker_wallet_dlq_total",
+    "Total number of failed refunds routed to the wallet DLQ",
+)
+
+WALLET_OPERATION_DURATION = Histogram(
+    "poker_wallet_operation_duration_seconds",
+    "Latency distribution for wallet operations",
+    labelnames=["operation"],
+)
+
+ACTION_DURATION = Histogram(
+    "poker_action_duration_seconds",
+    "Latency distribution for player betting actions",
+    labelnames=["action"],
+)
+

--- a/pokerapp/redis_client.py
+++ b/pokerapp/redis_client.py
@@ -1,0 +1,33 @@
+"""Type hints for redis client dependencies used across the poker application."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, MutableMapping, Protocol, Sequence
+
+
+class RedisClient(Protocol):
+    """Protocol describing redis operations required by the 2PC components."""
+
+    async def eval(
+        self, script: str, keys: Sequence[str], args: Sequence[Any]
+    ) -> Any:
+        ...
+
+    async def hgetall(self, key: str) -> Mapping[str, Any]:
+        ...
+
+    async def expire(self, key: str, ttl: int) -> bool:
+        ...
+
+    async def delete(self, key: str) -> int:
+        ...
+
+    async def lpush(self, key: str, value: Any) -> int:
+        ...
+
+    async def exists(self, key: str) -> bool:
+        ...
+
+    async def hset(self, key: str, mapping: MutableMapping[str, Any]) -> int:
+        ...
+

--- a/pokerapp/wallet_service.py
+++ b/pokerapp/wallet_service.py
@@ -1,372 +1,600 @@
+"""Wallet service implementing the Two-Phase Commit reservation protocol."""
+
 from __future__ import annotations
 
-"""
-Wallet Service - Two-Phase Commit Implementation
-Provides atomic chip reservation and commitment for betting operations.
-"""
-
 import asyncio
+import json
 import logging
 import time
+import uuid
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Awaitable, Mapping, Optional, Protocol, Tuple
 
-try:  # pragma: no cover - dependency optional in some environments
-    from prometheus_client import Counter, Histogram
-except Exception:  # pragma: no cover - fallback when prometheus_client missing
-    class _Metric:  # type: ignore[override]
-        def __init__(self, *args: object, **kwargs: object) -> None:
-            pass
-
-        def labels(self, *args: object, **kwargs: object) -> "_Metric":
-            return self
-
-        def inc(self, amount: float = 1.0) -> None:
-            return None
-
-        def observe(self, value: float) -> None:
-            return None
-
-    Counter = Histogram = _Metric  # type: ignore[assignment]
-
+from pokerapp.metrics import (
+    WALLET_COMMIT_COUNTER,
+    WALLET_DLQ_COUNTER,
+    WALLET_OPERATION_DURATION,
+    WALLET_RESERVE_COUNTER,
+    WALLET_ROLLBACK_COUNTER,
+)
+from pokerapp.redis_client import RedisClient
 
 logger = logging.getLogger(__name__)
 
-# Prometheus metrics
-wallet_reserve_counter = Counter(
-    "poker_wallet_reserve_total",
-    "Total chip reservations",
-    ["status"],  # success, insufficient_funds, error
-)
-wallet_commit_counter = Counter(
-    "poker_wallet_commit_total",
-    "Total reservation commits",
-    ["status"],  # success, not_found, error
-)
-wallet_rollback_counter = Counter(
-    "poker_wallet_rollback_total",
-    "Total reservation rollbacks",
-    ["status"],  # success, not_found, error
-)
-wallet_dlq_counter = Counter(
-    "poker_wallet_dlq_total",
-    "Failed refunds sent to DLQ",
-)
-wallet_operation_duration = Histogram(
-    "poker_wallet_operation_duration_seconds",
-    "Duration of wallet operations",
-    ["operation"],
-)
+
+class WalletRepository(Protocol):
+    """Persistence boundary for mutating wallet balances."""
+
+    async def get_balance(self, user_id: int, chat_id: int) -> int:
+        ...
+
+    async def debit(
+        self, user_id: int, chat_id: int, amount: int, *, metadata: Mapping[str, Any]
+    ) -> None:
+        ...
+
+    async def credit(
+        self, user_id: int, chat_id: int, amount: int, *, metadata: Mapping[str, Any]
+    ) -> None:
+        ...
 
 
-class ReservationStatus(Enum):
-    """Status of a chip reservation."""
+class DeadLetterQueue(Protocol):
+    """DLQ interface used when automated refunds fail."""
 
+    async def push(self, payload: Mapping[str, Any]) -> None:
+        ...
+
+
+class ReservationStatus(str, Enum):
     PENDING = "pending"
     COMMITTED = "committed"
     ROLLED_BACK = "rolled_back"
-    EXPIRED = "expired"
 
 
-@dataclass
-class ChipReservation:
-    """Represents a pending chip reservation."""
-
+@dataclass(frozen=True)
+class ReservationRecord:
     reservation_id: str
     user_id: int
     chat_id: int
     amount: int
-    timestamp: float
     status: ReservationStatus
-    metadata: Dict[str, Any]
+    metadata: Mapping[str, Any]
+    created_at: float
+
+
+_CREATE_RESERVATION_SCRIPT = """-- reservation_create
+local exists = redis.call('EXISTS', KEYS[1])
+if exists == 1 then
+  return 0
+end
+redis.call('HSET', KEYS[1],
+  'user_id', ARGV[1],
+  'chat_id', ARGV[2],
+  'amount', ARGV[3],
+  'status', ARGV[4],
+  'metadata', ARGV[5],
+  'created_at', ARGV[6]
+)
+redis.call('PEXPIRE', KEYS[1], ARGV[7])
+return 1
+"""
+
+
+_COMMIT_RESERVATION_SCRIPT = """-- reservation_commit
+local status = redis.call('HGET', KEYS[1], 'status')
+if not status then
+  return 'missing'
+end
+if status == 'committed' then
+  return 'committed'
+end
+if status ~= 'pending' then
+  return status
+end
+redis.call('HSET', KEYS[1], 'status', 'committed')
+redis.call('PEXPIRE', KEYS[1], ARGV[1])
+return 'ok'
+"""
+
+
+_ROLLBACK_RESERVATION_SCRIPT = """-- reservation_rollback
+local status = redis.call('HGET', KEYS[1], 'status')
+if not status then
+  return 'missing'
+end
+if status == 'rolled_back' then
+  return 'rolled_back'
+end
+if status == 'committed' then
+  if ARGV[1] == '1' then
+    redis.call('HSET', KEYS[1], 'status', 'rolled_back')
+    redis.call('HSET', KEYS[1], 'rollback_reason', ARGV[2])
+    redis.call('PEXPIRE', KEYS[1], ARGV[3])
+    return 'compensated'
+  end
+  return 'committed'
+end
+if status ~= 'pending' then
+  return status
+end
+redis.call('HSET', KEYS[1], 'status', 'rolled_back')
+redis.call('HSET', KEYS[1], 'rollback_reason', ARGV[2])
+redis.call('PEXPIRE', KEYS[1], ARGV[3])
+return 'rolled_back'
+"""
 
 
 class WalletService:
-    """Manages wallet operations with Two-Phase Commit support."""
+    """Coordinates wallet reservations for the Two-Phase Commit workflow."""
 
-    def __init__(self, db_session: Any, redis_client: Any, dlq_handler: Optional[Any] = None) -> None:
-        self.db = db_session
-        self.redis = redis_client
-        self.dlq = dlq_handler
-        self._reservations: Dict[str, ChipReservation] = {}
-        self._reservation_ttl = 300  # 5 minutes
+    _RESERVATION_KEY_TEMPLATE = "wallet:reservation:{reservation_id}"
+
+    def __init__(
+        self,
+        wallet_repository: WalletRepository,
+        redis_client: RedisClient,
+        *,
+        dlq: Optional[DeadLetterQueue] = None,
+        reservation_ttl_seconds: int = 300,
+        redis_timeout: float = 5.0,
+        wallet_timeout: float = 5.0,
+    ) -> None:
+        self._wallet_repository = wallet_repository
+        self._redis = redis_client
+        self._dlq = dlq
+        self._reservation_ttl = reservation_ttl_seconds
+        self._reservation_grace_period = 30
+        self._committed_ttl = 3600
+        self._redis_timeout = redis_timeout
+        self._wallet_timeout = wallet_timeout
+        self._watchdogs: Dict[str, asyncio.Task[None]] = {}
 
     async def reserve_chips(
         self,
         user_id: int,
         chat_id: int,
         amount: int,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
     ) -> Tuple[bool, Optional[str], str]:
-        """Phase 1: Reserve chips from user's wallet."""
+        """Phase 1 – reserve chips outside of the table lock."""
 
-        start_time = time.time()
-        reservation_id = f"res_{user_id}_{chat_id}_{int(time.time() * 1000)}"
+        start_time = time.perf_counter()
+        metadata = dict(metadata or {})
+        reservation_id = uuid.uuid4().hex
 
+        if amount <= 0:
+            WALLET_RESERVE_COUNTER.labels(status="success").inc()
+            WALLET_OPERATION_DURATION.labels(operation="reserve").observe(
+                time.perf_counter() - start_time
+            )
+            return True, reservation_id, "No chips reserved"
+
+        balance: Optional[int] = None
         try:
-            current_balance = await self._get_user_balance(user_id, chat_id)
+            balance = await self._with_timeout(
+                self._wallet_repository.get_balance(user_id, chat_id),
+                self._wallet_timeout,
+                "wallet_get_balance",
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            WALLET_RESERVE_COUNTER.labels(status="error").inc()
+            WALLET_OPERATION_DURATION.labels(operation="reserve").observe(
+                time.perf_counter() - start_time
+            )
+            logger.error(
+                "Failed to query balance for user_id=%s chat_id=%s: %s",
+                user_id,
+                chat_id,
+                exc,
+                exc_info=True,
+            )
+            return False, None, "Unable to access wallet"
 
-            if current_balance < amount:
-                wallet_reserve_counter.labels(status="insufficient_funds").inc()
-                logger.warning(
-                    "Insufficient funds for reservation %s: need=%s, have=%s",
-                    reservation_id,
-                    amount,
-                    current_balance,
-                )
-                return False, None, f"Insufficient chips: need {amount}, have {current_balance}"
+        if balance is None or balance < amount:
+            WALLET_RESERVE_COUNTER.labels(status="insufficient_funds").inc()
+            WALLET_OPERATION_DURATION.labels(operation="reserve").observe(
+                time.perf_counter() - start_time
+            )
+            logger.info(
+                "Reservation rejected due to insufficient funds",
+                extra={
+                    "reservation_id": reservation_id,
+                    "user_id": user_id,
+                    "chat_id": chat_id,
+                    "requested": amount,
+                    "balance": balance,
+                },
+            )
+            return False, None, "Insufficient chips for reservation"
 
-            reservation = ChipReservation(
-                reservation_id=reservation_id,
-                user_id=user_id,
-                chat_id=chat_id,
-                amount=amount,
-                timestamp=time.time(),
-                status=ReservationStatus.PENDING,
-                metadata=dict(metadata or {}),
+        debit_performed = False
+        try:
+            await self._with_timeout(
+                self._wallet_repository.debit(
+                    user_id, chat_id, amount, metadata=metadata
+                ),
+                self._wallet_timeout,
+                "wallet_debit",
+            )
+            debit_performed = True
+
+            record = {
+                "user_id": str(user_id),
+                "chat_id": str(chat_id),
+                "amount": str(amount),
+                "status": ReservationStatus.PENDING.value,
+                "metadata": json.dumps(metadata, default=str),
+                "created_at": str(time.time()),
+            }
+            ttl_ms = (self._reservation_ttl + self._reservation_grace_period) * 1000
+            create_result = await self._with_timeout(
+                self._redis.eval(
+                    _CREATE_RESERVATION_SCRIPT,
+                    [self._reservation_key(reservation_id)],
+                    [
+                        record["user_id"],
+                        record["chat_id"],
+                        record["amount"],
+                        record["status"],
+                        record["metadata"],
+                        record["created_at"],
+                        str(ttl_ms),
+                    ],
+                ),
+                self._redis_timeout,
+                "redis_create_reservation",
             )
 
-            await self._deduct_from_wallet(user_id, chat_id, amount)
+            if int(create_result or 0) != 1:
+                await self._with_timeout(
+                    self._wallet_repository.credit(
+                        user_id, chat_id, amount, metadata={"reason": "reservation_conflict"}
+                    ),
+                    self._wallet_timeout,
+                    "wallet_credit_on_conflict",
+                )
+                WALLET_RESERVE_COUNTER.labels(status="error").inc()
+                WALLET_OPERATION_DURATION.labels(operation="reserve").observe(
+                    time.perf_counter() - start_time
+                )
+                logger.error(
+                    "Duplicate reservation detected for %s", reservation_id
+                )
+                return False, None, "Unable to create reservation"
 
-            self._reservations[reservation_id] = reservation
-            await self._persist_reservation(reservation)
-
-            asyncio.create_task(self._auto_expire_reservation(reservation_id))
-
-            wallet_reserve_counter.labels(status="success").inc()
+            self._schedule_watchdog(reservation_id)
+            WALLET_RESERVE_COUNTER.labels(status="success").inc()
             logger.info(
-                "Reserved %s chips for user %s (reservation_id=%s)",
+                "Reserved %s chips for user_id=%s chat_id=%s reservation_id=%s",
                 amount,
                 user_id,
+                chat_id,
                 reservation_id,
             )
-
             return True, reservation_id, "Reservation successful"
+        except Exception as exc:
+            if debit_performed:
+                try:
+                    await self._with_timeout(
+                        self._wallet_repository.credit(
+                            user_id,
+                            chat_id,
+                            amount,
+                            metadata={"reason": "reservation_failure"},
+                        ),
+                        self._wallet_timeout,
+                        "wallet_credit_on_failure",
+                    )
+                except Exception:  # pragma: no cover - best effort compensation
+                    logger.exception(
+                        "Failed to compensate wallet after reservation error",
+                        extra={"reservation_id": reservation_id},
+                    )
 
-        except Exception as exc:  # pragma: no cover - defensive logging
-            wallet_reserve_counter.labels(status="error").inc()
-            logger.error(
-                "Reservation failed for %s: %s",
-                reservation_id,
-                exc,
-                exc_info=True,
+            WALLET_RESERVE_COUNTER.labels(status="error").inc()
+            logger.exception(
+                "Reservation error for reservation_id=%s", reservation_id
             )
             return False, None, f"Reservation error: {exc}"
-
         finally:
-            duration = time.time() - start_time
-            wallet_operation_duration.labels(operation="reserve").observe(duration)
+            WALLET_OPERATION_DURATION.labels(operation="reserve").observe(
+                time.perf_counter() - start_time
+            )
 
     async def commit_reservation(self, reservation_id: str) -> Tuple[bool, str]:
-        """Phase 2: Commit the reservation (finalize the bet)."""
+        """Phase 2 – finalize the reservation once the table lock is held."""
 
-        start_time = time.time()
-
+        start_time = time.perf_counter()
         try:
-            reservation = self._reservations.get(reservation_id)
+            result = await self._with_timeout(
+                self._redis.eval(
+                    _COMMIT_RESERVATION_SCRIPT,
+                    [self._reservation_key(reservation_id)],
+                    [str(self._committed_ttl * 1000)],
+                ),
+                self._redis_timeout,
+                "redis_commit_reservation",
+            )
 
-            if not reservation:
-                wallet_commit_counter.labels(status="not_found").inc()
-                logger.error("Reservation not found: %s", reservation_id)
-                return False, "Reservation not found or expired"
+            if result == "missing":
+                WALLET_COMMIT_COUNTER.labels(status="not_found").inc()
+                logger.warning("Reservation %s not found during commit", reservation_id)
+                return False, "Reservation not found"
 
-            if reservation.status is not ReservationStatus.PENDING:
-                logger.warning(
-                    "Invalid reservation status for %s: %s",
-                    reservation_id,
-                    reservation.status,
+            if result == "committed":
+                WALLET_COMMIT_COUNTER.labels(status="success").inc()
+                logger.info(
+                    "Commit idempotent for reservation_id=%s", reservation_id
                 )
-                return False, f"Reservation already {reservation.status.value}"
+                self._cancel_watchdog(reservation_id)
+                return True, "Reservation already committed"
 
-            reservation.status = ReservationStatus.COMMITTED
-            await self._persist_reservation(reservation)
+            if result != "ok":
+                WALLET_COMMIT_COUNTER.labels(status="error").inc()
+                logger.error(
+                    "Unexpected reservation status during commit: %s", result
+                )
+                return False, f"Unable to commit reservation ({result})"
 
-            del self._reservations[reservation_id]
-
-            wallet_commit_counter.labels(status="success").inc()
+            WALLET_COMMIT_COUNTER.labels(status="success").inc()
+            self._cancel_watchdog(reservation_id)
             logger.info("Committed reservation %s", reservation_id)
-
             return True, "Reservation committed"
-
         except Exception as exc:  # pragma: no cover - defensive logging
-            wallet_commit_counter.labels(status="error").inc()
-            logger.error(
-                "Commit failed for %s: %s",
-                reservation_id,
-                exc,
-                exc_info=True,
+            WALLET_COMMIT_COUNTER.labels(status="error").inc()
+            logger.exception(
+                "Commit failure for reservation_id=%s", reservation_id
             )
             return False, f"Commit error: {exc}"
-
         finally:
-            duration = time.time() - start_time
-            wallet_operation_duration.labels(operation="commit").observe(duration)
+            WALLET_OPERATION_DURATION.labels(operation="commit").observe(
+                time.perf_counter() - start_time
+            )
 
     async def rollback_reservation(
         self,
         reservation_id: str,
-        reason: str = "explicit_rollback",
+        reason: str,
+        *,
+        allow_committed: bool = False,
     ) -> Tuple[bool, str]:
-        """Abort and return reserved funds to the user."""
+        """Abort a reservation and return the chips to the player."""
 
-        start_time = time.time()
-
+        start_time = time.perf_counter()
         try:
-            reservation = self._reservations.get(reservation_id)
+            script_result = await self._with_timeout(
+                self._redis.eval(
+                    _ROLLBACK_RESERVATION_SCRIPT,
+                    [self._reservation_key(reservation_id)],
+                    [
+                        "1" if allow_committed else "0",
+                        reason,
+                        str(self._committed_ttl * 1000),
+                    ],
+                ),
+                self._redis_timeout,
+                "redis_rollback_reservation",
+            )
 
-            if not reservation:
-                wallet_rollback_counter.labels(status="not_found").inc()
+            if script_result in {"missing", None}:
+                WALLET_ROLLBACK_COUNTER.labels(status="not_found").inc()
                 logger.warning(
-                    "Rollback requested for unknown reservation: %s",
-                    reservation_id,
+                    "Rollback requested for missing reservation_id=%s", reservation_id
                 )
                 return False, "Reservation not found"
 
-            if reservation.status is not ReservationStatus.PENDING:
-                logger.warning(
-                    "Cannot rollback reservation %s with status %s",
-                    reservation_id,
-                    reservation.status,
+            if script_result == "committed" and not allow_committed:
+                WALLET_ROLLBACK_COUNTER.labels(status="error").inc()
+                logger.error(
+                    "Rollback attempted on committed reservation without permission"
                 )
-                return False, f"Reservation is {reservation.status.value}"
+                return False, "Reservation already committed"
 
-            try:
-                await self._credit_to_wallet(
-                    reservation.user_id, reservation.chat_id, reservation.amount
-                )
-
-                reservation.status = ReservationStatus.ROLLED_BACK
-                await self._persist_reservation(reservation)
-                del self._reservations[reservation_id]
-
-                wallet_rollback_counter.labels(status="success").inc()
+            if script_result == "rolled_back":
+                record = await self._load_reservation(reservation_id)
+                await self._credit_reservation_amount(record, reason)
+                WALLET_ROLLBACK_COUNTER.labels(status="success").inc()
+                self._cancel_watchdog(reservation_id)
                 logger.info(
-                    "Rolled back reservation %s due to %s",
+                    "Rolled back reservation %s for reason=%s",
                     reservation_id,
                     reason,
                 )
-
                 return True, "Reservation rolled back"
 
-            except Exception as refund_error:
-                await self._send_to_dlq(reservation, refund_error, reason)
-                wallet_dlq_counter.inc()
-                logger.critical(
-                    "REFUND FAILED for %s, sent to DLQ: %s",
+            if script_result == "compensated":
+                record = await self._load_reservation(reservation_id)
+                await self._credit_reservation_amount(record, reason)
+                WALLET_ROLLBACK_COUNTER.labels(status="success").inc()
+                self._cancel_watchdog(reservation_id)
+                logger.info(
+                    "Reservation %s compensated due to %s",
                     reservation_id,
-                    refund_error,
+                    reason,
                 )
-                return False, "Refund failed - queued for manual resolution"
+                return True, "Reservation compensated"
 
-        except Exception as exc:  # pragma: no cover - defensive logging
-            wallet_rollback_counter.labels(status="error").inc()
+            if script_result == "rolled_back":
+                WALLET_ROLLBACK_COUNTER.labels(status="success").inc()
+                return True, "Reservation already rolled back"
+
+            WALLET_ROLLBACK_COUNTER.labels(status="error").inc()
             logger.error(
-                "Rollback error for %s: %s",
+                "Unexpected rollback result %s for reservation_id=%s",
+                script_result,
                 reservation_id,
-                exc,
-                exc_info=True,
+            )
+            return False, f"Unable to rollback reservation ({script_result})"
+        except Exception as exc:  # pragma: no cover - defensive logging
+            WALLET_ROLLBACK_COUNTER.labels(status="error").inc()
+            logger.exception(
+                "Rollback failure for reservation_id=%s", reservation_id
             )
             return False, f"Rollback error: {exc}"
-
         finally:
-            duration = time.time() - start_time
-            wallet_operation_duration.labels(operation="rollback").observe(duration)
-
-    # -------------------- PRIVATE HELPERS --------------------
-
-    async def _get_user_balance(self, user_id: int, chat_id: int) -> int:
-        """Get current wallet balance from database."""
-
-        from pokerapp.models import Player  # Local import to avoid circular deps
-
-        query = self.db.query(Player).filter_by(user_id=user_id, chat_id=chat_id)
-        player = await query.first()
-        return int(getattr(player, "chips", 0)) if player else 0
-
-    async def _deduct_from_wallet(self, user_id: int, chat_id: int, amount: int) -> None:
-        """Atomically deduct chips from wallet."""
-
-        from pokerapp.models import Player  # Local import to avoid circular deps
-
-        query = (
-            self.db.query(Player)
-            .filter_by(user_id=user_id, chat_id=chat_id)
-            .with_for_update()
-        )
-        player = await query.first()
-
-        if not player or getattr(player, "chips", 0) < amount:
-            raise ValueError("Insufficient funds or player not found")
-
-        player.chips -= amount
-        await self.db.commit()
-
-    async def _credit_to_wallet(self, user_id: int, chat_id: int, amount: int) -> None:
-        """Atomically credit chips to wallet."""
-
-        from pokerapp.models import Player  # Local import to avoid circular deps
-
-        query = (
-            self.db.query(Player)
-            .filter_by(user_id=user_id, chat_id=chat_id)
-            .with_for_update()
-        )
-        player = await query.first()
-
-        if not player:
-            raise ValueError("Player not found")
-
-        player.chips += amount
-        await self.db.commit()
-
-    async def _persist_reservation(self, reservation: ChipReservation) -> None:
-        """Store reservation in Redis for durability."""
-
-        key = f"poker:reservation:{reservation.reservation_id}"
-        data = {
-            "user_id": reservation.user_id,
-            "chat_id": reservation.chat_id,
-            "amount": reservation.amount,
-            "timestamp": reservation.timestamp,
-            "status": reservation.status.value,
-            "metadata": reservation.metadata,
-        }
-        await self.redis.setex(key, self._reservation_ttl, repr(data))
-
-    async def _auto_expire_reservation(self, reservation_id: str) -> None:
-        """Automatically rollback expired reservations."""
-
-        await asyncio.sleep(self._reservation_ttl)
-
-        reservation = self._reservations.get(reservation_id)
-        if reservation and reservation.status is ReservationStatus.PENDING:
-            logger.warning("Auto-expiring reservation %s", reservation_id)
-            await self.rollback_reservation(reservation_id, reason="timeout")
-
-    async def _send_to_dlq(
-        self,
-        reservation: ChipReservation,
-        error: Exception,
-        context: str,
-    ) -> None:
-        """Send failed refund to Dead Letter Queue for manual resolution."""
-
-        if not self.dlq:
-            logger.critical(
-                "NO DLQ CONFIGURED - manual refund required: user_id=%s amount=%s",
-                reservation.user_id,
-                reservation.amount,
+            WALLET_OPERATION_DURATION.labels(operation="rollback").observe(
+                time.perf_counter() - start_time
             )
+
+    async def _credit_reservation_amount(
+        self, record: Optional[ReservationRecord], reason: str
+    ) -> None:
+        if record is None:
+            logger.error("Cannot credit reservation – record missing")
             return
 
-        dlq_entry = {
-            "reservation_id": reservation.reservation_id,
-            "user_id": reservation.user_id,
-            "chat_id": reservation.chat_id,
-            "amount": reservation.amount,
+        try:
+            await self._with_timeout(
+                self._wallet_repository.credit(
+                    record.user_id,
+                    record.chat_id,
+                    record.amount,
+                    metadata={"reason": reason, **dict(record.metadata)},
+                ),
+                self._wallet_timeout,
+                "wallet_credit_on_rollback",
+            )
+        except Exception as exc:
+            await self._handle_refund_failure(record, exc, reason)
+
+    async def _handle_refund_failure(
+        self, record: ReservationRecord, error: Exception, reason: str
+    ) -> None:
+        WALLET_DLQ_COUNTER.inc()
+        logger.error(
+            "Refund failed for reservation_id=%s – routing to DLQ",
+            record.reservation_id,
+            exc_info=True,
+        )
+
+        if self._dlq is None:
+            return
+
+        payload = {
+            "reservation_id": record.reservation_id,
+            "user_id": record.user_id,
+            "chat_id": record.chat_id,
+            "amount": record.amount,
             "error": str(error),
-            "context": context,
+            "reason": reason,
+            "metadata": dict(record.metadata),
             "timestamp": time.time(),
         }
-        await self.dlq.push(dlq_entry)
+
+        try:
+            await self._with_timeout(
+                self._dlq.push(payload),
+                self._redis_timeout,
+                "dlq_push",
+            )
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception("Failed to push reservation to DLQ", extra=payload)
+
+    async def _load_reservation(
+        self, reservation_id: str
+    ) -> Optional[ReservationRecord]:
+        try:
+            raw = await self._with_timeout(
+                self._redis.hgetall(self._reservation_key(reservation_id)),
+                self._redis_timeout,
+                "redis_load_reservation",
+            )
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception("Failed to load reservation %s", reservation_id)
+            return None
+
+        if not raw:
+            return None
+
+        metadata_str = raw.get("metadata")
+        metadata: Mapping[str, Any]
+        if isinstance(metadata_str, bytes):
+            metadata_str = metadata_str.decode("utf-8", "ignore")
+        try:
+            metadata = json.loads(metadata_str) if metadata_str else {}
+        except (TypeError, json.JSONDecodeError):
+            metadata = {}
+
+        try:
+            amount = int(raw.get("amount", 0))
+        except (TypeError, ValueError):
+            amount = 0
+
+        try:
+            created_at = float(raw.get("created_at", 0.0))
+        except (TypeError, ValueError):
+            created_at = 0.0
+
+        status_value = raw.get("status", ReservationStatus.PENDING.value)
+        if isinstance(status_value, bytes):
+            status_value = status_value.decode("utf-8", "ignore")
+
+        try:
+            status = ReservationStatus(status_value)
+        except ValueError:
+            status = ReservationStatus.PENDING
+
+        user_value = raw.get("user_id", 0)
+        chat_value = raw.get("chat_id", 0)
+        try:
+            user_id = int(user_value)
+        except (TypeError, ValueError):
+            user_id = 0
+        try:
+            chat_id = int(chat_value)
+        except (TypeError, ValueError):
+            chat_id = 0
+
+        return ReservationRecord(
+            reservation_id=reservation_id,
+            user_id=user_id,
+            chat_id=chat_id,
+            amount=amount,
+            status=status,
+            metadata=metadata,
+            created_at=created_at,
+        )
+
+    def _schedule_watchdog(self, reservation_id: str) -> None:
+        if reservation_id in self._watchdogs:
+            return
+        self._watchdogs[reservation_id] = asyncio.create_task(
+            self._auto_rollback(reservation_id)
+        )
+
+    def _cancel_watchdog(self, reservation_id: str) -> None:
+        task = self._watchdogs.pop(reservation_id, None)
+        if task is not None:
+            task.cancel()
+
+    async def _auto_rollback(self, reservation_id: str) -> None:
+        try:
+            await asyncio.sleep(self._reservation_ttl)
+            await self.rollback_reservation(
+                reservation_id,
+                "timeout",
+                allow_committed=False,
+            )
+        except asyncio.CancelledError:  # pragma: no cover - cancellation path
+            raise
+        except Exception:  # pragma: no cover - watchdog safety net
+            logger.exception(
+                "Auto rollback failed for reservation_id=%s", reservation_id
+            )
+
+    def _reservation_key(self, reservation_id: str) -> str:
+        return self._RESERVATION_KEY_TEMPLATE.format(reservation_id=reservation_id)
+
+    async def _with_timeout(
+        self, awaitable: Awaitable[Any], timeout: float, label: str
+    ) -> Any:
+        try:
+            if hasattr(asyncio, "timeout"):
+                async with asyncio.timeout(timeout):  # type: ignore[attr-defined]
+                    return await awaitable
+            return await asyncio.wait_for(awaitable, timeout)
+        except asyncio.TimeoutError as exc:
+            raise TimeoutError(f"Operation timed out: {label}") from exc
+

--- a/tests/test_two_phase_commit.py
+++ b/tests/test_two_phase_commit.py
@@ -1,236 +1,353 @@
-"""Integration tests for Two-Phase Commit betting system."""
+from __future__ import annotations
 
 import asyncio
-from typing import Any, Iterable
-from unittest.mock import AsyncMock, MagicMock
+import json
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Tuple
 
 import pytest
 
-from pokerapp.betting_handler import BettingHandler
+from pokerapp.betting_handler import BettingHandler, BettingResult
 from pokerapp.wallet_service import WalletService
 
 
-class _DummyLock:
-    async def __aenter__(self) -> None:  # pragma: no cover - trivial
-        return None
+class FakeRedisClient:
+    def __init__(self) -> None:
+        self.reservations: Dict[str, Dict[str, Any]] = {}
+        self.state_store: Dict[str, Dict[str, Any]] = {}
+        self.lists: Dict[str, List[Any]] = {}
 
-    async def __aexit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - trivial
-        return None
+    async def eval(
+        self, script: str, keys: List[str], args: List[Any]
+    ) -> Any:  # pragma: no cover - exercised via wallet service
+        key = keys[0]
+        if script.startswith("-- reservation_create"):
+            if key in self.reservations:
+                return 0
+            self.reservations[key] = {
+                "user_id": args[0],
+                "chat_id": args[1],
+                "amount": args[2],
+                "status": args[3],
+                "metadata": args[4],
+                "created_at": args[5],
+            }
+            return 1
+        if script.startswith("-- reservation_commit"):
+            record = self.reservations.get(key)
+            if not record:
+                return "missing"
+            status = record.get("status")
+            if status == "committed":
+                return "committed"
+            if status != "pending":
+                return status
+            record["status"] = "committed"
+            return "ok"
+        if script.startswith("-- reservation_rollback"):
+            record = self.reservations.get(key)
+            if not record:
+                return "missing"
+            status = record.get("status")
+            allow_committed = args[0] == "1"
+            reason = args[1]
+            if status == "rolled_back":
+                return "rolled_back"
+            if status == "committed":
+                if allow_committed:
+                    record["status"] = "rolled_back"
+                    record["rollback_reason"] = reason
+                    return "compensated"
+                return "committed"
+            if status != "pending":
+                return status
+            record["status"] = "rolled_back"
+            record["rollback_reason"] = reason
+            return "rolled_back"
+        if script.startswith("-- game_state_save"):
+            state_json, expected_version, _ttl = args
+            current = self.state_store.setdefault(key, {"version": 0, "state": "{}"})
+            current_version = int(current.get("version", 0))
+            if current_version != int(expected_version):
+                return 0
+            current["version"] = current_version + 1
+            current["state"] = state_json
+            return 1
+        raise AssertionError(f"Unexpected script execution: {script}")
+
+    async def hgetall(self, key: str) -> Mapping[str, Any]:
+        if key in self.reservations:
+            return dict(self.reservations[key])
+        if key in self.state_store:
+            store = self.state_store[key]
+            return {"state": store.get("state", "{}"), "version": store.get("version", 0)}
+        return {}
+
+    async def expire(self, key: str, ttl: int) -> bool:
+        return True
+
+    async def delete(self, key: str) -> int:
+        removed = 0
+        if key in self.reservations:
+            del self.reservations[key]
+            removed += 1
+        if key in self.state_store:
+            del self.state_store[key]
+            removed += 1
+        return removed
+
+    async def lpush(self, key: str, value: Any) -> int:
+        self.lists.setdefault(key, [])
+        self.lists[key].insert(0, value)
+        return len(self.lists[key])
+
+    async def exists(self, key: str) -> bool:
+        return key in self.reservations or key in self.state_store
+
+    async def hset(self, key: str, mapping: MutableMapping[str, Any]) -> int:
+        self.state_store[key] = dict(mapping)
+        return 1
 
 
-def _make_query_stub(result: Any) -> MagicMock:
-    stub = MagicMock()
-    stub.filter_by.return_value = stub
-    stub.with_for_update.return_value = stub
+class FakeWalletRepository:
+    def __init__(self, *, balances: Optional[Dict[Tuple[int, int], int]] = None) -> None:
+        self._balances = balances or {}
+        self.fail_credit = False
 
-    if isinstance(result, Exception):
-        async def _raise(*_args: Any, **_kwargs: Any) -> Any:
-            raise result
+    async def get_balance(self, user_id: int, chat_id: int) -> int:
+        return self._balances.get((user_id, chat_id), 0)
 
-        stub.first = AsyncMock(side_effect=_raise)
-    else:
-        stub.first = AsyncMock(return_value=result)
+    async def debit(
+        self, user_id: int, chat_id: int, amount: int, *, metadata: Mapping[str, Any]
+    ) -> None:
+        key = (user_id, chat_id)
+        balance = self._balances.get(key, 0)
+        if balance < amount:
+            raise ValueError("Insufficient funds")
+        self._balances[key] = balance - amount
 
-    return stub
+    async def credit(
+        self, user_id: int, chat_id: int, amount: int, *, metadata: Mapping[str, Any]
+    ) -> None:
+        if self.fail_credit:
+            raise RuntimeError("credit failure")
+        key = (user_id, chat_id)
+        balance = self._balances.get(key, 0)
+        self._balances[key] = balance + amount
 
 
-def _set_query_sequence(db: MagicMock, stubs: Iterable[MagicMock]) -> None:
-    db.query.side_effect = list(stubs)
+class FakeDLQ:
+    def __init__(self) -> None:
+        self.items: List[Mapping[str, Any]] = []
+
+    async def push(self, payload: Mapping[str, Any]) -> None:
+        self.items.append(dict(payload))
+
+
+class FakeGameEngine:
+    def __init__(self) -> None:
+        self._states: Dict[int, Dict[str, Any]] = {}
+        self.fail_next_save = False
+
+    def seed_state(self, chat_id: int, state: Mapping[str, Any]) -> None:
+        self._states[chat_id] = json.loads(json.dumps(state))
+
+    async def load_game_state(self, chat_id: int) -> Optional[Dict[str, Any]]:
+        state = self._states.get(chat_id)
+        if state is None:
+            return None
+        return json.loads(json.dumps(state))
+
+    async def save_game_state_with_version(
+        self, chat_id: int, state: Mapping[str, Any], *, expected_version: int
+    ) -> bool:
+        if self.fail_next_save:
+            self.fail_next_save = False
+            return False
+        current = self._states.get(chat_id)
+        current_version = int(current.get("version", 0)) if current else 0
+        if current_version != expected_version:
+            return False
+        next_state = json.loads(json.dumps(state))
+        next_state["version"] = expected_version + 1
+        self._states[chat_id] = next_state
+        return True
+
+    async def apply_betting_action(
+        self,
+        state: Mapping[str, Any],
+        user_id: int,
+        action: str,
+        amount: int,
+    ) -> Mapping[str, Any]:
+        updated = json.loads(json.dumps(state))
+        players = updated.get("players", [])
+        for player in players:
+            if int(player.get("user_id", 0)) == int(user_id):
+                if action == "fold":
+                    player["folded"] = True
+                else:
+                    player["chips"] = int(player.get("chips", 0)) - amount
+                    player["current_bet"] = int(player.get("current_bet", 0)) + amount
+                break
+        updated.setdefault("pot", 0)
+        updated["pot"] = int(updated["pot"]) + amount
+        return updated
+
+
+class FakeLockManager:
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+
+    @asynccontextmanager
+    async def acquire_table_write_lock(self, chat_id: int, timeout: Optional[float] = None):
+        async with self._lock:
+            yield
 
 
 @pytest.fixture
-def mock_db() -> MagicMock:
-    session = MagicMock()
-    session.commit = AsyncMock()
-    session.query = MagicMock()
-    return session
+def redis_client() -> FakeRedisClient:
+    return FakeRedisClient()
 
 
 @pytest.fixture
-def mock_redis() -> MagicMock:
-    redis = MagicMock()
-    redis.setex = AsyncMock()
-    redis.get = AsyncMock(return_value="1")
-    redis.eval = AsyncMock(return_value=1)
-    return redis
+def wallet_repository() -> FakeWalletRepository:
+    return FakeWalletRepository(balances={(1, 99): 1_000})
 
 
 @pytest.fixture
-def wallet_service(mock_db: MagicMock, mock_redis: MagicMock) -> WalletService:
-    service = WalletService(mock_db, mock_redis)
-    return service
+def wallet_service(
+    wallet_repository: FakeWalletRepository, redis_client: FakeRedisClient
+) -> WalletService:
+    return WalletService(wallet_repository, redis_client, dlq=FakeDLQ())
 
 
 @pytest.fixture
-def betting_handler(wallet_service: WalletService) -> BettingHandler:
-    engine = MagicMock()
-    engine.load_game_state = AsyncMock()
-    engine.load_game_state_with_version = AsyncMock()
-    engine.apply_betting_action = AsyncMock()
-    engine.save_game_state_with_version = AsyncMock()
+def game_engine() -> FakeGameEngine:
+    engine = FakeGameEngine()
+    engine.seed_state(
+        99,
+        {
+            "version": 1,
+            "current_player_id": 1,
+            "current_bet": 100,
+            "pot": 0,
+            "players": [
+                {"user_id": 1, "chips": 1_000, "current_bet": 0, "folded": False}
+            ],
+        },
+    )
+    return engine
 
-    lock_manager = MagicMock()
-    lock_manager.acquire_table_write_lock.return_value = _DummyLock()
 
-    return BettingHandler(wallet_service, engine, lock_manager)
+@pytest.fixture
+def lock_manager() -> FakeLockManager:
+    return FakeLockManager()
+
+
+@pytest.fixture
+def betting_handler(
+    wallet_service: WalletService,
+    game_engine: FakeGameEngine,
+    lock_manager: FakeLockManager,
+) -> BettingHandler:
+    return BettingHandler(wallet_service, game_engine, lock_manager)
 
 
 @pytest.mark.asyncio
-async def test_successful_bet_with_2pc(
-    betting_handler: BettingHandler, wallet_service: WalletService, mock_db: MagicMock
+async def test_happy_path_reserve_commit(
+    betting_handler: BettingHandler,
+    wallet_repository: FakeWalletRepository,
+    game_engine: FakeGameEngine,
 ) -> None:
-    user_id, chat_id = 123, 456
-    mock_player = MagicMock()
-    mock_player.chips = 1000
-
-    _set_query_sequence(
-        mock_db,
-        [
-            _make_query_stub(mock_player),
-            _make_query_stub(mock_player),
-        ],
-    )
-
-    betting_handler.engine.load_game_state.return_value = {
-        "players": [{"user_id": user_id, "chips": 1000, "current_bet": 0}],
-        "current_bet": 10,
-        "stage": "FLOP",
-    }
-    betting_handler.engine.load_game_state_with_version.return_value = {
-        "players": [{"user_id": user_id, "chips": 1000, "current_bet": 0}],
-        "current_player_id": user_id,
-        "current_bet": 10,
-        "stage": "FLOP",
-        "version": 1,
-    }
-    betting_handler.engine.apply_betting_action.return_value = {"version": 2}
-    betting_handler.engine.save_game_state_with_version.return_value = True
-
-    result = await betting_handler.handle_betting_action(user_id, chat_id, "call")
+    result = await betting_handler.handle_betting_action(1, 99, "call")
 
     assert result.success is True
-    assert "successful" in result.message.lower()
-    assert mock_player.chips == 990
+    assert wallet_repository._balances[(1, 99)] == 900
+    state = game_engine._states[99]
+    assert state["version"] == 2
+    assert state["pot"] == 100
 
 
 @pytest.mark.asyncio
-async def test_insufficient_funds_rollback(
-    betting_handler: BettingHandler, wallet_service: WalletService, mock_db: MagicMock
+async def test_insufficient_funds(
+    betting_handler: BettingHandler,
+    wallet_repository: FakeWalletRepository,
 ) -> None:
-    user_id, chat_id = 123, 456
-    mock_player = MagicMock()
-    mock_player.chips = 5
-
-    _set_query_sequence(mock_db, [_make_query_stub(mock_player)])
-
-    betting_handler.engine.load_game_state.return_value = {
-        "players": [{"user_id": user_id, "chips": 5, "current_bet": 0}],
-        "current_bet": 100,
-        "stage": "FLOP",
-    }
-
-    result = await betting_handler.handle_betting_action(user_id, chat_id, "call")
+    wallet_repository._balances[(1, 99)] = 50
+    result = await betting_handler.handle_betting_action(1, 99, "call")
 
     assert result.success is False
     assert "insufficient" in result.message.lower()
-    assert mock_player.chips == 5
+    assert wallet_repository._balances[(1, 99)] == 50
 
 
 @pytest.mark.asyncio
-async def test_version_conflict_refund(
-    betting_handler: BettingHandler, wallet_service: WalletService, mock_db: MagicMock
+async def test_version_conflict_triggers_refund(
+    betting_handler: BettingHandler,
+    wallet_repository: FakeWalletRepository,
+    game_engine: FakeGameEngine,
 ) -> None:
-    user_id, chat_id = 123, 456
-    mock_player = MagicMock()
-    mock_player.chips = 1000
+    game_engine.fail_next_save = True
+    starting_balance = wallet_repository._balances[(1, 99)]
 
-    _set_query_sequence(
-        mock_db,
-        [
-            _make_query_stub(mock_player),
-            _make_query_stub(mock_player),
-            _make_query_stub(mock_player),
-        ],
-    )
-
-    betting_handler.engine.load_game_state.return_value = {
-        "players": [{"user_id": user_id, "chips": 1000, "current_bet": 0}],
-        "current_bet": 10,
-        "stage": "FLOP",
-    }
-    betting_handler.engine.load_game_state_with_version.return_value = {
-        "players": [{"user_id": user_id, "chips": 1000, "current_bet": 0}],
-        "current_player_id": user_id,
-        "current_bet": 10,
-        "version": 1,
-    }
-    betting_handler.engine.apply_betting_action.return_value = {"version": 2}
-    betting_handler.engine.save_game_state_with_version.return_value = False
-
-    result = await betting_handler.handle_betting_action(user_id, chat_id, "call")
+    result = await betting_handler.handle_betting_action(1, 99, "call")
 
     assert result.success is False
     assert "conflict" in result.message.lower()
-    assert mock_player.chips == 1000
+    assert wallet_repository._balances[(1, 99)] == starting_balance
 
 
 @pytest.mark.asyncio
-async def test_reservation_auto_expiry(
-    wallet_service: WalletService, mock_db: MagicMock
+async def test_auto_rollback_on_timeout(
+    wallet_service: WalletService,
+    wallet_repository: FakeWalletRepository,
 ) -> None:
-    user_id, chat_id = 123, 456
-    mock_player = MagicMock()
-    mock_player.chips = 1000
-
     wallet_service._reservation_ttl = 0.1
+    wallet_service._reservation_grace_period = 0
 
-    _set_query_sequence(
-        mock_db,
-        [
-            _make_query_stub(mock_player),
-            _make_query_stub(mock_player),
-            _make_query_stub(mock_player),
-        ],
+    success, reservation_id, _ = await wallet_service.reserve_chips(
+        1, 99, 100, metadata={}
     )
-
-    success, reservation_id, _ = await wallet_service.reserve_chips(user_id, chat_id, 100)
     assert success is True
-    assert reservation_id in wallet_service._reservations
-
+    assert reservation_id is not None
     await asyncio.sleep(0.2)
-
-    assert reservation_id not in wallet_service._reservations
-    assert mock_player.chips == 1000
+    assert wallet_repository._balances[(1, 99)] == 1_000
 
 
 @pytest.mark.asyncio
 async def test_dlq_on_refund_failure(
-    wallet_service: WalletService, mock_db: MagicMock, mock_redis: MagicMock
+    wallet_repository: FakeWalletRepository,
+    redis_client: FakeRedisClient,
 ) -> None:
-    user_id, chat_id = 123, 456
-    mock_player = MagicMock()
-    mock_player.chips = 1000
-
-    mock_dlq = AsyncMock()
-    wallet_service.dlq = mock_dlq
-
-    _set_query_sequence(
-        mock_db,
-        [
-            _make_query_stub(mock_player),
-            _make_query_stub(mock_player),
-            _make_query_stub(Exception("DB error")),
-        ],
+    dlq = FakeDLQ()
+    service = WalletService(wallet_repository, redis_client, dlq=dlq)
+    wallet_repository.fail_credit = True
+    success, reservation_id, _ = await service.reserve_chips(
+        1, 99, 100, metadata={}
     )
-
-    success, reservation_id, _ = await wallet_service.reserve_chips(user_id, chat_id, 100)
     assert success is True
+    await service.rollback_reservation(reservation_id or "", "test", allow_committed=True)
+    assert dlq.items
+    entry = dlq.items[0]
+    assert entry["amount"] == 100
+    assert entry["reason"] == "test"
 
-    rollback_success, message = await wallet_service.rollback_reservation(reservation_id)
 
-    assert rollback_success is False
-    assert "refund" in message.lower()
-    mock_dlq.push.assert_awaited_once()
-    dlq_entry = mock_dlq.push.await_args.args[0]
-    assert dlq_entry["user_id"] == user_id
-    assert dlq_entry["amount"] == 100
+@pytest.mark.asyncio
+async def test_idempotent_commit(
+    wallet_service: WalletService,
+) -> None:
+    wallet_service._reservation_grace_period = 0
+    success, reservation_id, _ = await wallet_service.reserve_chips(
+        1, 99, 50, metadata={}
+    )
+    assert success is True and reservation_id
+
+    commit_first = await wallet_service.commit_reservation(reservation_id or "")
+    commit_second = await wallet_service.commit_reservation(reservation_id or "")
+
+    assert commit_first[0] is True
+    assert commit_second[0] is True
+


### PR DESCRIPTION
## Summary
- implement Redis-backed wallet reservation service with metrics, DLQ handling, and watchdog expiry
- orchestrate two-phase betting handler with optimistic locking and compensating rollbacks
- extend game engine with Redis versioned state helpers and refresh documentation for operations

## Testing
- `pytest tests/test_two_phase_commit.py`


------
https://chatgpt.com/codex/tasks/task_e_68e2781d9720832da9cc3c46bba66b92