### PR TITLE
Fix flake8 indentation in deferred tasks logging

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -3297,8 +3297,8 @@ class GameEngine:
                             "error": str(exc),
                             "error_type": type(exc).__name__,
                             "stage": snapshot.stage,
-                    },
-                )
+                        },
+                    )
 
         delete_task_count = len(tasks)
 


### PR DESCRIPTION
## Summary
- adjust indentation of deferred task logging cleanup to satisfy flake8

## Testing
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68e351b0fc10832d8a602089ab567471