### PR TITLE
Add timeout to Redis loop validation and log client initialization

### DIFF
--- a/pokerapp/bootstrap.py
+++ b/pokerapp/bootstrap.py
@@ -275,6 +275,15 @@ def build_services(cfg: Config, *, skip_stats_buffer: bool = False) -> Applicati
             recovery_logger.exception("Failed to close recovery Redis client")
 
     kv_async = _create_redis_client(redis_client_kwargs)
+    logger.info(
+        "Redis client initialized with lazy connection",
+        extra={
+            "event_type": "redis_client_created",
+            "host": cfg.REDIS_HOST,
+            "port": cfg.REDIS_PORT,
+            "health_check_interval": 30,
+        },
+    )
 
     cache_logger = _make_service_logger(logger, "cache", "cache")
     cache_config = CacheConfig(

--- a/pokerapp/utils/redis_safeops.py
+++ b/pokerapp/utils/redis_safeops.py
@@ -154,7 +154,7 @@ class RedisSafeOps:
 
         if not self._loop_validated:
             try:
-                await self._redis.ping()
+                await asyncio.wait_for(self._redis.ping(), timeout=2.0)
             except Exception as exc:
                 self._logger.error(
                     "Redis connection validation failed",


### PR DESCRIPTION
## Summary
- add a timeout to the Redis ping loop validation to avoid hangs when Redis is unresponsive
- log the creation of the primary Redis client with context for production observability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e533a0a9ac832db5bedd6cabc224d3