### PR TITLE
Handle deferred post-start notification errors

### DIFF
--- a/pokerapp/game_engine.py
+++ b/pokerapp/game_engine.py
@@ -3111,7 +3111,19 @@ class GameEngine:
             raise
         else:
             if post_start_notification is not None:
-                await post_start_notification
+                try:
+                    await post_start_notification
+                except Exception:
+                    self._logger.exception(
+                        "Error sending post-start turn notification",
+                        extra=self._log_extra(
+                            stage="post_start_notification_error",
+                            chat_id=chat_id,
+                            game=game,
+                            event_type="post_start_notification_error",
+                            lock_key=lock_key,
+                        ),
+                    )
         finally:
             self._logger.info(
                 "Game start completed or failed, lock released for chat %s.",

--- a/tests/test_matchmaking_service_helpers.py
+++ b/tests/test_matchmaking_service_helpers.py
@@ -1,6 +1,7 @@
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
+import inspect
 
 import pytest
 
@@ -199,7 +200,7 @@ async def test_handle_post_start_notifications_sends_updates(matchmaking_setup):
     game.add_player(player, seat_index=0)
 
     context = SimpleNamespace(chat_data={})
-    await service._handle_post_start_notifications(
+    notification = await service._handle_post_start_notifications(
         context=context,
         game=game,
         chat_id=-400,
@@ -208,7 +209,9 @@ async def test_handle_post_start_notifications_sends_updates(matchmaking_setup):
 
     assert game.chat_id == -400
     matchmaking_setup.view.send_player_role_anchors.assert_awaited_once()
-    matchmaking_setup.send_turn_message.assert_awaited_once_with(game, player, -400)
+    matchmaking_setup.send_turn_message.assert_called_once_with(game, player, -400)
+    assert inspect.isawaitable(notification)
+    await notification
     assert context.chat_data["old_players"] == [player.user_id]
     assert game.last_actions[-1] == "بازی شروع شد"
 


### PR DESCRIPTION
## Summary
- add exception handling around deferred post-start turn notifications so failures are logged
- adjust matchmaking post-start notification test to reflect deferred coroutine handling and awaitable behavior

## Testing
- pytest tests/test_matchmaking_service_helpers.py::test_handle_post_start_notifications_sends_updates

------
https://chatgpt.com/codex/tasks/task_e_68f08bc0d6a0832d898b1d832c4e84ba