### PR TITLE
Fix circular import between pokerbotmodel and countdown_manager

### DIFF
--- a/pokerapp/countdown_manager.py
+++ b/pokerapp/countdown_manager.py
@@ -9,7 +9,7 @@ from contextlib import suppress
 
 from telegram.error import TelegramError
 
-from pokerapp.pokerbotmodel import PERSIAN_DIGIT_MAP
+from pokerapp.utils.locale_utils import to_persian_digits
 
 
 @dataclass
@@ -482,10 +482,10 @@ class SmartCountdownManager:
         percentage = int(progress * 100)
 
         # Persian number conversion using the shared translation map
-        remaining_fa = str(state.remaining_seconds).translate(PERSIAN_DIGIT_MAP)
-        players_fa = str(state.player_count).translate(PERSIAN_DIGIT_MAP)
-        pot_fa = str(state.pot_size).translate(PERSIAN_DIGIT_MAP)
-        pct_fa = str(percentage).translate(PERSIAN_DIGIT_MAP)
+        remaining_fa = to_persian_digits(state.remaining_seconds)
+        players_fa = to_persian_digits(state.player_count)
+        pot_fa = to_persian_digits(state.pot_size)
+        pct_fa = to_persian_digits(percentage)
 
         return f"""
 🎮 <b>بازی در حال شروع...</b>

--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -79,8 +79,7 @@ from pokerapp.utils.telegram_safeops import TelegramSafeOps
 from pokerapp.stats_reporter import StatsReporter
 from pokerapp.translations import translate
 from pokerapp.query_optimizer import QueryBatcher
-
-PERSIAN_DIGIT_MAP = str.maketrans("0123456789", "۰۱۲۳۴۵۶۷۸۹")
+from pokerapp.utils.locale_utils import PERSIAN_DIGIT_MAP, to_persian_digits
 
 _GAME_CONSTANTS = get_game_constants()
 _GAME_SECTION = _GAME_CONSTANTS.game
@@ -1075,8 +1074,8 @@ class PokerBotModel:
             ascii_empty = "░" * max(0, (empty * 2) - len(ascii_pulse))
             ascii_bar = ascii_filled + ascii_pulse + ascii_empty
             percentage = int(progress_ratio * 100)
-            remaining_fa = str(seconds_remaining).translate(PERSIAN_DIGIT_MAP)
-            pct_fa = str(percentage).translate(PERSIAN_DIGIT_MAP)
+            remaining_fa = to_persian_digits(seconds_remaining)
+            pct_fa = to_persian_digits(percentage)
             lines.append("🎯 *شمارش معکوس شروع بازی*")
             lines.append("")
             lines.append(bar_emojis)

--- a/pokerapp/utils/locale_utils.py
+++ b/pokerapp/utils/locale_utils.py
@@ -1,0 +1,26 @@
+"""Locale-specific helpers for presenting numbers."""
+
+from __future__ import annotations
+
+from typing import Union
+
+NumberLike = Union[int, float, str]
+
+PERSIAN_DIGIT_MAP = str.maketrans("0123456789", "۰۱۲۳۴۵۶۷۸۹")
+
+
+def to_persian_digits(value: NumberLike) -> str:
+    """Convert ASCII digits in *value* to Persian digits.
+
+    Args:
+        value: The value whose digits should be translated. Non-string values
+            are converted to ``str`` before translation.
+
+    Returns:
+        The string representation of ``value`` with Persian numerals.
+    """
+
+    return str(value).translate(PERSIAN_DIGIT_MAP)
+
+
+__all__ = ["PERSIAN_DIGIT_MAP", "to_persian_digits"]


### PR DESCRIPTION
## Summary
- extract the Persian digit translation map into a dedicated locale utility module
- update countdown manager and poker bot model to consume the shared helper and avoid cross-imports

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e52c2bfce4832dac3f9db092e16606