### PR TITLE
Use Persian countdown progress bar for countdown displays

### DIFF
--- a/pokerapp/countdown_manager.py
+++ b/pokerapp/countdown_manager.py
@@ -675,39 +675,27 @@ class SmartCountdownManager:
         Generate the visual countdown message
         Using PERSIAN THEMED design (most eye-catching)
         """
-        # Progress calculation
-        progress = state.remaining_seconds / state.total_seconds
-        filled = int(progress * 15)
-        empty = 15 - filled
+        total_seconds = max(state.total_seconds, 1)
+        remaining_seconds = max(0, min(state.remaining_seconds, total_seconds))
+        progress_ratio = remaining_seconds / total_seconds if total_seconds else 0
 
-        # Dynamic emoji based on urgency
-        if state.remaining_seconds == 0:
-            emoji = '🚀'
+        filled_blocks = max(0, min(20, int(progress_ratio * 20)))
+        empty_blocks = 20 - filled_blocks
+
+        if remaining_seconds == 0:
             urgency_msg = '<b>🎮 بازی شروع شد!</b>'
-        elif state.remaining_seconds <= 3:
-            emoji = '🔥'
+        elif remaining_seconds <= 3:
             urgency_msg = '<b>🔥 آخرین فرصت!</b>'
-        elif state.remaining_seconds <= 10:
-            emoji = '🟨'
+        elif remaining_seconds <= 10:
             urgency_msg = '⚡ عجله کنید!'
         else:
-            emoji = '🟩'
             urgency_msg = '⚡ برای پیوستن /join را بزنید!'
 
-        # Build progress bar
-        bar_emojis = (emoji * filled) + ('⬜' * empty)
-
-        # ASCII progress bar
-        ascii_filled = '█' * (filled * 2)
-        ascii_pulse = '▓' if state.remaining_seconds <= 10 else ''
-        ascii_bar = (
-            ('█' * (filled * 2)) + ascii_pulse + ('░' * max((empty * 2) - len(ascii_pulse), 0))
-        )
-
-        percentage = int(progress * 100)
+        percentage = max(0, min(100, int(progress_ratio * 100)))
+        bar = ('█' * filled_blocks) + ('░' * empty_blocks)
 
         # Persian number conversion using the shared translation map
-        remaining_fa = to_persian_digits(state.remaining_seconds)
+        remaining_fa = to_persian_digits(remaining_seconds)
         players_fa = to_persian_digits(state.player_count)
         pot_fa = to_persian_digits(state.pot_size)
         pct_fa = to_persian_digits(percentage)
@@ -717,8 +705,7 @@ class SmartCountdownManager:
 
 ⏰ زمان باقی‌مانده: <b>{remaining_fa}</b> ثانیه
 
-{bar_emojis}
-<code>{ascii_bar}</code> {pct_fa}٪
+{bar} {pct_fa}٪
 
 👥 بازیکنان: <b>{players_fa}</b> نفر
 💰 پات: <b>{pot_fa}</b> سکه

--- a/pokerapp/pokerbotmodel.py
+++ b/pokerapp/pokerbotmodel.py
@@ -1053,33 +1053,24 @@ class PokerBotModel:
             resolved_total = max(resolved_total, 1)
             seconds_remaining = min(seconds_remaining, resolved_total)
             progress_ratio = seconds_remaining / resolved_total
-            segments = 15
-            filled = min(segments, max(0, int(progress_ratio * segments)))
-            empty = segments - filled
+            progress_ratio = max(0.0, min(1.0, progress_ratio))
+            filled_blocks = max(0, min(20, int(progress_ratio * 20)))
+            empty_blocks = 20 - filled_blocks
             if seconds_remaining == 0:
-                emoji = "🚀"
                 urgency_line = "🚀 *بازی شروع شد!*"
             elif seconds_remaining <= 3:
-                emoji = "🔥"
                 urgency_line = "🔥 *آخرین فرصت!*"
             elif seconds_remaining <= 10:
-                emoji = "🟨"
                 urgency_line = "⚡ عجله کنید!"
             else:
-                emoji = "🟩"
                 urgency_line = "⚡ برای پیوستن /join را بزنید!"
-            bar_emojis = (emoji * filled) + ("⬜" * empty)
-            ascii_filled = "█" * (filled * 2)
-            ascii_pulse = "▓" if 0 < seconds_remaining <= 10 else ""
-            ascii_empty = "░" * max(0, (empty * 2) - len(ascii_pulse))
-            ascii_bar = ascii_filled + ascii_pulse + ascii_empty
-            percentage = int(progress_ratio * 100)
+            bar = ("█" * filled_blocks) + ("░" * empty_blocks)
+            percentage = max(0, min(100, int(progress_ratio * 100)))
             remaining_fa = to_persian_digits(seconds_remaining)
             pct_fa = to_persian_digits(percentage)
             lines.append("🎯 *شمارش معکوس شروع بازی*")
             lines.append("")
-            lines.append(bar_emojis)
-            lines.append(f"`{ascii_bar}` {pct_fa}٪")
+            lines.append(f"{bar} {pct_fa}٪")
             lines.append("")
             lines.append(f"⏰ زمان باقی‌مانده: *{remaining_fa}* ثانیه")
             lines.append(urgency_line)


### PR DESCRIPTION
## Summary
- remove the emoji-based countdown bar rendering in the countdown manager and replace it with the Persian block style
- update the poker bot model countdown preview to reuse the same Persian progress bar layout and digit formatting

## Testing
- pytest *(fails: existing lock hierarchy and redis_safeops tests in the suite, see log)*

------
https://chatgpt.com/codex/tasks/task_e_68e551c5eeb0832d89d1aed39475a1dc