### PR TITLE
Clarify countdown restart logging

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -638,19 +638,19 @@ class GameEngine:
                     return
 
                 self._logger.info(
-                    "Countdown update returned False, starting new countdown",
+                    "Countdown update returned False, restarting",
                     extra={
-                        "event_type": "countdown_update_failed_restart",
+                        "event_type": "countdown_update_false_restart",
                         "chat_id": chat_id,
                         "trigger": trigger,
                     },
                 )
             except Exception:
                 self._logger.warning(
-                    "Failed to update countdown display",
+                    "Countdown update raised exception, restarting",
                     extra={
                         "chat_id": chat_id,
-                        "event_type": "countdown_update_failed",
+                        "event_type": "countdown_update_exception_restart",
                         "trigger": trigger,
                     },
                     exc_info=True,


### PR DESCRIPTION
## Summary
- clarify the log message when a countdown update returns False so the restart is explicit
- add a dedicated event type and clearer warning message when the countdown update raises an exception before restarting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e54ac01440832da3178e370896f6cb