### PR TITLE
Adopt table write lock helper and harden fine-grained locking tests

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -777,7 +777,7 @@ class GameEngine:
             if lock_manager is None:
                 result = await _process_once()
             else:
-                async with lock_manager.table_write_lock(chat_id):
+                async with lock_manager.acquire_table_write_lock(chat_id):
                     result = await _process_once()
 
             if result is None:
@@ -879,7 +879,7 @@ class GameEngine:
             if lock_manager is None:
                 result = await _process_once()
             else:
-                async with lock_manager.table_write_lock(chat_id):
+                async with lock_manager.acquire_table_write_lock(chat_id):
                     result = await _process_once()
 
             if result is not None:
@@ -1013,7 +1013,7 @@ class GameEngine:
             if lock_manager is None:
                 result = await _process_once()
             else:
-                async with lock_manager.table_write_lock(chat_id):
+                async with lock_manager.acquire_table_write_lock(chat_id):
                     result = await _process_once()
 
             if result is not None:
@@ -1861,7 +1861,7 @@ class GameEngine:
             if lock_manager is None:
                 result = await _process_once()
             else:
-                async with lock_manager.table_write_lock(chat_id):
+                async with lock_manager.acquire_table_write_lock(chat_id):
                     result = await _process_once()
 
             if result is None:


### PR DESCRIPTION
## Summary
- update the GameEngine retry loops to use `LockManager.acquire_table_write_lock` instead of the legacy helper
- refresh the fine-grained locking integration fixture to mimic persisted state while testing concurrent actions

## Testing
- pytest tests/test_fine_grained_locking.py -q


------
https://chatgpt.com/codex/tasks/task_e_68e29a936ba8832da1ba42da1c98e287