### PR TITLE
Refactor countdown handling to SmartCountdownManager

### DIFF
--- a/tests/test_pokerbotmodel.py
+++ b/tests/test_pokerbotmodel.py
@@ -711,9 +711,9 @@ async def test_auto_start_tick_starts_prestart_countdown_and_updates_state():
     assert countdown_call.kwargs["seconds"] == 5
     payload_fn = countdown_call.kwargs["payload_fn"]
     initial_text = game.ready_message_main_text
-    assert "5 ثانیه" in initial_text
+    assert "⏰ زمان باقی‌مانده: *۵* ثانیه" in initial_text
     preview_text, _ = payload_fn(3)
-    assert "3 ثانیه" in preview_text
+    assert "⏰ زمان باقی‌مانده: *۳* ثانیه" in preview_text
     state = context.chat_data[KEY_START_COUNTDOWN_CONTEXT][(chat_id, str(game.id))]
     assert state["seconds"] == 4
     assert state["active"] is True


### PR DESCRIPTION
## Summary
- remove the legacy countdown task machinery from `PokerBotViewer` and replace it with no-op stubs that defer to SmartCountdownManager
- update the ready-message countdown builder to render the new progress-bar format with Persian digits
- route pre-start countdown start/cancel flows in `GameEngine` through SmartCountdownManager and refresh tests for the new UI

## Testing
- pytest tests/test_pokerbotmodel.py -k countdown -q

------
https://chatgpt.com/codex/tasks/task_e_68e522cd5524832db7b23d41f2cca321