### PR TITLE
Allow configuring metrics server host via environment variable

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,9 +59,12 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     cfg: Config = Config()
 
     metrics_port = int(os.getenv("POKERBOT_METRICS_PORT", "8000"))
-    if start_metrics_server(metrics_port):
+    metrics_host = os.getenv("POKERBOT_METRICS_HOST")
+    if start_metrics_server(metrics_port, host=metrics_host):
+        display_host = metrics_host or "localhost"
         print(
-            f"✅ Prometheus metrics available at http://localhost:{metrics_port}/metrics"
+            "✅ Prometheus metrics available at "
+            f"http://{display_host}:{metrics_port}/metrics"
         )
     else:
         print(f"⚠️  Failed to start metrics server on port {metrics_port}")


### PR DESCRIPTION
## Summary
- allow the metrics server bootstrapper to bind to a configured host and log metadata about the binding
- read an optional POKERBOT_METRICS_HOST value during startup and include it in the console message when metrics start successfully

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e410fb2a90832d9de654eea372f2c0