### PR TITLE
Reduce countdown diagnostic noise

### DIFF
--- a/pokerapp/countdown_manager.py
+++ b/pokerapp/countdown_manager.py
@@ -1,7 +1,6 @@
 import asyncio
 import time
 import logging
-import traceback
 from typing import Dict, Optional, Callable
 from dataclasses import dataclass, field
 from collections import deque
@@ -177,14 +176,13 @@ class SmartCountdownManager:
         """
         existing_task = self._active_countdowns.get(chat_id)
         if existing_task is not None and not existing_task.done():
-            self.logger.warning(
+            self.logger.debug(
                 "Duplicate countdown spawn detected; cancelling existing task",
                 extra={
                     'event_type': 'countdown_duplicate_spawn',
                     'chat_id': chat_id,
                     'existing_task_id': id(existing_task),
                     'existing_countdown_id': self._countdown_metadata.get(chat_id),
-                    'call_stack': ''.join(traceback.format_stack()),
                 }
             )
 
@@ -538,7 +536,7 @@ class SmartCountdownManager:
                     self._countdown_states[chat_id] = new_state
 
                     self.logger.debug(
-                        "Countdown tick",
+                        "countdown_tick",
                         extra={
                             'event_type': 'countdown_tick',
                             'chat_id': chat_id,

--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -22,7 +22,6 @@ import warnings
 from collections import defaultdict
 from dataclasses import dataclass
 from contextlib import asynccontextmanager, suppress
-from pathlib import Path
 from typing import (
     Any,
     AsyncIterator,
@@ -669,16 +668,6 @@ class GameEngine:
                     },
                 )
 
-        callsite = "unknown"
-        frame = inspect.currentframe()
-        if frame is not None:
-            caller = frame.f_back
-            if caller is not None:
-                code = caller.f_code
-                callsite = f"{Path(code.co_filename).name}:{caller.f_lineno}"
-            del caller
-        del frame
-
         try:
             await countdown_manager.start_countdown(
                 chat_id=chat_id,
@@ -696,7 +685,6 @@ class GameEngine:
                     "chat_id": chat_id,
                     "duration": duration,
                     "trigger": trigger,
-                    "callsite": callsite,
                 },
                 exc_info=True,
             )
@@ -711,7 +699,6 @@ class GameEngine:
                 "player_count": player_count,
                 "pot_size": pot_size,
                 "trigger": trigger,
-                "callsite": callsite,
             },
         )
 


### PR DESCRIPTION
## Summary
- downgrade duplicate countdown spawn logging to debug and drop stack traces
- trim countdown tick logging and remove callsite tracking from waiting countdowns

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e553feaff0832d8b2775e73f7ba60c