### PR TITLE
Cache countdown message id on send

### DIFF
--- a/pokerapp/countdown_manager.py
+++ b/pokerapp/countdown_manager.py
@@ -641,6 +641,9 @@ class SmartCountdownManager:
             parse_mode='HTML'
         )
 
+        # Cache anchor message id for future updates
+        self._countdown_messages[state.chat_id] = message.message_id
+
         self._metrics['updates_sent'] += 1
         return message
 


### PR DESCRIPTION
## Summary
- ensure `_send_countdown_message` stores the countdown message id immediately after sending so later updates can reference it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e544b01144832daa6993f41f463aeb