### PR TITLE
Remove redundant local random import in lock manager

### DIFF
--- a/pokerapp/lock_manager.py
+++ b/pokerapp/lock_manager.py
@@ -3687,7 +3687,6 @@ class LockManager:
         base_estimate = queue_depth * SECONDS_PER_OPERATION
 
         # Add ±10% jitter to avoid thundering herd on retries
-        import random
         jitter_factor = random.uniform(0.9, 1.1)
 
         estimated_seconds = base_estimate * jitter_factor


### PR DESCRIPTION
## Summary
- remove the redundant in-function random import in the lock manager

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e28bbdac4c832d8d8f6b8d2e870daf