### PR TITLE
Fix lock metric definitions

### DIFF
--- a/pokerapp/metrics.py
+++ b/pokerapp/metrics.py
@@ -64,24 +64,6 @@ ACTION_DURATION = Histogram(
     labelnames=["action"],
 )
 
-LOCK_RETRY_TOTAL = Counter(
-    "poker_lock_retry_total",
-    "Lock retry attempts",
-    labelnames=["outcome"],
-)
-
-LOCK_QUEUE_DEPTH = Histogram(
-    "poker_lock_queue_depth",
-    "Number of operations waiting for table lock",
-    buckets=[0, 1, 2, 3, 4, 5, 8, 10, 15],
-)
-
-LOCK_WAIT_DURATION = Histogram(
-    "poker_lock_wait_duration_seconds",
-    "Time spent waiting for lock acquisition",
-    buckets=[0.1, 0.5, 1, 2, 5, 10, 15, 20, 25, 30],
-)
-
 # ============================================================================
 # PHASE 2: SMART LOCK RETRY METRICS
 # ============================================================================


### PR DESCRIPTION
## Summary
- remove the outdated lock metric definitions that used incorrect bucket configurations so only the required versions remain

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e28a0ec668832dabc1532c76d56516