### PR TITLE
Enable PTB signal handlers for webhook

### DIFF
--- a/pokerapp/pokerbot.py
+++ b/pokerapp/pokerbot.py
@@ -133,6 +133,8 @@ class PokerBot:
                 allowed_updates=settings.allowed_updates,
                 drop_pending_updates=settings.drop_pending_updates,
                 max_connections=settings.max_connections,
+                # Enable graceful shutdown by letting PTB install signal handlers.
+                signal_handlers=True,
             )
         except Exception:
             self._logger.exception("Webhook run terminated due to an error.")


### PR DESCRIPTION
## Summary
- enable the Telegram webhook runner to install signal handlers for graceful shutdowns

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e34635296c832db904a9ffb3c97fcc