### PR TITLE
Remove deprecated signal_handlers argument from webhook runner

### DIFF
--- a/pokerapp/pokerbot.py
+++ b/pokerapp/pokerbot.py
@@ -133,8 +133,6 @@ class PokerBot:
                 allowed_updates=settings.allowed_updates,
                 drop_pending_updates=settings.drop_pending_updates,
                 max_connections=settings.max_connections,
-                # Enable graceful shutdown by letting PTB install signal handlers.
-                signal_handlers=True,
             )
         except Exception:
             self._logger.exception("Webhook run terminated due to an error.")


### PR DESCRIPTION
## Summary
- remove the deprecated `signal_handlers` argument from the webhook runner to match the PTB v20+ API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e370011808832db53cd53790ae095f