### PR TITLE
Fix countdown monotonic handling and manager lifecycle

### DIFF
--- a/pokerapp/countdown_manager.py
+++ b/pokerapp/countdown_manager.py
@@ -247,7 +247,7 @@ class SmartCountdownManager:
         """Main countdown loop using monotonic clock to prevent second jumps"""
         try:
             start_time = time.monotonic()
-            end_time = time.monotonic() + duration
+            end_time = start_time + duration
             last_reported_second = duration
             if duration <= 0:
                 last_reported_second += 1
@@ -263,7 +263,16 @@ class SmartCountdownManager:
                 if remaining != last_reported_second:
                     last_reported_second = remaining
 
-                    current_state = self._countdown_states[chat_id]
+                    current_state = self._countdown_states.get(chat_id)
+                    if current_state is None:
+                        self.logger.debug(
+                            "Countdown state disappeared mid-loop; cancelling",
+                            extra={
+                                'event_type': 'countdown_state_missing',
+                                'chat_id': chat_id,
+                            },
+                        )
+                        break
 
                     new_state = CountdownState(
                         chat_id=current_state.chat_id,

--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -468,10 +468,7 @@ class GameEngine:
                     redis_client=redis_client,
                     logger=countdown_logger or logger,
                 )
-                # CRITICAL FIX: Start the batch worker
-                if self._smart_countdown_manager is not None:
-                    asyncio.create_task(self._smart_countdown_manager.start())
-                    self._logger.info("SmartCountdownManager initialized and started")
+                self._logger.info("SmartCountdownManager initialized")
             except Exception:
                 self._logger.warning(
                     "Failed to initialize SmartCountdownManager", exc_info=True


### PR DESCRIPTION
## Summary
- use a single monotonic baseline in the countdown loop and guard against missing state mid-iteration
- simplify countdown manager initialization by deferring `start()` to the engine lifecycle while keeping logging intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4a01dd590832d94d2691de5580ec8